### PR TITLE
Expose canonical source identity in candle envelopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 .venv/
 data/*.db
+data/*.db-*
 .env
 .env.local
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ capability:
     - "source identity and cache/quality/fallback policies are visible in every response"
     - "profile=realtime skips cache and applies strict quality checks"
     - "profile=execution_live uses Binance USD-M Futures XAUUSDT, skips cache, applies strict quality checks, and requires execution_venue=true"
+    - "instrument-definition-v1 exposes upstream price/quantity constraints and reports unavailable fee or multiplier fields instead of inventing values"
   fail:
     - "ticker not found → suggestions list"
     - "cache_policy=require + no cache → cache_miss"
@@ -347,6 +348,16 @@ capability:
   sources: [tushare_pro, yahoo_finance, yahoo_finance_futures, binance_spot_public, binance_usdm_futures]
 api_base_url: http://localhost:8100
 endpoints:
+  - path: /api/instruments/{asset_class}/{ticker}
+    method: GET
+    description: "Get a versioned upstream execution instrument definition"
+    params:
+      - name: source
+        type: string
+        default: auto
+      - name: require_execution_venue
+        type: boolean
+        default: false
   - path: /api/candles/{asset_class}/{ticker}
     method: GET
     description: "Get OHLCV candles under explicit source/cache/quality policy"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ fail timeframe not supported → supported list
 fail A-share no token     → setup instructions
 ```
 
-Sources: `tushare_pro`, `yahoo_finance`, `yahoo_finance_futures`, `binance_spot_public`, `binance_usdm_futures`
+Built-in sources: `tushare_pro`, `yahoo_finance`, `yahoo_finance_futures`,
+`binance_spot_public`, `binance_usdm_futures`, and the FRED macro/flow/event adapters.
+Tiger OpenAPI and OANDA v20 are credential-backed config adapters; see
+`configs/adapters.example.json`.
 
 ## Ports And Adapters
 
@@ -47,6 +50,9 @@ MarketDataPort
         ├─ Binance Spot adapter
         ├─ Yahoo adapter
         ├─ TuShare adapter
+        ├─ FRED macro / flow / event adapters
+        ├─ Tiger quote + market-session adapter
+        ├─ OANDA v20 pricing adapter
         └─ any new broker adapter
 ```
 
@@ -61,9 +67,23 @@ MarketDataPort
    - `realtime_supported`
    - `quality_flags`
    - `ticker_aliases`
-3. 调用 `register_adapter(adapter)`。
+3. 通过 Python entry point `kline.market_data_adapters` 安装，或在 JSON 配置中声明 factory。
 
-API 主流程不需要为新 broker 改分支。请求只需要：
+API 主流程不需要为新 broker 改分支，也不需要修改 registry。配置文件可通过
+`KLINE_ADAPTER_CONFIG_PATH` 指定，敏感值使用 `${ENV_VAR}`，启动时缺失会 fail closed。
+
+```json
+{
+  "adapters": [
+    {
+      "factory": "my_broker.datafeed:create_adapter",
+      "config": {"account": "paper", "token": "${MY_BROKER_TOKEN}"}
+    }
+  ]
+}
+```
+
+请求只需要：
 
 ```bash
 curl "localhost:8100/api/candles/crypto/BTC?source=fake_broker_feed&cache_policy=bypass"
@@ -78,7 +98,7 @@ datafeed 本体只负责数据。它不判断“研究”或“交易”，而�
 | Source | `source=auto` 或具体 source id | 选择上游，如 `binance_usdm_futures` |
 | Cache | `cache_policy=allow|bypass|require` | 是否允许、跳过、或只读 SQLite cache |
 | Quality | `quality=standard|strict` | `strict` 会检查 empty/stale/gap/duplicate/out-of-order 并 blocked |
-| Fallback | `fallback_policy=none|explicit` | 当前不做静默 fallback；字段保留给未来显式 fallback |
+| Fallback | `fallback_policy=none|explicit` | 默认不 fallback；`explicit` 只尝试调用方列出的 `fallback_sources` |
 | Execution venue | `require_execution_venue=true|false` | 要求 source 必须是执行场所 |
 
 常用 profile：
@@ -101,6 +121,7 @@ datafeed 本体只负责数据。它不判断“研究”或“交易”，而�
 - `cache_policy=bypass` / `profile=realtime` / `profile=execution_live` 不读 cache。
 - `quality=strict` 下，上游失败、空数据、陈旧、gap、乱序都返回错误/blocked envelope。
 - `require_execution_venue=true` 会拒绝 Yahoo、TuShare、Binance Spot 等非执行场所 source。
+- normalized storage 以 `source_id + ticker + asset_class + timeframe + timestamp` 隔离；同一标的多源不会互相覆盖。
 
 ```bash
 # 历史/回放：允许 cache
@@ -112,8 +133,14 @@ curl "localhost:8100/api/candles/crypto/BTC?timeframe=1m&source=binance_spot_pub
 # 执行场所实时：Binance USD-M Futures XAUUSDT
 curl "localhost:8100/api/candles/commodity/XAUUSDT?timeframe=1m&profile=execution_live&limit=200"
 
+# 显式 fallback：主源失败后只尝试调用方点名的源，响应记录 selected/attempted sources
+curl "localhost:8100/api/candles/commodity/GOLD?timeframe=1m&source=binance_usdm_futures&cache_policy=bypass&fallback_policy=explicit&fallback_sources=yahoo_finance_futures"
+
 # WebSocket 实时 candle update
 ws://localhost:8100/api/ws/candles/commodity/XAUUSDT?timeframe=1m&source=binance_usdm_futures
+
+# 浏览器可见的来源健康、最近请求和 source-scoped storage coverage
+http://localhost:8100/health-ui
 ```
 
 ## 示例输出
@@ -234,6 +261,7 @@ python -m kline
 | `WS` | `/api/ws/candles/{asset_class}/{ticker}` | 实时 candle update；当前支持 Binance USD-M Futures |
 | `GET` | `/api/tickers` | 列出本地已缓存的 ticker |
 | `GET` | `/api/health` | 健康检查 + provider availability |
+| `GET` | `/api/sessions/{asset_class}/{ticker}` | 获取 adapter-owned market sessions |
 
 ### 参数
 

--- a/configs/adapters.example.json
+++ b/configs/adapters.example.json
@@ -1,0 +1,25 @@
+{
+  "adapters": [
+    {
+      "factory": "kline.providers.tiger:create_adapter",
+      "enabled": false,
+      "config": {
+        "source_id": "tiger_openapi_comex",
+        "props_path": "${TIGER_OPENAPI_CONFIG_PATH}",
+        "contract": "MGCmain",
+        "exchange": "COMEX",
+        "grab_quote_permission": false
+      }
+    },
+    {
+      "factory": "kline.providers.oanda:create_adapter",
+      "enabled": false,
+      "config": {
+        "source_id": "oanda_v20",
+        "token": "${OANDA_API_TOKEN}",
+        "base_url": "https://api-fxpractice.oanda.com",
+        "instrument": "XAU_USD"
+      }
+    }
+  ]
+}

--- a/decision-log.md
+++ b/decision-log.md
@@ -137,9 +137,11 @@ contract definition instead of duplicating precision and margin assumptions.
 - Binance USD-M definitions are parsed from live `exchangeInfo`; the response
   preserves price/quantity increments, limits, currencies, contract status,
   order types, and normalized initial/maintenance margin rates.
-- Public `exchangeInfo` does not provide account fee rates or an explicit
-  contract multiplier. Those fields remain null and are named in
-  `missing_fields`; no default fee or synthetic multiplier is returned.
+- Public `exchangeInfo` does not provide account fee rates. Those fields remain
+  null and are named in `missing_fields`.
+- The USD-M adapter returns `contract_multiplier=1` as an explicitly derived
+  field because linear USD-M notional is `price * quantity`; `derived_fields`
+  records that derivation so consumers do not mistake it for a raw field.
 - The response always reports `served_from=upstream` and
   `is_synthetic=false`. Upstream failure returns an explicit 502 error.
 
@@ -151,6 +153,8 @@ contract definition instead of duplicating precision and margin assumptions.
   Consumers must preserve the upstream contract type.
 - `exchangeInfo?symbol=XAUUSDT` can still return a multi-symbol payload, so the
   provider selects the exact symbol and fails if it is absent.
+- Derived fields must carry a stable explanation in `derived_fields`; consumers
+  must reject an unexplained multiplier rather than silently defaulting it.
 - Raw instrument responses are auditable through `last_raw_response` but are
   not yet persisted in a dedicated instrument-history table.
 

--- a/decision-log.md
+++ b/decision-log.md
@@ -162,3 +162,127 @@ contract definition instead of duplicating precision and margin assumptions.
 
 - Provider tests assert exact XAUUSDT increments, minimums, currencies, margin
   conversion, missing fields, and raw response capture.
+
+## 2026-07-15 - Independent multi-source data plane foundation
+
+Objective: make datafeed the source-aware, auditable market-data boundary that trading
+consumers can use without direct exchange or private SQLite access.
+
+### Decisions
+
+- Upgraded normalized candle identity to include `source_id`. Two upstreams can now store
+  the same ticker/timestamp without overwriting each other.
+- Added an in-place SQLite schema migration. Pre-v0.3 rows are labeled
+  `legacy_unknown`; datafeed does not guess which upstream produced old rows.
+- Added config and package entry-point adapter discovery. A new source can ship as an
+  adapter package plus JSON config and environment-backed credentials without changing
+  API routing or the core registry.
+- Implemented caller-explicit fallback. `fallback_policy=explicit` is rejected unless
+  named fallback sources are provided, and responses expose `selected_source`,
+  `selection_reason`, and `attempted_sources`.
+- Persisted source observations and exposed source-scoped coverage through `/api/health`.
+  Added `/health-ui` as the browser-visible source health and provenance surface.
+
+### Gotchas
+
+- `legacy_unknown` rows remain queryable only through the legacy store API; source-scoped
+  API requests intentionally do not reuse them because their origin cannot be proven.
+- Entry-point/config adapters must use a lowercase stable `source_id` and implement the
+  complete `MarketDataPort`, including explicit unsupported behavior for streaming or
+  instrument definitions.
+- Explicit fallback does not imply semantic equivalence. Callers must only name sources
+  whose instrument mapping and market semantics are acceptable for that request.
+- Provider health means the latest observed request result, not merely registration.
+  A registered source remains `registered` until it has an actual observation.
+
+### Verification
+
+- `python3 -m pytest -q` -> 65 passed.
+- `python3 -m ruff check .` -> all checks passed.
+
+### Follow-up decisions in the same milestone
+
+- Added canonical `instrument_id` separate from each provider symbol. GOLD now remains
+  one canonical instrument while Binance uses `XAUUSDT` and Yahoo uses `GC=F`.
+- Added explicit asset-class extension points for futures, forex, index, ETF, and macro.
+  These classes fail closed until a default adapter is installed; datafeed does not invent
+  a provider for them.
+- Moved the Tiger COMEX futures quote path into a datafeed-owned adapter. It imports only
+  Tiger quote APIs and intentionally has no order client.
+- Migrated 329,353 proven-source legacy rows into datafeed: Binance GOLD 1m/5m and Tiger
+  MGCmain 1m. Unknown FRED rows were reported as skipped rather than mislabeled.
+- Canonicalized intraday timestamps to UTC `+00:00` and merged logical duplicates created
+  by old naive timestamps versus new timezone-aware timestamps.
+- Added `/api/compare/...` and the health UI comparison card. Binance XAUUSDT and Yahoo
+  GC=F coexist, are compared by canonical GOLD timestamps, and are never blended.
+
+### Additional gotchas
+
+- SQLite bulk upserts can exceed the build-dependent bind-variable limit. KlineStore now
+  chunks large saves into 500-row batches; the first migration attempt exposed this and
+  was safely retried.
+- Provider symbol and canonical instrument must never be collapsed into one field. Doing
+  so would make `GOLD`, `XAUUSDT`, `GC=F`, and `MGCmain` appear interchangeable when their
+  contracts and venue semantics differ.
+- Existing FRED macro rows are not yet migrated because no datafeed-owned FRED adapter and
+  manifest exists. They remain explicitly skipped, not silently assigned to another source.
+
+## 2026-07-15 - Binance USD-M daily candles for production grid context
+
+### Decisions
+
+- Added native `1d` support to the existing Binance USD-M Futures adapter. GOLD strategy
+  planning now receives D1 candles from the same `XAUUSDT` execution-venue source used by
+  intraday market data; no Yahoo, synthetic, or silent fallback was introduced.
+- Kept the normalized candle and provenance contracts unchanged. The new interval is an
+  additional explicit capability of `binance_usdm_futures`, not a derived or blended feed.
+
+### Gotchas
+
+- Binance's upstream futures kline API supports `1d`, but the adapter capability map had
+  stopped at `4h`. The trading console therefore showed healthy 1m prices while its
+  fail-closed StrategyPlan preview correctly refused to start without trusted D1 context.
+- A healthy realtime ticker is not sufficient proof that a strategy can start. Every fixed
+  planning timeframe (D1, 4H, 1H, 15m) must independently satisfy the trusted-source gate.
+
+### Verification
+
+- Binance provider/API/provenance focused tests: `24 passed`.
+- Live datafeed request returned 20 non-synthetic Binance USD-M `1d` candles for `XAUUSDT`.
+- Browser-visible downstream proof:
+  `/Users/wendy/park-io/008_codex session insights and decision logs/交易系统/evidence/goldbot-v5-start-ready-binance-d1-2026-07-15.png`.
+
+## 2026-07-15 - Multi-asset adapter completion and owner-side health
+
+### Decisions
+
+- Added datafeed-owned FRED adapters for macro, flow-proxy, and event-proxy daily
+  series. DXY, US10Y_REAL, GLD_FLOW, and FED_CPI_EVENTS now use the same candle,
+  provenance, storage, and health contracts as tradable instruments.
+- Added a configurable OANDA v20 adapter. Credentials are resolved by datafeed's
+  adapter config and never by trading-orchestrator.
+- Added Tiger market-session capability and `/api/sessions/...`; trading no longer
+  needs Tiger's quote SDK to determine market windows.
+- Added owner-side SQLite integrity to `/api/health`, without exposing the storage
+  path to consumers.
+- Binance range fetching now paginates in datafeed for explicit historical windows.
+
+### Gotchas
+
+- FRED series are daily observations and can be published with date lag. Their
+  `fresh` value remains unknown rather than applying a 24/7-market freshness rule.
+- A configured adapter and a healthy adapter are different states. Tiger and OANDA
+  remain absent/unavailable until their datafeed-owned credential config is enabled.
+- OANDA pricing credentials belong to the market-data adapter; OANDA account/order
+  credentials remain a separate execution concern.
+- Large Binance backfills must have explicit start/end windows. A latest-only request
+  without a start cannot safely page backward without changing semantics.
+
+### Verification
+
+- Full datafeed suite: `70 passed`; Ruff: all checks passed.
+- Owner storage receipt: integrity `ok`, 330k+ candles, six stored sources.
+- All 376 formerly skipped FRED rows were migrated with explicit source/asset identity;
+  the final legacy migration reports zero skipped rows.
+- Visual proof:
+  `/Users/wendy/park-io/008_codex session insights and decision logs/交易系统/evidence/2026-07-15-datafeed-source-health-final.png`.

--- a/decision-log.md
+++ b/decision-log.md
@@ -87,3 +87,40 @@ Objective: make any broker/exchange feed fit into datafeed by implementing one s
 - `python3 -m compileall src/kline`
 - `python3 -m ruff check .` -> all checks passed
 - `python3 -m pytest` -> 47 passed in 6.10s
+
+## 2026-07-10 - WebSocket proxy runtime dependency
+
+Objective: make the standardized Binance USD-M WebSocket path dependency-
+complete and fail visibly when the upstream stream is silent.
+
+### Decisions
+
+- Added `python-socks[asyncio]` as an explicit runtime dependency. `websockets`
+  auto-detects SOCKS proxy settings, so proxy support is part of the production
+  stream path rather than an optional development convenience.
+- Kept the existing `binance_usdm_futures` source, strict quality policy, and
+  `fallback_policy=none`. No alternate source is selected when the stream fails.
+- Ignored SQLite `-wal` and `-shm` sidecars created by a running datafeed service.
+
+### Gotchas
+
+- `/api/health` validates provider registration, not a live upstream socket. A
+  healthy service can still fail its first WebSocket subscription if proxy
+  runtime dependencies are missing.
+- Installing proxy support removes the immediate import failure but does not
+  prove market messages flow. On this machine both XAUUSDT and BTCUSDT complete
+  the WebSocket handshake and then receive no frames through the current
+  network path.
+- The provider now times out a silent upstream and raises `ProviderError`; the
+  API returns a structured `stream_error` with `fallback_policy=none` rather
+  than leaving consumers connected indefinitely.
+
+### Verification
+
+- `python3 -m pytest` -> 48 passed.
+- Real local subscription returned `stream_error` after 30 seconds with
+  `served_from=websocket`, `is_synthetic=false`, `execution_venue=true`, and
+  `reject_reason=upstream_error`.
+- No real candle was received. Tick-level server streaming remains blocked by
+  the machine's Binance WebSocket network path; REST and cached data were not
+  substituted into the WebSocket response.

--- a/decision-log.md
+++ b/decision-log.md
@@ -124,3 +124,37 @@ complete and fail visibly when the upstream stream is silent.
 - No real candle was received. Tick-level server streaming remains blocked by
   the machine's Binance WebSocket network path; REST and cached data were not
   substituted into the WebSocket response.
+
+## 2026-07-10 - Versioned execution instrument definition
+
+Objective: give paper and shadow execution engines one upstream-derived GOLD
+contract definition instead of duplicating precision and margin assumptions.
+
+### Decisions
+
+- Added `instrument-definition-v1` and
+  `GET /api/instruments/{asset_class}/{ticker}`.
+- Binance USD-M definitions are parsed from live `exchangeInfo`; the response
+  preserves price/quantity increments, limits, currencies, contract status,
+  order types, and normalized initial/maintenance margin rates.
+- Public `exchangeInfo` does not provide account fee rates or an explicit
+  contract multiplier. Those fields remain null and are named in
+  `missing_fields`; no default fee or synthetic multiplier is returned.
+- The response always reports `served_from=upstream` and
+  `is_synthetic=false`. Upstream failure returns an explicit 502 error.
+
+### Gotchas
+
+- `requiredMarginPercent` and `maintMarginPercent` are percentages upstream;
+  the v1 response converts them to decimal rates (`5.0000` -> `0.0500`).
+- XAUUSDT currently reports `TRADIFI_PERPETUAL`, not generic `PERPETUAL`.
+  Consumers must preserve the upstream contract type.
+- `exchangeInfo?symbol=XAUUSDT` can still return a multi-symbol payload, so the
+  provider selects the exact symbol and fails if it is absent.
+- Raw instrument responses are auditable through `last_raw_response` but are
+  not yet persisted in a dedicated instrument-history table.
+
+### Verification
+
+- Provider tests assert exact XAUUSDT increments, minimums, currencies, margin
+  conversion, missing fields, and raw response capture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kline"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multi-asset K-line data. in ticker + timeframe → out OHLCV candles."
 requires-python = ">=3.11"
 dependencies = [
@@ -19,6 +19,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+tiger = [
+    "tigeropen>=3.3.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "httpx>=0.27.0",
     "websockets>=12.0",
+    "python-socks[asyncio]>=2.7.1",
     "tushare>=1.3.0",
     "akshare>=1.14.0",
     "yfinance>=0.2.36",

--- a/src/kline/__init__.py
+++ b/src/kline/__init__.py
@@ -1,3 +1,3 @@
 """kline — Multi-asset K-line data. in ticker + timeframe → out OHLCV candles."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from time import monotonic
 
 from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
 
@@ -24,6 +25,7 @@ from kline.provenance import (
     canonical_ticker_for_source,
     normalize_source,
     source_meta,
+    source_manifest,
 )
 from kline.quality import QualityReport, analyze_candles
 from kline.registry import get_adapter_for_source, get_store, provider_status
@@ -38,6 +40,7 @@ class RequestPolicy:
     cache_policy: CachePolicy
     quality_policy: QualityPolicy
     fallback_policy: FallbackPolicy
+    fallback_sources: tuple[str, ...]
     require_execution_venue: bool
 
     @property
@@ -61,6 +64,9 @@ def _build_response(
     extra_quality_flags: list[str] | None = None,
     reject_reason: str | None = None,
     access_issues: list[str] | None = None,
+    selected_source: str | None = None,
+    attempted_sources: list[str] | None = None,
+    instrument_id: str | None = None,
 ) -> CandleResponse:
     """Stamp provenance on each candle and wrap them in the trust envelope."""
     strict = policy.strict_quality if policy else False
@@ -76,6 +82,8 @@ def _build_response(
     ]
     return CandleResponse(
         ticker=ticker,
+        instrument_id=instrument_id or ticker,
+        provider_symbol=ticker,
         asset_class=asset_class,
         timeframe=timeframe,
         count=len(stamped),
@@ -83,6 +91,13 @@ def _build_response(
         provider=meta.name,
         source_mode=meta.source_mode,
         requested_source=policy.requested_source if policy else meta.source_mode,
+        selected_source=selected_source or meta.source_mode,
+        selection_reason=(
+            "requested_or_default"
+            if not policy or (selected_source or meta.source_mode) == policy.source
+            else "explicit_fallback"
+        ),
+        attempted_sources=attempted_sources or [selected_source or meta.source_mode],
         cache_policy=policy.cache_policy if policy else CachePolicy.ALLOW,
         quality_policy=policy.quality_policy if policy else QualityPolicy.STANDARD,
         fallback_policy=policy.fallback_policy if policy else FallbackPolicy.NONE,
@@ -113,6 +128,8 @@ def _error(
     report: QualityReport | None = None,
     reject_reason: str | None = None,
     access_issues: list[str] | None = None,
+    selected_source: str | None = None,
+    attempted_sources: list[str] | None = None,
 ) -> HTTPException:
     quality_flags = list(meta.quality_flags)
     if report:
@@ -127,6 +144,8 @@ def _error(
             provider=meta.name,
             source_mode=meta.source_mode,
             requested_source=policy.requested_source if policy else meta.source_mode,
+            selected_source=selected_source,
+            attempted_sources=attempted_sources or [],
             cache_policy=policy.cache_policy if policy else None,
             quality_policy=policy.quality_policy if policy else None,
             fallback_policy=policy.fallback_policy if policy else None,
@@ -180,6 +199,7 @@ def _resolve_policy(
     cache_policy: CachePolicy,
     quality: QualityPolicy,
     fallback_policy: FallbackPolicy,
+    fallback_sources: list[str],
     require_execution_venue: bool,
     profile: str | None,
     strict: bool,
@@ -223,12 +243,29 @@ def _resolve_policy(
     except KeyError as e:
         raise ValueError(f"Unknown source: {resolved_source}") from e
 
+    normalized_fallbacks: list[str] = []
+    if fallback_sources and resolved_fallback_policy != FallbackPolicy.EXPLICIT:
+        raise ValueError("fallback_sources requires fallback_policy=explicit")
+    if resolved_fallback_policy == FallbackPolicy.EXPLICIT and not fallback_sources:
+        raise ValueError("fallback_policy=explicit requires at least one fallback source")
+    for fallback_source in fallback_sources:
+        try:
+            normalized_fallback = normalize_source(fallback_source, asset_class)
+            source_meta(normalized_fallback, asset_class)
+        except (KeyError, ValueError) as error:
+            raise ValueError(f"Invalid fallback source: {fallback_source}") from error
+        if normalized_fallback != normalized_source and normalized_fallback not in normalized_fallbacks:
+            normalized_fallbacks.append(normalized_fallback)
+    if resolved_fallback_policy == FallbackPolicy.EXPLICIT and not normalized_fallbacks:
+        raise ValueError("fallback sources must differ from the primary source")
+
     return RequestPolicy(
         requested_source=requested_source,
         source=normalized_source,
         cache_policy=resolved_cache_policy,
         quality_policy=resolved_quality,
         fallback_policy=resolved_fallback_policy,
+        fallback_sources=tuple(normalized_fallbacks),
         require_execution_venue=resolved_require_execution_venue,
     )
 
@@ -279,76 +316,139 @@ async def _fetch_upstream_candles(
     policy: RequestPolicy,
 ) -> CandleResponse:
     """Fetch upstream under an explicit source/cache/quality policy."""
-    try:
-        adapter = get_adapter_for_source(policy.source, asset_class)
-    except ProviderError as e:
-        raise _error(
-            status_code=400,
-            error="provider_unavailable",
-            detail=str(e),
-            suggestions=e.suggestions,
-            meta=meta,
-            served_from="upstream",
-            policy=policy,
-            reject_reason="provider_unavailable",
-            access_issues=[str(e)],
-        ) from e
-    try:
-        candles = await adapter.fetch_candles(
-            ticker,
-            timeframe,
-            start=start,
-            end=end,
-            limit=limit,
-        )
-    except ProviderError as e:
+    attempted_sources: list[str] = []
+    failures: list[str] = []
+    candidates = (policy.source, *policy.fallback_sources)
+    last_meta = meta
+    last_error: ProviderError | None = None
+    last_report: QualityReport | None = None
+
+    for selected_source in candidates:
+        attempted_sources.append(selected_source)
+        selected_meta = source_meta(selected_source, asset_class)
+        last_meta = selected_meta
+        selected_ticker = canonical_ticker_for_source(selected_source, asset_class, ticker)
+        started_at = monotonic()
+        adapter: MarketDataPort | None = None
+        try:
+            adapter = get_adapter_for_source(selected_source, asset_class)
+            candles = await adapter.fetch_candles(
+                selected_ticker,
+                timeframe,
+                start=start,
+                end=end,
+                limit=limit,
+            )
+        except ProviderError as error:
+            last_error = error
+            failures.append(f"{selected_source}: {error}")
+            if adapter is not None:
+                _save_raw_if_available(
+                    adapter=adapter,
+                    ticker=selected_ticker,
+                    asset_class=asset_class,
+                    timeframe=timeframe,
+                    meta=selected_meta,
+                    served_from="upstream",
+                )
+            get_store().save_source_observation(
+                source_id=selected_source,
+                provider=selected_meta.name,
+                ticker=selected_ticker,
+                asset_class=asset_class,
+                timeframe=timeframe,
+                success=False,
+                candle_count=0,
+                latest_timestamp=None,
+                latency_ms=(monotonic() - started_at) * 1000,
+                quality_flags=list(selected_meta.quality_flags),
+                error=str(error),
+            )
+            continue
+
         _save_raw_if_available(
             adapter=adapter,
-            ticker=ticker,
+            ticker=selected_ticker,
             asset_class=asset_class,
             timeframe=timeframe,
-            meta=meta,
+            meta=selected_meta,
             served_from="upstream",
         )
+        report = analyze_candles(
+            candles, timeframe, selected_meta, strict=policy.strict_quality
+        )
+        last_report = report
+        get_store().save_source_observation(
+            source_id=selected_source,
+            provider=selected_meta.name,
+            ticker=selected_ticker,
+            asset_class=asset_class,
+            timeframe=timeframe,
+            success=report.reject_reason is None,
+            candle_count=len(candles),
+            latest_timestamp=report.latest_timestamp,
+            latency_ms=(monotonic() - started_at) * 1000,
+            quality_flags=_dedupe([*selected_meta.quality_flags, *report.quality_flags]),
+            error=report.reject_reason,
+        )
+        if report.reject_reason:
+            failures.append(f"{selected_source}: {report.reject_reason}")
+            continue
+
+        if candles:
+            get_store().save(
+                selected_ticker,
+                asset_class,
+                timeframe,
+                candles,
+                source_id=selected_source,
+            )
+        return _build_response(
+            selected_ticker,
+            asset_class,
+            timeframe,
+            candles,
+            selected_meta,
+            served_from="upstream",
+            policy=policy,
+            selected_source=selected_source,
+            attempted_sources=attempted_sources,
+            access_issues=failures if selected_source != policy.source else [],
+            instrument_id=source_manifest(
+                selected_source, asset_class
+            ).canonical_instrument_id(ticker),
+        )
+
+    if last_error:
+        final_reason = "all_sources_failed" if len(attempted_sources) > 1 else "upstream_error"
         raise _error(
             status_code=502,
             error="upstream_error",
-            detail=str(e),
-            suggestions=e.suggestions,
-            meta=meta,
+            detail=str(last_error),
+            suggestions=last_error.suggestions,
+            meta=last_meta,
             served_from="upstream",
             policy=policy,
-            reject_reason="upstream_error",
-            access_issues=[str(e)],
-        ) from e
-
-    _save_raw_if_available(
-        adapter=adapter,
-        ticker=ticker,
-        asset_class=asset_class,
-        timeframe=timeframe,
-        meta=meta,
-        served_from="upstream",
+            reject_reason=final_reason,
+            access_issues=failures,
+            attempted_sources=attempted_sources,
+        ) from last_error
+    final_reason = (
+        "all_sources_failed"
+        if len(attempted_sources) > 1
+        else (last_report.reject_reason if last_report else "data_blocked")
     )
-    report = analyze_candles(candles, timeframe, meta, strict=policy.strict_quality)
-    _block_if_quality_rejected(
-        report=report,
-        meta=meta,
-        policy=policy,
-        served_from="upstream",
-    )
-
-    if candles:
-        get_store().save(ticker, asset_class, timeframe, candles)
-
-    return _build_response(
-        ticker,
-        asset_class,
-        timeframe,
-        candles,
-        meta,
+    raise _error(
+        status_code=503,
+        error="data_blocked",
+        detail="All explicitly selected sources failed quality checks",
+        meta=last_meta,
         served_from="upstream",
         policy=policy,
+        report=last_report,
+        reject_reason=final_reason,
+        access_issues=failures,
+        attempted_sources=attempted_sources,
     )
 
 
@@ -368,7 +468,7 @@ async def get_candles(
     timeframe: Timeframe = Query(default=Timeframe.DAY),
     start: str | None = Query(default=None, description="Start date: YYYY-MM-DD"),
     end: str | None = Query(default=None, description="End date: YYYY-MM-DD"),
-    limit: int = Query(default=500, ge=1, le=2000),
+    limit: int = Query(default=500, ge=1, le=60000),
     refresh: bool = Query(default=False, description="Force fetch from source"),
     source: str = Query(default="auto", description="Source id, e.g. binance_usdm_futures"),
     cache_policy: CachePolicy = Query(default=CachePolicy.ALLOW),
@@ -378,6 +478,7 @@ async def get_candles(
     profile: str | None = Query(default=None, pattern="^(historical|realtime|execution_live)$"),
     strict: bool = Query(default=False, description="Compatibility shortcut for execution_live"),
     mode: str = Query(default="research", pattern="^(research|live)$"),
+    fallback_sources: list[str] | None = None,
 ) -> CandleResponse:
     """
     Get K-line candles for any asset.
@@ -398,6 +499,7 @@ async def get_candles(
             cache_policy=cache_policy,
             quality=quality,
             fallback_policy=fallback_policy,
+            fallback_sources=fallback_sources or [],
             require_execution_venue=require_execution_venue,
             profile=profile,
             strict=strict,
@@ -422,12 +524,23 @@ async def get_candles(
         ) from e
 
     _raise_if_execution_venue_required(meta, policy)
+    for fallback_source in policy.fallback_sources:
+        _raise_if_execution_venue_required(source_meta(fallback_source, asset_class), policy)
+    requested_ticker = ticker
     ticker = canonical_ticker_for_source(policy.source, asset_class, ticker)
 
     store = get_store()
 
     if policy.cache_policy in (CachePolicy.ALLOW, CachePolicy.REQUIRE):
-        cached = store.query(ticker, asset_class, timeframe, start=start, end=end, limit=limit)
+        cached = store.query(
+            ticker,
+            asset_class,
+            timeframe,
+            source_id=policy.source,
+            start=start,
+            end=end,
+            limit=limit,
+        )
         if cached:
             report = analyze_candles(cached, timeframe, meta, strict=policy.strict_quality)
             _block_if_quality_rejected(
@@ -444,6 +557,9 @@ async def get_candles(
                 meta,
                 served_from="cache",
                 policy=policy,
+                instrument_id=source_manifest(
+                    policy.source, asset_class
+                ).canonical_instrument_id(requested_ticker),
             )
         if policy.cache_policy == CachePolicy.REQUIRE:
             raise _error(
@@ -460,13 +576,13 @@ async def get_candles(
 
     return await _fetch_upstream_candles(
         asset_class=asset_class,
-        ticker=ticker,
         timeframe=timeframe,
         start=start,
         end=end,
         limit=limit,
         meta=meta,
         policy=policy,
+        ticker=requested_ticker,
     )
 
 
@@ -506,6 +622,7 @@ async def stream_candles(
         cache_policy=CachePolicy.BYPASS,
         quality_policy=quality,
         fallback_policy=FallbackPolicy.NONE,
+        fallback_sources=(),
         require_execution_venue=False,
     )
     ticker = canonical_ticker_for_source(normalized_source, asset_class, ticker)
@@ -531,7 +648,13 @@ async def stream_candles(
 
     try:
         async for candle in adapter.stream_candles(ticker, timeframe):
-            get_store().save(ticker, asset_class, timeframe, [candle])
+            get_store().save(
+                ticker,
+                asset_class,
+                timeframe,
+                [candle],
+                source_id=normalized_source,
+            )
             response = _build_response(
                 ticker,
                 asset_class,
@@ -606,11 +729,108 @@ async def get_instrument_definition(
 @router.get("/tickers")
 async def list_tickers(
     asset_class: AssetClass | None = Query(default=None),
+    source: str | None = Query(default=None),
 ) -> dict:
     """List all tickers with stored data."""
     store = get_store()
-    tickers = store.list_tickers(asset_class)
-    return {"count": len(tickers), "tickers": tickers}
+    source_id = normalize_source(source, asset_class) if source and asset_class else source
+    tickers = store.list_tickers(asset_class, source_id=source_id)
+    return {"count": len(tickers), "source_id": source_id, "tickers": tickers}
+
+
+@router.get("/compare/{asset_class}/{ticker}")
+async def compare_sources(
+    asset_class: AssetClass,
+    ticker: str,
+    timeframe: Timeframe = Query(default=Timeframe.MIN_5),
+    sources: list[str] = Query(...),
+    limit: int = Query(default=500, ge=1, le=5000),
+) -> dict:
+    """Compare already stored source-scoped candles without fetching or blending them."""
+    normalized_sources: list[str] = []
+    for source in sources:
+        try:
+            normalized = normalize_source(source, asset_class)
+            source_meta(normalized, asset_class)
+        except (KeyError, ValueError) as error:
+            raise HTTPException(status_code=400, detail=f"Invalid comparison source: {source}") from error
+        if normalized not in normalized_sources:
+            normalized_sources.append(normalized)
+    if len(normalized_sources) < 2:
+        raise HTTPException(status_code=400, detail="At least two distinct sources are required")
+
+    store = get_store()
+    series: dict[str, list[Candle]] = {}
+    provider_symbols: dict[str, str] = {}
+    for source in normalized_sources:
+        provider_symbol = canonical_ticker_for_source(source, asset_class, ticker)
+        provider_symbols[source] = provider_symbol
+        series[source] = store.query(
+            provider_symbol,
+            asset_class,
+            timeframe,
+            source_id=source,
+            limit=limit,
+        )
+
+    by_source = {
+        source: {candle.timestamp: candle for candle in candles}
+        for source, candles in series.items()
+    }
+    common_timestamps = sorted(set.intersection(*(set(rows) for rows in by_source.values())))
+    primary = normalized_sources[0]
+    comparisons = []
+    max_deviation_pct = 0.0
+    for timestamp in common_timestamps:
+        closes = {source: by_source[source][timestamp].close for source in normalized_sources}
+        primary_close = closes[primary]
+        deviations = {
+            source: (abs(close - primary_close) / primary_close * 100 if primary_close else 0.0)
+            for source, close in closes.items()
+        }
+        max_deviation_pct = max(max_deviation_pct, *deviations.values())
+        comparisons.append(
+            {
+                "timestamp": timestamp,
+                "closes": closes,
+                "deviation_pct_from_primary": deviations,
+            }
+        )
+    return {
+        "schema_version": "source-comparison-v1",
+        "instrument_id": source_manifest(primary, asset_class).canonical_instrument_id(ticker),
+        "asset_class": asset_class.value,
+        "timeframe": timeframe.value,
+        "primary_source": primary,
+        "sources": normalized_sources,
+        "provider_symbols": provider_symbols,
+        "source_counts": {source: len(candles) for source, candles in series.items()},
+        "overlap_count": len(common_timestamps),
+        "max_close_deviation_pct": max_deviation_pct,
+        "is_blended": False,
+        "comparisons": comparisons[-100:],
+    }
+
+
+@router.get("/sessions/{asset_class}/{ticker}")
+async def market_sessions(
+    asset_class: AssetClass,
+    ticker: str,
+    source: str = Query(...),
+    trading_date: str | None = Query(None),
+) -> dict:
+    """Return an adapter-owned market calendar/session receipt."""
+    try:
+        adapter = get_adapter_for_source(source, asset_class)
+        fetch = getattr(adapter, "fetch_market_sessions", None)
+        if fetch is None:
+            raise ProviderError(f"Source {source} does not expose market sessions")
+        return await fetch(ticker, trading_date=trading_date)
+    except ProviderError as error:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "market_sessions_unavailable", "detail": str(error), "source": source},
+        ) from error
 
 
 @router.get("/health")
@@ -618,9 +838,20 @@ async def health() -> dict:
     """Health check."""
     from kline import __version__
 
+    coverage = get_store().source_coverage()
+    for row in coverage:
+        try:
+            row["instrument_id"] = source_manifest(
+                str(row["source_id"]), AssetClass(str(row["asset_class"]))
+            ).canonical_instrument_id(str(row["ticker"]))
+        except (KeyError, ValueError):
+            row["instrument_id"] = str(row["ticker"])
     return {
         "status": "ok",
         "service": "kline",
         "version": __version__,
         "providers": provider_status(),
+        "storage": get_store().storage_health(),
+        "storage_coverage": coverage,
+        "latest_observations": get_store().latest_source_observations(),
     }

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -15,6 +15,7 @@ from kline.models import (
     FallbackPolicy,
     QualityPolicy,
     Timeframe,
+    InstrumentDefinition,
 )
 from kline.ports import MarketDataPort
 from kline.providers.base import ProviderError
@@ -524,6 +525,8 @@ async def stream_candles(
             ).model_dump()
         )
         await websocket.close(code=1011)
+
+
         return
 
     try:
@@ -562,6 +565,42 @@ async def stream_candles(
             ).model_dump()
         )
         await websocket.close(code=1011)
+
+
+@router.get(
+    "/instruments/{asset_class}/{ticker}",
+    response_model=InstrumentDefinition,
+    summary="Get an upstream execution instrument definition",
+)
+async def get_instrument_definition(
+    asset_class: AssetClass,
+    ticker: str,
+    source: str = Query("auto"),
+    require_execution_venue: bool = Query(False),
+) -> InstrumentDefinition:
+    try:
+        normalized_source = normalize_source(source, asset_class)
+        meta = source_meta(normalized_source, asset_class)
+        if require_execution_venue and not meta.execution_venue:
+            raise ProviderError(
+                f"Source {normalized_source} is not an execution venue",
+                suggestions=["Choose a source with execution_venue=true"],
+            )
+        adapter = get_adapter_for_source(normalized_source, asset_class)
+        definition = await adapter.fetch_instrument_definition(ticker)
+    except ProviderError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "instrument_definition_unavailable",
+                "detail": str(e),
+                "suggestions": e.suggestions,
+                "source_mode": source,
+                "is_synthetic": False,
+                "reject_reason": "upstream_error",
+            },
+        ) from e
+    return definition
 
 
 @router.get("/tickers")

--- a/src/kline/app.py
+++ b/src/kline/app.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from kline import __version__
 from kline.api import router
+from kline.health_ui import router as health_ui_router
 from kline.registry import init
 
 
@@ -32,5 +33,6 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(router, prefix="/api")
+    app.include_router(health_ui_router)
 
     return app

--- a/src/kline/config.py
+++ b/src/kline/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     # Provider timeouts (seconds)
     request_timeout: int = 30
 
+    # Optional third-party adapter configuration. The file is JSON and may use
+    # ${ENV_VAR} placeholders so credentials never need to be committed.
+    adapter_config_path: str = ""
+    load_entrypoint_adapters: bool = True
+
     model_config = {"env_prefix": "KLINE_", "env_file": ".env", "extra": "ignore"}
 
 

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -1,0 +1,74 @@
+"""Small browser-visible source health and provenance surface."""
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+
+@router.get("/health-ui", response_class=HTMLResponse, include_in_schema=False)
+async def health_ui() -> str:
+    return """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Datafeed Source Health</title>
+  <style>
+    :root { color-scheme: dark; --bg:#091019; --panel:#101a26; --line:#253447;
+      --text:#e8f0f7; --muted:#8ea2b7; --ok:#39d98a; --bad:#ff6b6b; --accent:#58a6ff; }
+    * { box-sizing:border-box } body { margin:0; background:var(--bg); color:var(--text);
+      font:14px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif; }
+    main { max-width:1180px; margin:0 auto; padding:32px 24px 48px; }
+    header { display:flex; justify-content:space-between; gap:24px; align-items:end; margin-bottom:24px; }
+    h1 { font-size:27px; margin:0 0 6px } p { margin:0; color:var(--muted) }
+    .stamp { text-align:right; color:var(--muted) } .grid { display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:12px; margin-bottom:28px; }
+    .card { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:16px; }
+    .row { display:flex; justify-content:space-between; gap:12px; align-items:center; }
+    .source { font-weight:700; font-size:15px } .pill { border-radius:999px; padding:3px 8px;
+      font-size:12px; background:#1b2938; color:var(--muted) }
+    .pill.ok { color:var(--ok); background:#0e2b22 } .pill.bad { color:var(--bad); background:#341b20 }
+    dl { display:grid; grid-template-columns:1fr auto; gap:7px 12px; margin:14px 0 0 }
+    dt { color:var(--muted) } dd { margin:0; text-align:right; max-width:190px; overflow:hidden;
+      text-overflow:ellipsis; white-space:nowrap }
+    h2 { font-size:17px; margin:0 0 12px } table { width:100%; border-collapse:collapse;
+      background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
+    th,td { padding:11px 12px; border-bottom:1px solid var(--line); text-align:left }
+    th { color:var(--muted); font-size:12px; font-weight:600 } tr:last-child td { border:0 }
+    .empty { color:var(--muted); padding:20px } .error { color:var(--bad) }
+  </style>
+</head>
+<body><main>
+  <header><div><h1>Datafeed Source Health</h1><p>Availability, provenance and source-scoped storage coverage.</p></div>
+    <div class="stamp" id="stamp">Loading…</div></header>
+  <div class="grid" id="sources"></div>
+  <h2>Stored source coverage</h2>
+  <div id="coverage"></div>
+  <h2 style="margin-top:28px">GOLD 5m source comparison</h2>
+  <div id="comparison" class="card empty">Waiting for two stored GOLD sources…</div>
+</main><script>
+const esc = value => String(value ?? '—').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[c]));
+fetch('/api/health').then(r => r.json()).then(data => {
+  document.getElementById('stamp').textContent = `${data.service} ${data.version} · ${new Date().toLocaleString()}`;
+  const observations = Object.fromEntries((data.latest_observations || []).map(x => [x.source_id, x]));
+  const sources = data.providers?.sources || {};
+  document.getElementById('sources').innerHTML = Object.entries(sources).map(([id, src]) => {
+    const obs = observations[id]; const state = !src.available ? 'unavailable' : !obs ? 'registered' : obs.success ? 'healthy' : 'failed';
+    const klass = state === 'healthy' ? 'ok' : state === 'failed' || state === 'unavailable' ? 'bad' : '';
+    return `<section class="card"><div class="row"><span class="source">${esc(id)}</span><span class="pill ${klass}">${esc(state)}</span></div>
+      <dl><dt>Provider</dt><dd>${esc(src.provider)}</dd><dt>Asset / market</dt><dd>${esc(src.asset_class)} · ${esc(src.market_type)}</dd>
+      <dt>Execution venue</dt><dd>${src.execution_venue ? 'yes' : 'no'}</dd><dt>Realtime</dt><dd>${src.realtime_supported ? 'yes' : 'no'}</dd>
+      <dt>Last instrument</dt><dd>${esc(obs?.ticker)}</dd><dt>Latest candle</dt><dd>${esc(obs?.latest_timestamp)}</dd>
+      <dt>Latency</dt><dd>${obs?.latency_ms == null ? '—' : Math.round(obs.latency_ms) + ' ms'}</dd><dt>Last error</dt><dd title="${esc(obs?.error)}">${esc(obs?.error)}</dd></dl></section>`;
+  }).join('');
+  const rows = data.storage_coverage || [];
+  document.getElementById('coverage').innerHTML = rows.length ? `<table><thead><tr><th>Source</th><th>Asset</th><th>Symbol</th><th>TF</th><th>Bars</th><th>Latest</th></tr></thead><tbody>${rows.map(x => `<tr><td>${esc(x.source_id)}</td><td>${esc(x.asset_class)}</td><td>${esc(x.ticker)}</td><td>${esc(x.timeframe)}</td><td>${esc(x.count)}</td><td>${esc(x.latest_timestamp)}</td></tr>`).join('')}</tbody></table>` : '<div class="card empty">No source-scoped candles stored yet.</div>';
+  const ids = new Set(rows.filter(x => x.asset_class === 'commodity' && x.timeframe === '5m').map(x => x.source_id));
+  if (ids.has('binance_usdm_futures') && ids.has('yahoo_finance_futures')) {
+    fetch('/api/compare/commodity/GOLD?timeframe=5m&sources=binance_usdm_futures&sources=yahoo_finance_futures&limit=500').then(r => r.json()).then(c => {
+      document.getElementById('comparison').innerHTML = `<div class="row"><span class="source">${esc(c.instrument_id)} · ${esc(c.primary_source)} vs ${esc(c.sources[1])}</span><span class="pill">never blended</span></div><dl><dt>Overlapping candles</dt><dd>${esc(c.overlap_count)}</dd><dt>Max close deviation</dt><dd>${Number(c.max_close_deviation_pct || 0).toFixed(4)}%</dd><dt>Provider symbols</dt><dd>${esc(Object.values(c.provider_symbols).join(' / '))}</dd></dl>`;
+    });
+  }
+}).catch(error => { document.getElementById('sources').innerHTML = `<div class="card error">Health request failed: ${esc(error)}</div>`; });
+</script></body></html>"""

--- a/src/kline/migrate_legacy.py
+++ b/src/kline/migrate_legacy.py
@@ -1,0 +1,117 @@
+"""One-time import of proven-source rows from the old trading market database."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from collections import Counter
+from pathlib import Path
+
+from kline.config import get_settings
+from kline.models import AssetClass, Candle, Timeframe
+from kline.store import KlineStore
+
+_SOURCE_MAP = {
+    "binance_usdm": ("binance_usdm_futures", AssetClass.COMMODITY),
+    "tiger_openapi:COMEX": ("tiger_openapi_comex", AssetClass.COMMODITY),
+    "fred:DTWEXBGS": ("fred_public_csv_macro", AssetClass.MACRO),
+    "fred:DFII10": ("fred_public_csv_macro", AssetClass.MACRO),
+    "fred:GVZCLS": ("fred_public_csv_flow", AssetClass.FLOW),
+    "fred:DFF": ("fred_public_csv_event", AssetClass.EVENT),
+}
+_SYMBOL_MAP = {
+    ("binance_usdm_futures", "GOLD"): "XAUUSDT",
+    ("fred_public_csv_macro", "DXY"): "DTWEXBGS",
+    ("fred_public_csv_macro", "US10Y_REAL"): "DFII10",
+    ("fred_public_csv_flow", "GLD_FLOW"): "GVZCLS",
+    ("fred_public_csv_event", "FED_CPI_EVENTS"): "DFF",
+}
+_ASSET_BY_SOURCE = {source_id: asset_class for source_id, asset_class in _SOURCE_MAP.values()}
+
+
+def import_legacy_market_db(
+    source_db: Path,
+    *,
+    target_db: Path | None = None,
+    batch_size: int = 10_000,
+) -> dict:
+    target = target_db or Path(get_settings().db_path)
+    store = KlineStore(str(target))
+    imported: Counter[str] = Counter()
+    skipped: Counter[str] = Counter()
+
+    source_uri = f"file:{source_db.resolve()}?mode=ro"
+    with sqlite3.connect(source_uri, uri=True) as connection:
+        cursor = connection.execute(
+            "SELECT symbol, timeframe, timestamp, open, high, low, close, volume, provider "
+            "FROM bars ORDER BY provider, symbol, timeframe, timestamp"
+        )
+        group_key: tuple[str, str, str] | None = None
+        candles: list[Candle] = []
+
+        def flush() -> None:
+            nonlocal candles
+            if not group_key or not candles:
+                return
+            source_id, symbol, timeframe_value = group_key
+            asset_class = _ASSET_BY_SOURCE[source_id]
+            store.save(
+                _SYMBOL_MAP.get((source_id, symbol), symbol),
+                asset_class,
+                Timeframe(timeframe_value),
+                candles,
+                source_id=source_id,
+            )
+            imported[f"{source_id}:{symbol}:{timeframe_value}"] += len(candles)
+            candles = []
+
+        for row in cursor:
+            provider = str(row[8])
+            mapping = _SOURCE_MAP.get(provider)
+            if mapping is None:
+                skipped[provider] += 1
+                continue
+            source_id, _asset_class = mapping
+            try:
+                Timeframe(str(row[1]))
+            except ValueError:
+                skipped[f"{provider}:unsupported_timeframe:{row[1]}"] += 1
+                continue
+            key = (source_id, str(row[0]), str(row[1]))
+            if group_key != key or len(candles) >= batch_size:
+                flush()
+                group_key = key
+            candles.append(
+                Candle(
+                    timestamp=str(row[2]),
+                    open=float(row[3]),
+                    high=float(row[4]),
+                    low=float(row[5]),
+                    close=float(row[6]),
+                    volume=float(row[7] or 0),
+                )
+            )
+        flush()
+
+    return {
+        "source_db": str(source_db),
+        "target_db": str(target),
+        "imported": dict(imported),
+        "imported_rows": sum(imported.values()),
+        "skipped": dict(skipped),
+        "skipped_rows": sum(skipped.values()),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_db", type=Path)
+    parser.add_argument("--target-db", type=Path)
+    args = parser.parse_args()
+    result = import_legacy_market_db(args.source_db, target_db=args.target_db)
+    for key, value in result.items():
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kline/models.py
+++ b/src/kline/models.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import Boolean, Column, DateTime, Float, Index, Integer, String, Text, func
 from sqlalchemy.orm import DeclarativeBase
 
@@ -18,6 +19,13 @@ class AssetClass(str, Enum):
     US_STOCK = "us_stock"
     CRYPTO = "crypto"
     COMMODITY = "commodity"
+    FUTURES = "futures"
+    FOREX = "forex"
+    INDEX = "index"
+    ETF = "etf"
+    MACRO = "macro"
+    FLOW = "flow"
+    EVENT = "event"
 
 
 class Timeframe(str, Enum):
@@ -65,6 +73,17 @@ class Candle(BaseModel):
     provider: Optional[str] = None
     quality_flags: list[str] = Field(default_factory=list)
 
+    @field_validator("timestamp")
+    @classmethod
+    def normalize_timestamp(cls, value: str) -> str:
+        text = value.strip()
+        if "T" not in text and " " not in text:
+            return text
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
 
 class CandleResponse(BaseModel):
     """API response envelope.
@@ -78,6 +97,8 @@ class CandleResponse(BaseModel):
     """
 
     ticker: str
+    instrument_id: str = ""
+    provider_symbol: str = ""
     asset_class: AssetClass
     timeframe: Timeframe
     count: int
@@ -86,6 +107,9 @@ class CandleResponse(BaseModel):
     provider: str = ""  # concrete upstream, e.g. "binance_spot", "yahoo_finance"
     source_mode: str = ""  # path label, e.g. "binance_spot_public"
     requested_source: str = "auto"
+    selected_source: str = ""
+    selection_reason: str = "requested_or_default"
+    attempted_sources: list[str] = Field(default_factory=list)
     cache_policy: CachePolicy = CachePolicy.ALLOW
     quality_policy: QualityPolicy = QualityPolicy.STANDARD
     fallback_policy: FallbackPolicy = FallbackPolicy.NONE
@@ -112,6 +136,8 @@ class ErrorResponse(BaseModel):
     provider: Optional[str] = None
     source_mode: Optional[str] = None
     requested_source: Optional[str] = None
+    selected_source: Optional[str] = None
+    attempted_sources: list[str] = Field(default_factory=list)
     cache_policy: Optional[CachePolicy] = None
     quality_policy: Optional[QualityPolicy] = None
     fallback_policy: Optional[FallbackPolicy] = None
@@ -187,6 +213,7 @@ class KlineRow(Base):
     __tablename__ = "klines"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    source_id = Column(String, nullable=False, default="legacy_unknown", server_default="legacy_unknown")
     ticker = Column(String, nullable=False)
     asset_class = Column(String, nullable=False)
     timeframe = Column(String, nullable=False)
@@ -201,8 +228,16 @@ class KlineRow(Base):
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 
     __table_args__ = (
-        Index("ix_kline_lookup", "ticker", "asset_class", "timeframe", "timestamp", unique=True),
-        Index("ix_kline_ticker_tf", "ticker", "timeframe"),
+        Index(
+            "ix_kline_lookup",
+            "source_id",
+            "ticker",
+            "asset_class",
+            "timeframe",
+            "timestamp",
+            unique=True,
+        ),
+        Index("ix_kline_ticker_tf", "source_id", "ticker", "timeframe"),
     )
 
     def to_candle(self) -> Candle:
@@ -238,4 +273,36 @@ class RawUpstreamResponse(Base):
 
     __table_args__ = (
         Index("ix_raw_response_lookup", "provider", "ticker", "timeframe", "created_at"),
+    )
+
+
+class SourceObservation(Base):
+    """Auditable result of one upstream source request."""
+
+    __tablename__ = "source_observations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    source_id = Column(String, nullable=False)
+    provider = Column(String, nullable=False)
+    asset_class = Column(String, nullable=False)
+    ticker = Column(String, nullable=False)
+    timeframe = Column(String, nullable=False)
+    success = Column(Boolean, nullable=False)
+    served_from = Column(String, nullable=False, default="upstream")
+    candle_count = Column(Integer, nullable=False, default=0)
+    latest_timestamp = Column(String, nullable=True)
+    latency_ms = Column(Float, nullable=True)
+    error = Column(Text, nullable=True)
+    quality_flags = Column(Text, nullable=False, default="[]")
+    observed_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        Index("ix_source_observation_latest", "source_id", "observed_at"),
+        Index(
+            "ix_source_observation_instrument",
+            "source_id",
+            "ticker",
+            "timeframe",
+            "observed_at",
+        ),
     )

--- a/src/kline/models.py
+++ b/src/kline/models.py
@@ -128,6 +128,51 @@ class ErrorResponse(BaseModel):
     access_issues: list[str] = Field(default_factory=list)
 
 
+class InstrumentDefinition(BaseModel):
+    """Versioned execution instrument metadata from an upstream venue."""
+
+    schema_version: str = "instrument-definition-v1"
+    instrument_id: str
+    venue: str
+    symbol: str
+    asset_class: AssetClass
+    market_type: str
+    contract_type: str
+    status: str
+    base_currency: str
+    quote_currency: str
+    settlement_currency: str
+    margin_currency: str
+    is_inverse: bool
+    price_precision: int
+    price_increment: str
+    min_price: str
+    max_price: str
+    size_precision: int
+    size_increment: str
+    min_quantity: str
+    max_quantity: str
+    market_size_increment: str
+    market_min_quantity: str
+    market_max_quantity: str
+    min_notional: str
+    margin_init_rate: str
+    margin_maint_rate: str
+    maker_fee_rate: Optional[str] = None
+    taker_fee_rate: Optional[str] = None
+    contract_multiplier: Optional[str] = None
+    order_types: list[str] = Field(default_factory=list)
+    time_in_force: list[str] = Field(default_factory=list)
+    provider: str
+    source_mode: str
+    served_from: str = "upstream"
+    execution_venue: bool
+    is_synthetic: bool = False
+    upstream_server_time: Optional[int] = None
+    observed_at: str
+    missing_fields: list[str] = Field(default_factory=list)
+
+
 # ── SQLAlchemy ORM (storage layer) ─────────────────────────
 
 

--- a/src/kline/models.py
+++ b/src/kline/models.py
@@ -171,6 +171,7 @@ class InstrumentDefinition(BaseModel):
     upstream_server_time: Optional[int] = None
     observed_at: str
     missing_fields: list[str] = Field(default_factory=list)
+    derived_fields: dict[str, str] = Field(default_factory=dict)
 
 
 # ── SQLAlchemy ORM (storage layer) ─────────────────────────

--- a/src/kline/plugin_loader.py
+++ b/src/kline/plugin_loader.py
@@ -1,0 +1,116 @@
+"""Discover market-data adapters without editing datafeed core routing."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Any, Callable
+
+from kline.ports import MarketDataPort
+from kline.providers.base import ProviderError
+
+ENTRYPOINT_GROUP = "kline.market_data_adapters"
+_ENV_PATTERN = re.compile(r"^\$\{([A-Z][A-Z0-9_]*)\}$")
+
+
+def _resolve_env(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _resolve_env(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env(item) for item in value]
+    if not isinstance(value, str):
+        return value
+    match = _ENV_PATTERN.match(value)
+    if not match:
+        return value
+    env_name = match.group(1)
+    resolved = os.getenv(env_name)
+    if resolved is None:
+        raise ProviderError(
+            f"Adapter credential/config environment variable is missing: {env_name}",
+            suggestions=[f"Set {env_name} before starting datafeed"],
+        )
+    return resolved
+
+
+def _validate_adapter(adapter: Any, origin: str) -> MarketDataPort:
+    required = (
+        "manifest",
+        "last_raw_response",
+        "canonical_ticker",
+        "supported_timeframes",
+        "fetch_candles",
+        "stream_candles",
+        "fetch_instrument_definition",
+    )
+    missing = [name for name in required if not hasattr(adapter, name)]
+    if missing:
+        raise ProviderError(
+            f"Invalid market-data adapter from {origin}: missing {', '.join(missing)}"
+        )
+    source_id = adapter.manifest.source_id
+    if not source_id or source_id != source_id.strip().lower():
+        raise ProviderError(
+            f"Invalid source_id from {origin}: use a non-empty lowercase id"
+        )
+    return adapter
+
+
+def _factory(reference: str) -> Callable[[dict[str, Any]], MarketDataPort]:
+    module_name, separator, attribute = reference.partition(":")
+    if not separator or not module_name or not attribute:
+        raise ProviderError(
+            f"Invalid adapter factory '{reference}'",
+            suggestions=["Use the format package.module:create_adapter"],
+        )
+    try:
+        factory = getattr(import_module(module_name), attribute)
+    except (ImportError, AttributeError) as error:
+        raise ProviderError(f"Cannot load adapter factory {reference}: {error}") from error
+    if not callable(factory):
+        raise ProviderError(f"Adapter factory is not callable: {reference}")
+    return factory
+
+
+def load_configured_adapters(config_path: str) -> list[MarketDataPort]:
+    if not config_path:
+        return []
+    path = Path(config_path).expanduser()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ProviderError(f"Cannot load adapter config {path}: {error}") from error
+
+    entries = payload.get("adapters") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        raise ProviderError("Adapter config must contain an 'adapters' list")
+
+    adapters: list[MarketDataPort] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ProviderError(f"Adapter config entry {index} must be an object")
+        if entry.get("enabled", True) is False:
+            continue
+        reference = str(entry.get("factory") or "")
+        settings = _resolve_env(entry.get("config") or {})
+        if not isinstance(settings, dict):
+            raise ProviderError(f"Adapter config entry {index} config must be an object")
+        adapter = _factory(reference)(settings)
+        adapters.append(_validate_adapter(adapter, reference))
+    return adapters
+
+
+def load_entrypoint_adapters() -> list[MarketDataPort]:
+    adapters: list[MarketDataPort] = []
+    try:
+        discovered = metadata.entry_points(group=ENTRYPOINT_GROUP)
+    except TypeError:  # Python 3.10 compatibility for older importlib metadata behavior
+        discovered = metadata.entry_points().select(group=ENTRYPOINT_GROUP)
+    for entrypoint in discovered:
+        loaded = entrypoint.load()
+        adapter = loaded() if callable(loaded) else loaded
+        adapters.append(_validate_adapter(adapter, f"entrypoint:{entrypoint.name}"))
+    return adapters

--- a/src/kline/ports.py
+++ b/src/kline/ports.py
@@ -37,10 +37,19 @@ class SourceManifest:
     meta: ProviderMeta
     default_for_asset_class: bool = False
     ticker_aliases: Mapping[str, str] = field(default_factory=dict)
+    canonical_instrument_ids: Mapping[str, str] = field(default_factory=dict)
 
     def canonical_ticker(self, ticker: str) -> str:
         normalized = ticker.upper().strip()
         return self.ticker_aliases.get(normalized, ticker)
+
+    def canonical_instrument_id(self, ticker: str) -> str:
+        normalized = ticker.upper().strip()
+        provider_symbol = self.canonical_ticker(normalized).upper().strip()
+        return self.canonical_instrument_ids.get(
+            normalized,
+            self.canonical_instrument_ids.get(provider_symbol, normalized),
+        )
 
 
 class MarketDataPort(Protocol):

--- a/src/kline/ports.py
+++ b/src/kline/ports.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Mapping, Protocol
 
-from kline.models import AssetClass, Candle, Timeframe
+from kline.models import AssetClass, Candle, InstrumentDefinition, Timeframe
 from kline.providers.base import Provider, ProviderError
 
 
@@ -78,6 +78,9 @@ class MarketDataPort(Protocol):
     ) -> AsyncIterator[Candle]:
         ...
 
+    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
+        ...
+
 
 class ProviderBackedMarketDataAdapter:
     """Adapter wrapper for the existing provider classes."""
@@ -133,3 +136,13 @@ class ProviderBackedMarketDataAdapter:
         canonical = self.canonical_ticker(ticker)
         async for candle in stream(canonical, timeframe):
             yield candle
+
+    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
+        fetch = getattr(self._provider, "fetch_instrument_definition", None)
+        if fetch is None:
+            raise ProviderError(
+                f"Source {self.manifest.source_id} does not expose instrument definitions",
+                suggestions=["Choose an execution source with instrument metadata"],
+            )
+        canonical = self.canonical_ticker(ticker)
+        return await fetch(canonical)

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -82,6 +82,17 @@ BINANCE_USDM_FUTURES_META = ProviderMeta(
     supported_symbols=("XAUUSDT",),
 )
 
+FRED_META = ProviderMeta(
+    name="fred",
+    source_mode="fred_public_csv",
+    quality_flags=("public_api", "daily_factor", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="economic_series",
+    supported_symbols=("DTWEXBGS", "DFII10", "GVZCLS", "DFF"),
+)
+
 _SOURCE_ALIASES = {
     "auto": "auto",
     "binance_spot": "binance_spot_public",
@@ -93,6 +104,8 @@ _SOURCE_ALIASES = {
     "yahoo_finance_futures": "yahoo_finance_futures",
     "tushare": "tushare_pro",
     "tushare_pro": "tushare_pro",
+    "fred": "fred_public_csv",
+    "fred_public_csv": "fred_public_csv",
 }
 
 _SOURCE_ASSET_CLASSES = {
@@ -123,6 +136,7 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.COMMODITY,
         meta=BINANCE_USDM_FUTURES_META,
         ticker_aliases={"GOLD": "XAUUSDT", "XAUUSD": "XAUUSDT", "XAUUSDT": "XAUUSDT"},
+        canonical_instrument_ids={"GOLD": "GOLD", "XAUUSD": "GOLD", "XAUUSDT": "GOLD"},
     ),
     "yahoo_finance": SourceManifest(
         source_id="yahoo_finance",
@@ -135,6 +149,8 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.COMMODITY,
         meta=_PROVIDER_META[AssetClass.COMMODITY],
         default_for_asset_class=True,
+        ticker_aliases={"GOLD": "GC=F", "XAUUSD": "GC=F", "GC=F": "GC=F"},
+        canonical_instrument_ids={"GOLD": "GOLD", "XAUUSD": "GOLD", "GC=F": "GOLD"},
     ),
     "tushare_pro": SourceManifest(
         source_id="tushare_pro",
@@ -144,11 +160,37 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
     ),
 }
 
+
+def fred_source_manifest(asset_class: AssetClass) -> SourceManifest:
+    aliases = {
+        "DXY": "DTWEXBGS",
+        "US10Y_REAL": "DFII10",
+        "GLD_FLOW": "GVZCLS",
+        "FED_CPI_EVENTS": "DFF",
+    }
+    return SourceManifest(
+        source_id=f"fred_public_csv_{asset_class.value}",
+        asset_class=asset_class,
+        meta=ProviderMeta(**{**FRED_META.__dict__, "source_mode": f"fred_public_csv_{asset_class.value}"}),
+        default_for_asset_class=True,
+        ticker_aliases=aliases,
+        canonical_instrument_ids={key: key for key in aliases},
+    )
+
 _EXTRA_SOURCE_MANIFESTS: dict[str, SourceManifest] = {}
 
 
 def provider_meta(asset_class: AssetClass) -> ProviderMeta:
-    return _PROVIDER_META[asset_class]
+    if asset_class in _PROVIDER_META:
+        return _PROVIDER_META[asset_class]
+    defaults = [
+        manifest
+        for manifest in all_source_manifests().values()
+        if manifest.asset_class == asset_class and manifest.default_for_asset_class
+    ]
+    if not defaults:
+        raise KeyError(f"No default source configured for {asset_class.value}")
+    return defaults[0].meta
 
 
 def default_source(asset_class: AssetClass) -> str:

--- a/src/kline/providers/binance_usdm.py
+++ b/src/kline/providers/binance_usdm.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from decimal import Decimal
 from datetime import datetime, timezone
 from typing import Any, AsyncIterator
 
 import httpx
 
-from kline.models import Candle, Timeframe
+from kline.models import AssetClass, Candle, InstrumentDefinition, Timeframe
 from kline.providers.base import ProviderError
 
 logger = logging.getLogger(__name__)
 
 BINANCE_USDM_KLINE_URL = "https://fapi.binance.com/fapi/v1/klines"
+BINANCE_USDM_EXCHANGE_INFO_URL = "https://fapi.binance.com/fapi/v1/exchangeInfo"
 BINANCE_USDM_WS_URL = "wss://fstream.binance.com/stream?streams="
 
 _TF_MAP = {
@@ -81,6 +83,17 @@ def _candle_from_ws_kline(item: dict[str, Any]) -> Candle:
         volume=float(item["v"]),
         amount=float(item.get("q", 0)),
     )
+
+
+def _decimal_rate_from_percent(value: str) -> str:
+    return format(Decimal(value) / Decimal(100), "f")
+
+
+def _required_filter(filters: list[dict[str, Any]], filter_type: str) -> dict[str, Any]:
+    match = next((item for item in filters if item.get("filterType") == filter_type), None)
+    if match is None:
+        raise ProviderError(f"Binance exchangeInfo omitted required {filter_type} filter")
+    return match
 
 
 class BinanceUsdmFuturesProvider:
@@ -210,3 +223,89 @@ class BinanceUsdmFuturesProvider:
                 f"Binance USD-M Futures stream failed: {e}",
                 suggestions=["Check network and proxy access to fstream.binance.com"],
             ) from e
+
+    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
+        symbol = _normalize_symbol(ticker)
+        params = {"symbol": symbol}
+        client_kwargs: dict[str, Any] = {"timeout": self._timeout}
+        if self._transport is not None:
+            client_kwargs["transport"] = self._transport
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            try:
+                response = await client.get(BINANCE_USDM_EXCHANGE_INFO_URL, params=params)
+            except httpx.RequestError as e:
+                self.last_raw_response = {
+                    "request_params": params,
+                    "response_body": None,
+                    "status_code": None,
+                    "error": str(e),
+                }
+                raise ProviderError(
+                    f"Binance USD-M Futures exchangeInfo request failed: {e}",
+                    suggestions=["Check network access to fapi.binance.com"],
+                ) from e
+
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = response.text
+        self.last_raw_response = {
+            "request_params": params,
+            "response_body": payload,
+            "status_code": response.status_code,
+            "error": None,
+        }
+        if response.status_code >= 400:
+            raise ProviderError(
+                f"Binance USD-M Futures exchangeInfo error {response.status_code}: {payload}"
+            )
+        if not isinstance(payload, dict) or not isinstance(payload.get("symbols"), list):
+            raise ProviderError("Binance USD-M Futures returned invalid exchangeInfo")
+
+        item = next((row for row in payload["symbols"] if row.get("symbol") == symbol), None)
+        if item is None:
+            raise ProviderError(f"Binance exchangeInfo did not include {symbol}")
+        filters = item.get("filters") or []
+        price_filter = _required_filter(filters, "PRICE_FILTER")
+        lot_filter = _required_filter(filters, "LOT_SIZE")
+        market_lot_filter = _required_filter(filters, "MARKET_LOT_SIZE")
+        notional_filter = _required_filter(filters, "MIN_NOTIONAL")
+        observed_at = datetime.now(timezone.utc).isoformat()
+
+        return InstrumentDefinition(
+            instrument_id=f"{symbol}.BINANCE",
+            venue="BINANCE",
+            symbol=symbol,
+            asset_class=AssetClass.COMMODITY,
+            market_type="usd_m_futures",
+            contract_type=str(item["contractType"]),
+            status=str(item["status"]),
+            base_currency=str(item["baseAsset"]),
+            quote_currency=str(item["quoteAsset"]),
+            settlement_currency=str(item["marginAsset"]),
+            margin_currency=str(item["marginAsset"]),
+            is_inverse=False,
+            price_precision=int(item["pricePrecision"]),
+            price_increment=str(price_filter["tickSize"]),
+            min_price=str(price_filter["minPrice"]),
+            max_price=str(price_filter["maxPrice"]),
+            size_precision=int(item["quantityPrecision"]),
+            size_increment=str(lot_filter["stepSize"]),
+            min_quantity=str(lot_filter["minQty"]),
+            max_quantity=str(lot_filter["maxQty"]),
+            market_size_increment=str(market_lot_filter["stepSize"]),
+            market_min_quantity=str(market_lot_filter["minQty"]),
+            market_max_quantity=str(market_lot_filter["maxQty"]),
+            min_notional=str(notional_filter["notional"]),
+            margin_init_rate=_decimal_rate_from_percent(str(item["requiredMarginPercent"])),
+            margin_maint_rate=_decimal_rate_from_percent(str(item["maintMarginPercent"])),
+            order_types=[str(value) for value in item.get("orderTypes", [])],
+            time_in_force=[str(value) for value in item.get("timeInForce", [])],
+            provider="binance_usdm_futures",
+            source_mode="binance_usdm_futures",
+            execution_venue=True,
+            upstream_server_time=payload.get("serverTime"),
+            observed_at=observed_at,
+            missing_fields=["maker_fee_rate", "taker_fee_rate", "contract_multiplier"],
+        )

--- a/src/kline/providers/binance_usdm.py
+++ b/src/kline/providers/binance_usdm.py
@@ -300,6 +300,7 @@ class BinanceUsdmFuturesProvider:
             min_notional=str(notional_filter["notional"]),
             margin_init_rate=_decimal_rate_from_percent(str(item["requiredMarginPercent"])),
             margin_maint_rate=_decimal_rate_from_percent(str(item["maintMarginPercent"])),
+            contract_multiplier="1",
             order_types=[str(value) for value in item.get("orderTypes", [])],
             time_in_force=[str(value) for value in item.get("timeInForce", [])],
             provider="binance_usdm_futures",
@@ -307,5 +308,9 @@ class BinanceUsdmFuturesProvider:
             execution_venue=True,
             upstream_server_time=payload.get("serverTime"),
             observed_at=observed_at,
-            missing_fields=["maker_fee_rate", "taker_fee_rate", "contract_multiplier"],
+            missing_fields=["maker_fee_rate", "taker_fee_rate"],
+            derived_fields={
+                "is_inverse": "binance_usdm_linear_contract",
+                "contract_multiplier": "usd_m_notional_equals_price_times_quantity",
+            },
         )

--- a/src/kline/providers/binance_usdm.py
+++ b/src/kline/providers/binance_usdm.py
@@ -27,6 +27,15 @@ _TF_MAP = {
     Timeframe.MIN_30: "30m",
     Timeframe.HOUR_1: "1h",
     Timeframe.HOUR_4: "4h",
+    Timeframe.DAY: "1d",
+}
+_TF_MILLIS = {
+    Timeframe.MIN_1: 60_000,
+    Timeframe.MIN_5: 300_000,
+    Timeframe.MIN_15: 900_000,
+    Timeframe.MIN_30: 1_800_000,
+    Timeframe.HOUR_1: 3_600_000,
+    Timeframe.HOUR_4: 14_400_000,
 }
 
 _ALIASES = {
@@ -131,52 +140,67 @@ class BinanceUsdmFuturesProvider:
             )
 
         symbol = _normalize_symbol(ticker)
-        params: dict[str, Any] = {"symbol": symbol, "interval": interval, "limit": min(limit, 1500)}
-        if start:
-            params["startTime"] = _to_millis(start)
-        if end:
-            params["endTime"] = _to_millis(end)
-
         client_kwargs: dict[str, Any] = {"timeout": self._timeout}
         if self._transport is not None:
             client_kwargs["transport"] = self._transport
 
+        requested = max(1, limit)
+        cursor = _to_millis(start) if start else None
+        end_ms = _to_millis(end) if end else None
+        raw_pages: list[list[Any]] = []
         async with httpx.AsyncClient(**client_kwargs) as client:
-            try:
-                resp = await client.get(BINANCE_USDM_KLINE_URL, params=params)
-            except httpx.RequestError as e:
-                self.last_raw_response = {
-                    "request_params": params,
-                    "response_body": None,
-                    "status_code": None,
-                    "error": str(e),
+            while len(raw_pages) == 0 or (cursor is not None and sum(map(len, raw_pages)) < requested):
+                remaining = requested - sum(map(len, raw_pages))
+                params: dict[str, Any] = {
+                    "symbol": symbol,
+                    "interval": interval,
+                    "limit": min(max(1, remaining), 1500),
                 }
-                raise ProviderError(
-                    f"Binance USD-M Futures request failed: {e}",
-                    suggestions=["Check network access to fapi.binance.com"],
-                ) from e
+                if cursor is not None:
+                    params["startTime"] = cursor
+                if end_ms is not None:
+                    params["endTime"] = end_ms
+                try:
+                    resp = await client.get(BINANCE_USDM_KLINE_URL, params=params)
+                except httpx.RequestError as e:
+                    self.last_raw_response = {
+                        "request_params": params,
+                        "response_body": None,
+                        "status_code": None,
+                        "error": str(e),
+                    }
+                    raise ProviderError(
+                        f"Binance USD-M Futures request failed: {e}",
+                        suggestions=["Check network access to fapi.binance.com"],
+                    ) from e
+                try:
+                    data = resp.json()
+                except ValueError:
+                    data = resp.text
+                if resp.status_code >= 400:
+                    raise ProviderError(
+                        f"Binance USD-M Futures API error {resp.status_code}: {data}",
+                        suggestions=["Verify XAUUSDT is available on Binance USD-M Futures"],
+                    )
+                if not isinstance(data, list):
+                    raise ProviderError("Binance USD-M Futures returned a non-list kline payload")
+                raw_pages.append(data)
+                if cursor is None or not data or len(data) < params["limit"]:
+                    break
+                next_cursor = int(data[-1][0]) + _TF_MILLIS[timeframe]
+                if next_cursor <= cursor or (end_ms is not None and next_cursor > end_ms):
+                    break
+                cursor = next_cursor
 
-        try:
-            data = resp.json()
-        except ValueError:
-            data = resp.text
-
+        flat_data = [item for page in raw_pages for item in page]
         self.last_raw_response = {
-            "request_params": params,
-            "response_body": data,
-            "status_code": resp.status_code,
+            "request_params": {"symbol": symbol, "interval": interval, "start": start, "end": end, "limit": limit},
+            "response_body": flat_data,
+            "status_code": 200,
             "error": None,
+            "page_count": len(raw_pages),
         }
-
-        if resp.status_code >= 400:
-            raise ProviderError(
-                f"Binance USD-M Futures API error {resp.status_code}: {data}",
-                suggestions=["Verify XAUUSDT is available on Binance USD-M Futures"],
-            )
-        if not isinstance(data, list):
-            raise ProviderError("Binance USD-M Futures returned a non-list kline payload")
-
-        candles = [_candle_from_rest_item(item) for item in data]
+        candles = [_candle_from_rest_item(item) for item in flat_data]
         logger.info("Fetched %s Binance USD-M Futures candles for %s", len(candles), symbol)
         return candles
 

--- a/src/kline/providers/binance_usdm.py
+++ b/src/kline/providers/binance_usdm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -85,9 +86,15 @@ def _candle_from_ws_kline(item: dict[str, Any]) -> Candle:
 class BinanceUsdmFuturesProvider:
     """Fetch and stream XAUUSDT candles from Binance USD-M Futures."""
 
-    def __init__(self, timeout: int = 30, transport: httpx.AsyncBaseTransport | None = None) -> None:
+    def __init__(
+        self,
+        timeout: float = 30,
+        transport: httpx.AsyncBaseTransport | None = None,
+        websocket_connect: Any | None = None,
+    ) -> None:
         self._timeout = timeout
         self._transport = transport
+        self._websocket_connect = websocket_connect
         self.last_raw_response: dict[str, Any] | None = None
 
     def supported_timeframes(self) -> list[Timeframe]:
@@ -180,10 +187,26 @@ class BinanceUsdmFuturesProvider:
                 suggestions=["Install the websockets package"],
             ) from e
 
-        async with websockets.connect(url) as websocket:
-            async for raw_message in websocket:
-                message = json.loads(raw_message)
-                kline = message.get("data", {}).get("k")
-                if not kline:
-                    continue
-                yield _candle_from_ws_kline(kline)
+        connect = self._websocket_connect or websockets.connect
+        try:
+            async with connect(url, open_timeout=self._timeout) as websocket:
+                while True:
+                    try:
+                        raw_message = await asyncio.wait_for(websocket.recv(), timeout=self._timeout)
+                    except TimeoutError as e:
+                        raise ProviderError(
+                            f"Binance USD-M Futures stream returned no kline update within {self._timeout:g}s",
+                            suggestions=["Check the WebSocket proxy path to fstream.binance.com"],
+                        ) from e
+                    message = json.loads(raw_message)
+                    kline = message.get("data", {}).get("k")
+                    if not kline:
+                        continue
+                    yield _candle_from_ws_kline(kline)
+        except ProviderError:
+            raise
+        except (OSError, TimeoutError) as e:
+            raise ProviderError(
+                f"Binance USD-M Futures stream failed: {e}",
+                suggestions=["Check network and proxy access to fstream.binance.com"],
+            ) from e

--- a/src/kline/providers/fred.py
+++ b/src/kline/providers/fred.py
@@ -1,0 +1,75 @@
+"""FRED daily-series adapter for macro, flow-proxy, and event-proxy factors."""
+
+from __future__ import annotations
+
+from csv import DictReader
+from io import StringIO
+
+import httpx
+
+from kline.models import Candle, Timeframe
+from kline.providers.base import ProviderError
+
+
+class FredCsvProvider:
+    def __init__(self, *, timeout: float = 30, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self._timeout = timeout
+        self._transport = transport
+        self.last_raw_response: dict | None = None
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.DAY]
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        if timeframe != Timeframe.DAY:
+            raise ProviderError("FRED supports daily observations only")
+        series_id = ticker.upper().strip()
+        url = "https://fred.stlouisfed.org/graph/fredgraph.csv"
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                transport=self._transport,
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(url, params={"id": series_id})
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise ProviderError(f"FRED request failed: {exc}") from exc
+        self.last_raw_response = {
+            "url": str(response.request.url),
+            "status_code": response.status_code,
+            "series_id": series_id,
+            "body_preview": response.text[:500],
+        }
+        candles: list[Candle] = []
+        for row in DictReader(StringIO(response.text)):
+            raw = str(row.get(series_id, "")).strip()
+            observation_date = str(row.get("observation_date", "")).strip()
+            if not observation_date or not raw or raw == ".":
+                continue
+            if start and observation_date < start[:10]:
+                continue
+            if end and observation_date > end[:10]:
+                continue
+            value = float(raw)
+            candles.append(
+                Candle(
+                    timestamp=f"{observation_date}T00:00:00+00:00",
+                    open=value,
+                    high=value,
+                    low=value,
+                    close=value,
+                    volume=0,
+                )
+            )
+        if not candles:
+            raise ProviderError(f"FRED returned no usable observations for {series_id}")
+        return candles[-max(1, limit) :]

--- a/src/kline/providers/oanda.py
+++ b/src/kline/providers/oanda.py
@@ -1,0 +1,125 @@
+"""OANDA v20 pricing adapter; credentials stay inside datafeed."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator
+
+import httpx
+
+from kline.models import AssetClass, Candle, InstrumentDefinition, Timeframe
+from kline.ports import MarketDataPort, ProviderMeta, SourceManifest
+from kline.providers.base import ProviderError
+
+
+class OandaV20Adapter(MarketDataPort):
+    def __init__(self, config: dict[str, Any], transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self.config = config
+        self._transport = transport
+        source_id = str(config.get("source_id") or "oanda_v20")
+        instrument = str(config.get("instrument") or "XAU_USD")
+        aliases = {"GOLD": instrument, "XAUUSD": instrument, instrument.upper(): instrument}
+        self._manifest = SourceManifest(
+            source_id=source_id,
+            asset_class=AssetClass.COMMODITY,
+            meta=ProviderMeta(
+                name="oanda",
+                source_mode=source_id,
+                quality_flags=("official_broker_feed", "oanda_v20", "execution_venue"),
+                continuous=False,
+                execution_venue=True,
+                realtime_supported=False,
+                market_type="broker_spot_cfd",
+                supported_symbols=(instrument,),
+            ),
+            ticker_aliases=aliases,
+            canonical_instrument_ids={key: "GOLD" for key in aliases},
+        )
+        self._last_raw_response: dict[str, Any] | None = None
+
+    @property
+    def manifest(self) -> SourceManifest:
+        return self._manifest
+
+    @property
+    def last_raw_response(self) -> dict[str, Any] | None:
+        return self._last_raw_response
+
+    def canonical_ticker(self, ticker: str) -> str:
+        return self.manifest.canonical_ticker(ticker)
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.MIN_1, Timeframe.MIN_5, Timeframe.MIN_15, Timeframe.HOUR_1, Timeframe.HOUR_4, Timeframe.DAY]
+
+    async def fetch_candles(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        if timeframe not in self.supported_timeframes():
+            raise ProviderError(f"OANDA timeframe unsupported: {timeframe.value}")
+        token = str(self.config.get("token") or "")
+        if not token:
+            raise ProviderError("OANDA API token is missing")
+        instrument = self.canonical_ticker(ticker)
+        params: dict[str, Any] = {
+            "price": str(self.config.get("price") or "M"),
+            "granularity": self._granularity(timeframe),
+            "count": min(max(1, limit), 5000),
+        }
+        if start:
+            params["from"] = start
+            params.pop("count", None)
+        if end:
+            params["to"] = end
+        base_url = str(self.config.get("base_url") or "https://api-fxpractice.oanda.com").rstrip("/")
+        url = f"{base_url}/v3/instruments/{instrument}/candles"
+        try:
+            async with httpx.AsyncClient(timeout=float(self.config.get("timeout_seconds", 15)), transport=self._transport) as client:
+                response = await client.get(url, params=params, headers={"Authorization": f"Bearer {token}", "Accept-Datetime-Format": "RFC3339"})
+                response.raise_for_status()
+                payload = response.json()
+        except (httpx.HTTPError, ValueError) as error:
+            raise ProviderError(f"OANDA request failed: {error}") from error
+        self._last_raw_response = {"request_params": params, "response_body": payload, "status_code": response.status_code, "error": None}
+        candles = []
+        for item in payload.get("candles", []):
+            if item.get("complete") is False:
+                continue
+            mid = item.get("mid") or {}
+            if not all(key in mid for key in ("o", "h", "l", "c")):
+                continue
+            candles.append(Candle(timestamp=self._timestamp(str(item["time"])), open=float(mid["o"]), high=float(mid["h"]), low=float(mid["l"]), close=float(mid["c"]), volume=float(item.get("volume") or 0)))
+        return candles[-limit:]
+
+    async def stream_candles(self, ticker: str, timeframe: Timeframe) -> AsyncIterator[Candle]:
+        raise ProviderError("OANDA candle streaming is not configured; use REST polling")
+        if False:
+            yield Candle(timestamp="", open=0, high=0, low=0, close=0, volume=0)
+
+    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
+        raise ProviderError("OANDA instrument definition requires an account-scoped endpoint")
+
+    @staticmethod
+    def _granularity(timeframe: Timeframe) -> str:
+        return {Timeframe.MIN_1: "M1", Timeframe.MIN_5: "M5", Timeframe.MIN_15: "M15", Timeframe.HOUR_1: "H1", Timeframe.HOUR_4: "H4", Timeframe.DAY: "D"}[timeframe]
+
+    @staticmethod
+    def _timestamp(value: str) -> str:
+        head, dot, tail = value.partition(".")
+        if dot:
+            zone = "Z" if tail.endswith("Z") else "+00:00" if "+" not in tail else "+" + tail.split("+", 1)[1]
+            fraction = tail.rstrip("Z").split("+", 1)[0][:6]
+            value = f"{head}.{fraction}{zone}"
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def create_adapter(config: dict[str, Any]) -> OandaV20Adapter:
+    return OandaV20Adapter(config)

--- a/src/kline/providers/tiger.py
+++ b/src/kline/providers/tiger.py
@@ -1,0 +1,265 @@
+"""Tiger OpenAPI market-data adapter (quote endpoints only, never execution)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+from kline.models import AssetClass, Candle, InstrumentDefinition, Timeframe
+from kline.ports import MarketDataPort, ProviderMeta, SourceManifest
+from kline.providers.base import ProviderError
+
+
+class TigerOpenFuturesAdapter(MarketDataPort):
+    def __init__(self, config: dict[str, Any], quote_client: Any | None = None) -> None:
+        self.config = config
+        self._quote_client = quote_client
+        self._injected_quote_client = quote_client is not None
+        source_id = str(config.get("source_id") or "tiger_openapi_comex")
+        contract = str(config.get("contract") or "MGCmain")
+        aliases = {
+            "MGC": contract,
+            "MGCMAIN": contract,
+            contract.upper(): contract,
+        }
+        self._manifest = SourceManifest(
+            source_id=source_id,
+            asset_class=AssetClass.COMMODITY,
+            meta=ProviderMeta(
+                name="tiger_openapi",
+                source_mode=source_id,
+                quality_flags=(
+                    "official_broker_feed",
+                    "execution_venue_feed",
+                    "exchange_futures",
+                    "tiger_openapi",
+                    str(config.get("exchange") or "COMEX").lower(),
+                ),
+                continuous=False,
+                execution_venue=True,
+                realtime_supported=False,
+                market_type="broker_futures",
+                supported_symbols=(contract,),
+            ),
+            ticker_aliases=aliases,
+            canonical_instrument_ids={key: "MGC_CONTINUOUS" for key in aliases},
+        )
+        self._last_raw_response: dict[str, Any] | None = None
+
+    @property
+    def manifest(self) -> SourceManifest:
+        return self._manifest
+
+    @property
+    def last_raw_response(self) -> dict[str, Any] | None:
+        return self._last_raw_response
+
+    def canonical_ticker(self, ticker: str) -> str:
+        return self.manifest.canonical_ticker(ticker)
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.MIN_1, Timeframe.MIN_5, Timeframe.DAY]
+
+    async def fetch_candles(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        if timeframe not in self.supported_timeframes():
+            raise ProviderError(
+                f"Tiger futures timeframe is unsupported: {timeframe.value}",
+                suggestions=["Use 1m, 5m, or 1d"],
+            )
+        contract = self.canonical_ticker(ticker)
+        client = self._client()
+        begin_ms = self._to_ms(start) if start else -1
+        end_ms = self._to_ms(end) if end else -1
+        try:
+            payload = client.get_future_bars(
+                [contract],
+                period=self._period(timeframe),
+                begin_time=begin_ms,
+                end_time=end_ms,
+                limit=limit,
+            )
+        except Exception as error:
+            self._last_raw_response = {
+                "request_params": {
+                    "contract": contract,
+                    "period": timeframe.value,
+                    "begin_time": begin_ms,
+                    "end_time": end_ms,
+                    "limit": limit,
+                },
+                "response_body": None,
+                "status_code": None,
+                "error": f"{type(error).__name__}: {error}",
+            }
+            raise ProviderError(f"Tiger OpenAPI futures request failed: {error}") from error
+
+        rows = self._payload_rows(payload)
+        self._last_raw_response = {
+            "request_params": {
+                "contract": contract,
+                "period": timeframe.value,
+                "begin_time": begin_ms,
+                "end_time": end_ms,
+                "limit": limit,
+            },
+            "response_body": rows,
+            "status_code": 200,
+            "error": None,
+        }
+        unique = {candle.timestamp: candle for candle in (self._to_candle(row) for row in rows)}
+        return [unique[key] for key in sorted(unique)][-limit:]
+
+    async def stream_candles(
+        self, ticker: str, timeframe: Timeframe
+    ) -> AsyncIterator[Candle]:
+        raise ProviderError(
+            "Tiger OpenAPI streaming is not configured",
+            suggestions=["Use REST polling until a quote push adapter is installed"],
+        )
+        if False:
+            yield Candle(timestamp="", open=0, high=0, low=0, close=0, volume=0)
+
+    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
+        raise ProviderError(
+            "Tiger instrument-definition-v1 mapping is not implemented",
+            suggestions=["Use candle data only for this adapter"],
+        )
+
+    async def fetch_market_sessions(self, ticker: str, trading_date: str | None = None) -> dict[str, Any]:
+        contract = self.canonical_ticker(ticker)
+        try:
+            payload = self._client().get_future_trading_times(contract, trading_date=trading_date)
+        except Exception as error:
+            raise ProviderError(f"Tiger trading-times request failed: {error}") from error
+        windows = []
+        for row in self._payload_rows(payload):
+            if row.get("start") is None or row.get("end") is None:
+                continue
+            windows.append(
+                {
+                    "kind": "trading" if bool(row.get("trading")) else "bidding" if bool(row.get("bidding")) else "closed",
+                    "trading": bool(row.get("trading")),
+                    "bidding": bool(row.get("bidding")),
+                    "start": self._timestamp(row["start"]),
+                    "end": self._timestamp(row["end"]),
+                    "zone": str(row.get("zone") or row.get("time_zone") or self.config.get("time_zone", "")),
+                }
+            )
+        windows.sort(key=lambda item: item["start"])
+        return {
+            "schema_version": "market-sessions-v1",
+            "source": self.manifest.source_id,
+            "instrument_id": self.manifest.canonical_instrument_id(ticker),
+            "provider_symbol": contract,
+            "trading_date": trading_date or "",
+            "timezone": next((item["zone"] for item in windows if item.get("zone")), ""),
+            "windows": windows,
+            "trading_windows": [item for item in windows if item["trading"]],
+        }
+
+    def _client(self):
+        if self._quote_client is not None:
+            return self._quote_client
+        props_path = str(self.config.get("props_path") or "")
+        if not props_path or not Path(props_path).exists():
+            raise ProviderError("Tiger OpenAPI props_path is missing or does not exist")
+        try:
+            from tigeropen.quote.quote_client import QuoteClient
+            from tigeropen.tiger_open_config import TigerOpenClientConfig
+        except ImportError as error:
+            raise ProviderError(
+                "tigeropen is not installed",
+                suggestions=["Install datafeed with the tiger optional dependency"],
+            ) from error
+        client_config = TigerOpenClientConfig(props_path=props_path)
+        self._quote_client = QuoteClient(
+            client_config,
+            is_grab_permission=bool(self.config.get("grab_quote_permission", False)),
+        )
+        return self._quote_client
+
+    def _period(self, timeframe: Timeframe):
+        if self._injected_quote_client:
+            return timeframe.value
+        try:
+            from tigeropen.common.consts import BarPeriod
+        except ImportError as error:
+            raise ProviderError("tigeropen is not installed") from error
+        return {
+            Timeframe.MIN_1: BarPeriod.ONE_MINUTE,
+            Timeframe.MIN_5: BarPeriod.FIVE_MINUTES,
+            Timeframe.DAY: BarPeriod.DAY,
+        }[timeframe]
+
+    @staticmethod
+    def _payload_rows(payload: Any) -> list[dict[str, Any]]:
+        if payload is None:
+            return []
+        if hasattr(payload, "to_dict"):
+            try:
+                return list(payload.to_dict("records"))
+            except TypeError:
+                pass
+        items = payload if isinstance(payload, (list, tuple)) else [payload]
+        rows = []
+        for item in items:
+            if isinstance(item, dict):
+                rows.append(item)
+            elif hasattr(item, "_asdict"):
+                rows.append(dict(item._asdict()))
+            elif hasattr(item, "__dict__"):
+                rows.append(dict(item.__dict__))
+            else:
+                raise ProviderError(f"Unsupported Tiger response row: {type(item).__name__}")
+        return rows
+
+    @classmethod
+    def _to_candle(cls, row: dict[str, Any]) -> Candle:
+        timestamp = row.get("time") or row.get("timestamp") or row.get("latest_time")
+        if timestamp is None:
+            raise ProviderError("Tiger response row is missing a timestamp")
+        if isinstance(timestamp, (int, float)) or str(timestamp).isdigit():
+            parsed = datetime.fromtimestamp(float(timestamp) / 1000, tz=timezone.utc)
+        else:
+            parsed = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+        return Candle(
+            timestamp=parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat(),
+            open=float(row["open"]),
+            high=float(row["high"]),
+            low=float(row["low"]),
+            close=float(row["close"]),
+            volume=float(row.get("volume") or 0),
+            amount=float(row["amount"]) if row.get("amount") is not None else None,
+        )
+
+    @staticmethod
+    def _to_ms(value: str) -> int:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp() * 1000)
+
+    @staticmethod
+    def _timestamp(value: Any) -> str:
+        if isinstance(value, (int, float)) or str(value).isdigit():
+            parsed = datetime.fromtimestamp(float(value) / 1000, tz=timezone.utc)
+        else:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def create_adapter(config: dict[str, Any]) -> TigerOpenFuturesAdapter:
+    return TigerOpenFuturesAdapter(config)

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -4,18 +4,21 @@ from __future__ import annotations
 
 from kline.config import Settings, ensure_data_dir, get_settings
 from kline.models import AssetClass
+from kline.plugin_loader import load_configured_adapters, load_entrypoint_adapters
 from kline.ports import MarketDataPort, ProviderBackedMarketDataAdapter
 from kline.providers.ashare import AShareProvider
 from kline.providers.base import Provider, ProviderError
 from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 from kline.providers.commodity import CommodityProvider
 from kline.providers.crypto import CryptoProvider
+from kline.providers.fred import FredCsvProvider
 from kline.providers.us import USStockProvider
 from kline.provenance import (
     all_source_manifests,
     normalize_source,
     register_source_manifest,
     source_manifest,
+    fred_source_manifest,
 )
 from kline.store import KlineStore
 
@@ -48,6 +51,13 @@ def init(settings: Settings | None = None) -> None:
             _providers[AssetClass.US_STOCK],
         )
     )
+    for factor_asset_class in (AssetClass.MACRO, AssetClass.FLOW, AssetClass.EVENT):
+        register_adapter(
+            ProviderBackedMarketDataAdapter(
+                fred_source_manifest(factor_asset_class),
+                FredCsvProvider(timeout=s.request_timeout),
+            )
+        )
     register_adapter(
         ProviderBackedMarketDataAdapter(
             source_manifest("binance_spot_public", AssetClass.CRYPTO),
@@ -76,6 +86,12 @@ def init(settings: Settings | None = None) -> None:
                 _providers[AssetClass.A_SHARE],
             )
         )
+
+    external_adapters = load_configured_adapters(s.adapter_config_path)
+    if s.load_entrypoint_adapters:
+        external_adapters.extend(load_entrypoint_adapters())
+    for adapter in external_adapters:
+        register_adapter(adapter)
 
 
 def get_store() -> KlineStore:
@@ -109,7 +125,10 @@ def get_live_provider(source_mode: str = "binance_usdm_futures") -> Provider:
 
 def register_adapter(adapter: MarketDataPort) -> None:
     """Register a source adapter. This is the broker/plugin extension point."""
-    _adapters[adapter.manifest.source_id] = adapter
+    source_id = adapter.manifest.source_id
+    if source_id in _adapters:
+        raise ProviderError(f"Duplicate source adapter: {source_id}")
+    _adapters[source_id] = adapter
     register_source_manifest(adapter.manifest)
 
 

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -9,7 +9,17 @@ from sqlalchemy import create_engine, event, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import sessionmaker
 
-from kline.models import AssetClass, Base, Candle, KlineRow, RawUpstreamResponse, Timeframe
+from kline.models import (
+    AssetClass,
+    Base,
+    Candle,
+    KlineRow,
+    RawUpstreamResponse,
+    SourceObservation,
+    Timeframe,
+)
+
+LEGACY_SOURCE_ID = "legacy_unknown"
 
 
 class KlineStore:
@@ -20,6 +30,8 @@ class KlineStore:
         # Enable WAL mode for concurrent reads
         event.listen(self._engine, "connect", self._enable_wal)
         Base.metadata.create_all(self._engine)
+        self._migrate_source_aware_schema()
+        self._normalize_stored_timestamps()
         self._session_factory = sessionmaker(bind=self._engine)
 
     @staticmethod
@@ -28,12 +40,79 @@ class KlineStore:
         cursor.execute("PRAGMA journal_mode=WAL")
         cursor.close()
 
+    def _migrate_source_aware_schema(self) -> None:
+        """Upgrade pre-v0.3 candle stores without guessing their upstream source."""
+        expected_lookup = ["source_id", "ticker", "asset_class", "timeframe", "timestamp"]
+        expected_ticker_tf = ["source_id", "ticker", "timeframe"]
+        with self._engine.begin() as connection:
+            columns = {
+                row[1] for row in connection.exec_driver_sql("PRAGMA table_info(klines)").fetchall()
+            }
+            if "source_id" not in columns:
+                connection.exec_driver_sql(
+                    "ALTER TABLE klines ADD COLUMN source_id VARCHAR "
+                    f"NOT NULL DEFAULT '{LEGACY_SOURCE_ID}'"
+                )
+
+            for index_name, expected_columns, unique in (
+                ("ix_kline_lookup", expected_lookup, True),
+                ("ix_kline_ticker_tf", expected_ticker_tf, False),
+            ):
+                current_columns = [
+                    row[2]
+                    for row in connection.exec_driver_sql(
+                        f"PRAGMA index_info('{index_name}')"
+                    ).fetchall()
+                ]
+                if current_columns and current_columns != expected_columns:
+                    connection.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
+                unique_sql = "UNIQUE " if unique else ""
+                joined = ", ".join(expected_columns)
+                connection.exec_driver_sql(
+                    f"CREATE {unique_sql}INDEX IF NOT EXISTS {index_name} "
+                    f"ON klines ({joined})"
+                )
+
+    def _normalize_stored_timestamps(self) -> None:
+        """Canonicalize UTC timestamps and merge logically duplicate legacy rows."""
+        from datetime import datetime, timezone
+
+        with self._engine.begin() as connection:
+            rows = connection.exec_driver_sql(
+                "SELECT id, source_id, ticker, asset_class, timeframe, timestamp, "
+                "open, high, low, close, volume, amount FROM klines "
+                "WHERE timestamp LIKE '%T%' AND timestamp NOT LIKE '%+__:__' "
+                "AND timestamp NOT LIKE '%Z'"
+            ).fetchall()
+            for row in rows:
+                parsed = datetime.fromisoformat(str(row[5]))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                canonical = parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+                duplicate = connection.exec_driver_sql(
+                    "SELECT id FROM klines WHERE source_id=? AND ticker=? AND asset_class=? "
+                    "AND timeframe=? AND timestamp=? AND id<>? LIMIT 1",
+                    (row[1], row[2], row[3], row[4], canonical, row[0]),
+                ).fetchone()
+                if duplicate:
+                    connection.exec_driver_sql(
+                        "UPDATE klines SET open=?, high=?, low=?, close=?, volume=?, amount=? "
+                        "WHERE id=?",
+                        (row[6], row[7], row[8], row[9], row[10], row[11], duplicate[0]),
+                    )
+                    connection.exec_driver_sql("DELETE FROM klines WHERE id=?", (row[0],))
+                else:
+                    connection.exec_driver_sql(
+                        "UPDATE klines SET timestamp=? WHERE id=?", (canonical, row[0])
+                    )
+
     def query(
         self,
         ticker: str,
         asset_class: AssetClass,
         timeframe: Timeframe,
         *,
+        source_id: str = LEGACY_SOURCE_ID,
         start: str | None = None,
         end: str | None = None,
         limit: int = 500,
@@ -43,11 +122,12 @@ class KlineStore:
             stmt = (
                 select(KlineRow)
                 .where(
+                    KlineRow.source_id == source_id,
                     KlineRow.ticker == ticker,
                     KlineRow.asset_class == asset_class.value,
                     KlineRow.timeframe == timeframe.value,
                 )
-                .order_by(KlineRow.timestamp.asc())
+                .order_by(KlineRow.timestamp.desc())
                 .limit(limit)
             )
             if start:
@@ -56,7 +136,7 @@ class KlineStore:
                 stmt = stmt.where(KlineRow.timestamp <= end)
 
             rows = session.execute(stmt).scalars().all()
-            return [row.to_candle() for row in rows]
+            return [row.to_candle() for row in reversed(rows)]
 
     def save(
         self,
@@ -64,6 +144,8 @@ class KlineStore:
         asset_class: AssetClass,
         timeframe: Timeframe,
         candles: list[Candle],
+        *,
+        source_id: str = LEGACY_SOURCE_ID,
     ) -> int:
         """Upsert candles. Returns number of rows affected."""
         if not candles:
@@ -71,6 +153,7 @@ class KlineStore:
 
         records = [
             {
+                "source_id": source_id,
                 "ticker": ticker,
                 "asset_class": asset_class.value,
                 "timeframe": timeframe.value,
@@ -85,22 +168,31 @@ class KlineStore:
             for c in candles
         ]
 
+        affected = 0
         with self._session_factory() as session:
-            stmt = sqlite_insert(KlineRow).values(records)
-            stmt = stmt.on_conflict_do_update(
-                index_elements=["ticker", "asset_class", "timeframe", "timestamp"],
-                set_={
-                    "open": stmt.excluded.open,
-                    "high": stmt.excluded.high,
-                    "low": stmt.excluded.low,
-                    "close": stmt.excluded.close,
-                    "volume": stmt.excluded.volume,
-                    "amount": stmt.excluded.amount,
-                },
-            )
-            result = session.execute(stmt)
+            # Keep well below SQLite's build-dependent bound-variable limit.
+            for offset in range(0, len(records), 500):
+                stmt = sqlite_insert(KlineRow).values(records[offset : offset + 500])
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=[
+                        "source_id",
+                        "ticker",
+                        "asset_class",
+                        "timeframe",
+                        "timestamp",
+                    ],
+                    set_={
+                        "open": stmt.excluded.open,
+                        "high": stmt.excluded.high,
+                        "low": stmt.excluded.low,
+                        "close": stmt.excluded.close,
+                        "volume": stmt.excluded.volume,
+                        "amount": stmt.excluded.amount,
+                    },
+                )
+                affected += session.execute(stmt).rowcount
             session.commit()
-            return result.rowcount
+            return affected
 
     def save_raw_response(
         self,
@@ -136,15 +228,29 @@ class KlineStore:
             session.commit()
             return 1
 
-    def list_tickers(self, asset_class: AssetClass | None = None) -> list[str]:
+    def list_tickers(
+        self,
+        asset_class: AssetClass | None = None,
+        *,
+        source_id: str | None = None,
+    ) -> list[str]:
         """List all tickers with stored data."""
         with self._session_factory() as session:
             stmt = select(KlineRow.ticker).distinct()
             if asset_class:
                 stmt = stmt.where(KlineRow.asset_class == asset_class.value)
+            if source_id:
+                stmt = stmt.where(KlineRow.source_id == source_id)
             return list(session.execute(stmt).scalars().all())
 
-    def count(self, ticker: str, asset_class: AssetClass, timeframe: Timeframe) -> int:
+    def count(
+        self,
+        ticker: str,
+        asset_class: AssetClass,
+        timeframe: Timeframe,
+        *,
+        source_id: str = LEGACY_SOURCE_ID,
+    ) -> int:
         """Count stored candles for a ticker."""
         from sqlalchemy import func
 
@@ -153,12 +259,133 @@ class KlineStore:
                 select(func.count())
                 .select_from(KlineRow)
                 .where(
+                    KlineRow.source_id == source_id,
                     KlineRow.ticker == ticker,
                     KlineRow.asset_class == asset_class.value,
                     KlineRow.timeframe == timeframe.value,
                 )
             )
             return session.execute(stmt).scalar_one()
+
+    def source_coverage(self) -> list[dict[str, Any]]:
+        """Return source-scoped storage coverage for health and audit surfaces."""
+        from sqlalchemy import func
+
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(
+                    KlineRow.source_id,
+                    KlineRow.asset_class,
+                    KlineRow.ticker,
+                    KlineRow.timeframe,
+                    func.count().label("count"),
+                    func.min(KlineRow.timestamp).label("first_timestamp"),
+                    func.max(KlineRow.timestamp).label("latest_timestamp"),
+                ).group_by(
+                    KlineRow.source_id,
+                    KlineRow.asset_class,
+                    KlineRow.ticker,
+                    KlineRow.timeframe,
+                )
+            ).all()
+            return [
+                {
+                    "source_id": row.source_id,
+                    "asset_class": row.asset_class,
+                    "ticker": row.ticker,
+                    "timeframe": row.timeframe,
+                    "count": row.count,
+                    "first_timestamp": row.first_timestamp,
+                    "latest_timestamp": row.latest_timestamp,
+                }
+                for row in rows
+            ]
+
+    def save_source_observation(
+        self,
+        *,
+        source_id: str,
+        provider: str,
+        ticker: str,
+        asset_class: AssetClass,
+        timeframe: Timeframe,
+        success: bool,
+        candle_count: int,
+        latest_timestamp: str | None,
+        latency_ms: float | None,
+        quality_flags: list[str],
+        error: str | None = None,
+        served_from: str = "upstream",
+    ) -> int:
+        row = SourceObservation(
+            source_id=source_id,
+            provider=provider,
+            ticker=ticker,
+            asset_class=asset_class.value,
+            timeframe=timeframe.value,
+            success=success,
+            served_from=served_from,
+            candle_count=candle_count,
+            latest_timestamp=latest_timestamp,
+            latency_ms=latency_ms,
+            error=error,
+            quality_flags=json.dumps(quality_flags, ensure_ascii=False),
+        )
+        with self._session_factory() as session:
+            session.add(row)
+            session.commit()
+            return 1
+
+    def latest_source_observations(self) -> list[dict[str, Any]]:
+        """Return the latest request result for every source/instrument/timeframe."""
+        from sqlalchemy import and_, func
+
+        with self._session_factory() as session:
+            latest = (
+                select(
+                    SourceObservation.source_id,
+                    SourceObservation.ticker,
+                    SourceObservation.timeframe,
+                    func.max(SourceObservation.id).label("latest_id"),
+                )
+                .group_by(
+                    SourceObservation.source_id,
+                    SourceObservation.ticker,
+                    SourceObservation.timeframe,
+                )
+                .subquery()
+            )
+            rows = session.execute(
+                select(SourceObservation)
+                .join(
+                    latest,
+                    and_(
+                        SourceObservation.source_id == latest.c.source_id,
+                        SourceObservation.ticker == latest.c.ticker,
+                        SourceObservation.timeframe == latest.c.timeframe,
+                        SourceObservation.id == latest.c.latest_id,
+                    ),
+                )
+                .order_by(SourceObservation.source_id, SourceObservation.ticker)
+            ).scalars()
+            return [
+                {
+                    "source_id": row.source_id,
+                    "provider": row.provider,
+                    "asset_class": row.asset_class,
+                    "ticker": row.ticker,
+                    "timeframe": row.timeframe,
+                    "success": row.success,
+                    "served_from": row.served_from,
+                    "candle_count": row.candle_count,
+                    "latest_timestamp": row.latest_timestamp,
+                    "latency_ms": row.latency_ms,
+                    "error": row.error,
+                    "quality_flags": json.loads(row.quality_flags),
+                    "observed_at": row.observed_at.isoformat() if row.observed_at else None,
+                }
+                for row in rows
+            ]
 
     def count_raw_responses(self) -> int:
         """Count captured raw upstream payloads."""
@@ -167,3 +394,18 @@ class KlineStore:
         with self._session_factory() as session:
             stmt = select(func.count()).select_from(RawUpstreamResponse)
             return session.execute(stmt).scalar_one()
+
+    def storage_health(self) -> dict[str, Any]:
+        """Return an owner-side integrity receipt without exposing the database path."""
+        with self._engine.connect() as connection:
+            integrity = str(connection.exec_driver_sql("PRAGMA integrity_check").scalar_one())
+            candle_rows = int(connection.exec_driver_sql("SELECT COUNT(*) FROM klines").scalar_one())
+            source_rows = int(
+                connection.exec_driver_sql("SELECT COUNT(DISTINCT source_id) FROM klines").scalar_one()
+            )
+        return {
+            "status": "ok" if integrity == "ok" else "error",
+            "integrity": integrity,
+            "candle_rows": candle_rows,
+            "source_count": source_rows,
+        }

--- a/tests/test_binance_usdm.py
+++ b/tests/test_binance_usdm.py
@@ -80,7 +80,7 @@ def _exchange_info() -> dict:
 
 @pytest.mark.parametrize(
     ("timeframe", "interval"),
-    [(Timeframe.MIN_1, "1m"), (Timeframe.MIN_5, "5m")],
+    [(Timeframe.MIN_1, "1m"), (Timeframe.MIN_5, "5m"), (Timeframe.DAY, "1d")],
 )
 async def test_xauusdt_rest_normalizes_to_standard_candles(timeframe: Timeframe, interval: str):
     seen_params: dict[str, str] = {}
@@ -94,7 +94,7 @@ async def test_xauusdt_rest_normalizes_to_standard_candles(timeframe: Timeframe,
 
     assert seen_params["symbol"] == "XAUUSDT"
     assert seen_params["interval"] == interval
-    assert candles[0].timestamp == "2026-07-09T10:00:00"
+    assert candles[0].timestamp == "2026-07-09T10:00:00+00:00"
     assert candles[0].open == 3300.10
     assert candles[0].high == 3301.20
     assert candles[0].low == 3299.90

--- a/tests/test_binance_usdm.py
+++ b/tests/test_binance_usdm.py
@@ -139,11 +139,11 @@ async def test_xauusdt_instrument_definition_preserves_exchange_constraints():
     assert definition.margin_init_rate == "0.0500"
     assert definition.margin_maint_rate == "0.0250"
     assert definition.is_synthetic is False
-    assert definition.missing_fields == [
-        "maker_fee_rate",
-        "taker_fee_rate",
-        "contract_multiplier",
-    ]
+    assert definition.contract_multiplier == "1"
+    assert definition.missing_fields == ["maker_fee_rate", "taker_fee_rate"]
+    assert definition.derived_fields["contract_multiplier"] == (
+        "usd_m_notional_equals_price_times_quantity"
+    )
     assert provider.last_raw_response is not None
     assert provider.last_raw_response["response_body"]["serverTime"] == 1783667819466
 

--- a/tests/test_binance_usdm.py
+++ b/tests/test_binance_usdm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import asyncio
 
 import httpx
 import pytest
@@ -68,3 +69,35 @@ async def test_binance_usdm_rejects_non_xau_symbols():
         await provider.fetch("BTCUSDT", Timeframe.MIN_1)
 
     assert "not enabled" in str(exc.value)
+
+
+class _FakeWebSocket:
+    def __init__(self, messages: list[str] | None = None) -> None:
+        self.messages = list(messages or [])
+
+    async def recv(self) -> str:
+        if self.messages:
+            return self.messages.pop(0)
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class _FakeWebSocketContext:
+    def __init__(self, socket: _FakeWebSocket) -> None:
+        self.socket = socket
+
+    async def __aenter__(self) -> _FakeWebSocket:
+        return self.socket
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+
+async def test_binance_usdm_stream_fails_visibly_when_upstream_is_silent():
+    provider = BinanceUsdmFuturesProvider(
+        timeout=0.01,
+        websocket_connect=lambda *_args, **_kwargs: _FakeWebSocketContext(_FakeWebSocket()),
+    )
+
+    with pytest.raises(ProviderError, match="no kline update"):
+        await anext(provider.stream("XAUUSDT", Timeframe.MIN_1))

--- a/tests/test_binance_usdm.py
+++ b/tests/test_binance_usdm.py
@@ -35,6 +35,49 @@ def _kline(open_time_ms: int, open_price: str = "3300.10") -> list:
     ]
 
 
+def _exchange_info() -> dict:
+    return {
+        "serverTime": 1783667819466,
+        "symbols": [
+            {
+                "symbol": "XAUUSDT",
+                "contractType": "TRADIFI_PERPETUAL",
+                "status": "TRADING",
+                "maintMarginPercent": "2.5000",
+                "requiredMarginPercent": "5.0000",
+                "baseAsset": "XAU",
+                "quoteAsset": "USDT",
+                "marginAsset": "USDT",
+                "pricePrecision": 2,
+                "quantityPrecision": 3,
+                "filters": [
+                    {
+                        "filterType": "PRICE_FILTER",
+                        "tickSize": "0.01",
+                        "minPrice": "0.01",
+                        "maxPrice": "200000",
+                    },
+                    {
+                        "filterType": "LOT_SIZE",
+                        "stepSize": "0.001",
+                        "minQty": "0.001",
+                        "maxQty": "10000",
+                    },
+                    {
+                        "filterType": "MARKET_LOT_SIZE",
+                        "stepSize": "0.001",
+                        "minQty": "0.001",
+                        "maxQty": "1000",
+                    },
+                    {"filterType": "MIN_NOTIONAL", "notional": "5"},
+                ],
+                "orderTypes": ["LIMIT", "MARKET", "STOP_MARKET", "TAKE_PROFIT_MARKET"],
+                "timeInForce": ["GTC", "IOC", "FOK"],
+            }
+        ],
+    }
+
+
 @pytest.mark.parametrize(
     ("timeframe", "interval"),
     [(Timeframe.MIN_1, "1m"), (Timeframe.MIN_5, "5m")],
@@ -69,6 +112,40 @@ async def test_binance_usdm_rejects_non_xau_symbols():
         await provider.fetch("BTCUSDT", Timeframe.MIN_1)
 
     assert "not enabled" in str(exc.value)
+
+
+async def test_xauusdt_instrument_definition_preserves_exchange_constraints():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/fapi/v1/exchangeInfo"
+        assert request.url.params["symbol"] == "XAUUSDT"
+        return httpx.Response(200, json=_exchange_info())
+
+    provider = BinanceUsdmFuturesProvider(transport=httpx.MockTransport(handler))
+    definition = await provider.fetch_instrument_definition("GOLD")
+
+    assert definition.schema_version == "instrument-definition-v1"
+    assert definition.instrument_id == "XAUUSDT.BINANCE"
+    assert definition.contract_type == "TRADIFI_PERPETUAL"
+    assert definition.base_currency == "XAU"
+    assert definition.quote_currency == "USDT"
+    assert definition.settlement_currency == "USDT"
+    assert definition.is_inverse is False
+    assert definition.price_precision == 2
+    assert definition.price_increment == "0.01"
+    assert definition.size_precision == 3
+    assert definition.size_increment == "0.001"
+    assert definition.min_quantity == "0.001"
+    assert definition.min_notional == "5"
+    assert definition.margin_init_rate == "0.0500"
+    assert definition.margin_maint_rate == "0.0250"
+    assert definition.is_synthetic is False
+    assert definition.missing_fields == [
+        "maker_fee_rate",
+        "taker_fee_rate",
+        "contract_multiplier",
+    ]
+    assert provider.last_raw_response is not None
+    assert provider.last_raw_response["response_body"]["serverTime"] == 1783667819466
 
 
 class _FakeWebSocket:

--- a/tests/test_compare_sources.py
+++ b/tests/test_compare_sources.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from kline.api import compare_sources
+from kline.models import AssetClass, Candle, Timeframe
+from kline.store import KlineStore
+
+
+async def test_compare_sources_keeps_series_separate(monkeypatch, tmp_path: Path):
+    store = KlineStore(str(tmp_path / "compare.db"))
+    store.save(
+        "XAUUSDT",
+        AssetClass.COMMODITY,
+        Timeframe.MIN_5,
+        [Candle(timestamp="2026-07-15T10:00:00Z", open=100, high=101, low=99, close=100, volume=1)],
+        source_id="binance_usdm_futures",
+    )
+    store.save(
+        "GC=F",
+        AssetClass.COMMODITY,
+        Timeframe.MIN_5,
+        [Candle(timestamp="2026-07-15T10:00:00Z", open=101, high=102, low=100, close=101, volume=1)],
+        source_id="yahoo_finance_futures",
+    )
+    monkeypatch.setattr("kline.api.get_store", lambda: store)
+
+    result = await compare_sources(
+        AssetClass.COMMODITY,
+        "GOLD",
+        timeframe=Timeframe.MIN_5,
+        sources=["binance_usdm_futures", "yahoo_finance_futures"],
+        limit=10,
+    )
+    assert result["instrument_id"] == "GOLD"
+    assert result["provider_symbols"] == {
+        "binance_usdm_futures": "XAUUSDT",
+        "yahoo_finance_futures": "GC=F",
+    }
+    assert result["overlap_count"] == 1
+    assert result["max_close_deviation_pct"] == 1.0
+    assert result["is_blended"] is False

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -32,7 +32,7 @@ class TestBuildResponse:
         assert resp.provider == "binance_spot"
         assert resp.source_mode == "binance_spot_public"
         assert resp.served_from == "cache"
-        assert resp.latest_timestamp == "2026-03-28T11:59:00"
+        assert resp.latest_timestamp == "2026-03-28T11:59:00+00:00"
         assert resp.age_seconds is not None  # continuous source → age computed
 
     def test_is_synthetic_is_always_false(self):

--- a/tests/test_fred_provider.py
+++ b/tests/test_fred_provider.py
@@ -1,0 +1,28 @@
+import httpx
+import pytest
+
+from kline.models import Timeframe
+from kline.providers.fred import FredCsvProvider
+
+
+@pytest.mark.asyncio
+async def test_fred_provider_normalizes_daily_series_and_filters_range():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["id"] == "DFII10"
+        return httpx.Response(
+            200,
+            text="observation_date,DFII10\n2026-07-13,2.01\n2026-07-14,.\n2026-07-15,2.05\n",
+            request=request,
+        )
+
+    provider = FredCsvProvider(transport=httpx.MockTransport(handler))
+    bars = await provider.fetch(
+        "DFII10",
+        Timeframe.DAY,
+        start="2026-07-14",
+        limit=10,
+    )
+
+    assert len(bars) == 1
+    assert bars[0].timestamp == "2026-07-15T00:00:00+00:00"
+    assert bars[0].close == 2.05

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from kline.app import create_app
+
+
+def test_health_ui_is_browser_visible():
+    with TestClient(create_app()) as client:
+        response = client.get("/health-ui")
+    assert response.status_code == 200
+    assert "Datafeed Source Health" in response.text
+    assert "fetch('/api/health')" in response.text

--- a/tests/test_instrument_mapping.py
+++ b/tests/test_instrument_mapping.py
@@ -1,0 +1,12 @@
+from kline.models import AssetClass
+from kline.provenance import source_manifest
+
+
+def test_gold_has_one_canonical_id_across_provider_symbols():
+    binance = source_manifest("binance_usdm_futures", AssetClass.COMMODITY)
+    yahoo = source_manifest("yahoo_finance_futures", AssetClass.COMMODITY)
+
+    assert binance.canonical_ticker("GOLD") == "XAUUSDT"
+    assert yahoo.canonical_ticker("GOLD") == "GC=F"
+    assert binance.canonical_instrument_id("XAUUSDT") == "GOLD"
+    assert yahoo.canonical_instrument_id("GC=F") == "GOLD"

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -205,7 +205,13 @@ async def test_strict_empty_upstream_response_is_blocked(monkeypatch, store: Kli
 
 async def test_cache_policy_require_returns_cache_without_upstream(monkeypatch, store: KlineStore):
     cached = [_candle("2026-07-09T10:00:00", 101.0)]
-    store.save("BTC", AssetClass.CRYPTO, Timeframe.MIN_1, cached)
+    store.save(
+        "BTC",
+        AssetClass.CRYPTO,
+        Timeframe.MIN_1,
+        cached,
+        source_id="binance_spot_public",
+    )
     live = FakeAdapter([_candle(_fresh_ts(), 999.0)])
     monkeypatch.setattr("kline.api.get_store", lambda: store)
     monkeypatch.setattr("kline.api.get_adapter_for_source", lambda *_args: live)
@@ -257,6 +263,64 @@ async def test_realtime_profile_bypasses_cache_without_requiring_execution_venue
     assert response.require_execution_venue is False
     assert response.execution_venue is False
     assert response.candles[0].close == 120000.0
+
+
+async def test_explicit_fallback_is_visible_and_source_scoped(monkeypatch, store: KlineStore):
+    primary = FakeAdapter(error=ProviderError("primary unavailable"))
+    fallback = FakeAdapter([_candle("2026-07-15T10:00:00", 3333.0)])
+
+    def adapter_for_source(source, _asset_class):
+        return primary if source == "binance_usdm_futures" else fallback
+
+    monkeypatch.setattr("kline.api.get_store", lambda: store)
+    monkeypatch.setattr("kline.api.get_adapter_for_source", adapter_for_source)
+
+    response = await _get_candles(
+        asset_class=AssetClass.COMMODITY,
+        ticker="GOLD",
+        source="binance_usdm_futures",
+        cache_policy=CachePolicy.BYPASS,
+        fallback_policy=FallbackPolicy.EXPLICIT,
+        fallback_sources=["yahoo_finance_futures"],
+    )
+
+    assert response.selected_source == "yahoo_finance_futures"
+    assert response.selection_reason == "explicit_fallback"
+    assert response.attempted_sources == [
+        "binance_usdm_futures",
+        "yahoo_finance_futures",
+    ]
+    assert response.candles[0].close == 3333.0
+    assert response.instrument_id == "GOLD"
+    assert response.provider_symbol == "GC=F"
+    assert any("primary unavailable" in issue for issue in response.access_issues)
+    assert store.count(
+        "GC=F",
+        AssetClass.COMMODITY,
+        Timeframe.MIN_1,
+        source_id="yahoo_finance_futures",
+    ) == 1
+    assert store.count(
+        "XAUUSDT",
+        AssetClass.COMMODITY,
+        Timeframe.MIN_1,
+        source_id="binance_usdm_futures",
+    ) == 0
+
+
+async def test_explicit_fallback_requires_named_sources(store: KlineStore):
+    with pytest.raises(HTTPException) as exc:
+        await _get_candles(
+            asset_class=AssetClass.COMMODITY,
+            ticker="GOLD",
+            source="binance_usdm_futures",
+            fallback_policy=FallbackPolicy.EXPLICIT,
+            fallback_sources=[],
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "invalid_policy"
+    assert "requires at least one" in exc.value.detail["detail"]
 
 
 async def test_require_execution_venue_rejects_non_execution_source(store: KlineStore):

--- a/tests/test_migrate_legacy.py
+++ b/tests/test_migrate_legacy.py
@@ -1,0 +1,34 @@
+import sqlite3
+from pathlib import Path
+
+from kline.migrate_legacy import import_legacy_market_db
+from kline.models import AssetClass, Timeframe
+from kline.store import KlineStore
+
+
+def test_migration_imports_only_rows_with_proven_source(tmp_path: Path):
+    source = tmp_path / "market.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE bars (symbol, timeframe, timestamp, open, high, low, close, "
+            "volume, provider)"
+        )
+        connection.executemany(
+            "INSERT INTO bars VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("GOLD", "1m", "2026-07-15T01:00:00+00:00", 1, 2, 0, 1, 10, "binance_usdm"),
+                ("UNKNOWN", "1d", "2026-07-15", 1, 2, 0, 1, 10, "unknown_provider"),
+            ],
+        )
+    target = tmp_path / "datafeed.db"
+    result = import_legacy_market_db(source, target_db=target)
+
+    assert result["imported_rows"] == 1
+    assert result["skipped"] == {"unknown_provider": 1}
+    store = KlineStore(str(target))
+    assert store.count(
+        "XAUUSDT",
+        AssetClass.COMMODITY,
+        Timeframe.MIN_1,
+        source_id="binance_usdm_futures",
+    ) == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,26 @@ class TestCandle:
         c = Candle(timestamp="2026-03-28", open=100, high=105, low=99, close=103, volume=1000, amount=50000)
         assert c.amount == 50000
 
+    def test_intraday_timestamp_is_canonical_utc(self):
+        naive = Candle(
+            timestamp="2026-07-15T10:00:00",
+            open=1,
+            high=1,
+            low=1,
+            close=1,
+            volume=1,
+        )
+        zulu = Candle(
+            timestamp="2026-07-15T10:00:00Z",
+            open=1,
+            high=1,
+            low=1,
+            close=1,
+            volume=1,
+        )
+        assert naive.timestamp == "2026-07-15T10:00:00+00:00"
+        assert zulu.timestamp == naive.timestamp
+
 
 class TestCandleResponse:
     def test_response_envelope(self):

--- a/tests/test_oanda_adapter.py
+++ b/tests/test_oanda_adapter.py
@@ -1,0 +1,19 @@
+import httpx
+import pytest
+
+from kline.models import Timeframe
+from kline.providers.oanda import OandaV20Adapter
+
+
+@pytest.mark.asyncio
+async def test_oanda_adapter_normalizes_complete_candles():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer secret"
+        return httpx.Response(200, json={"candles": [{"complete": True, "time": "2026-07-15T10:00:00.000000000Z", "volume": 12, "mid": {"o": "4030", "h": "4032", "l": "4029", "c": "4031"}}]}, request=request)
+
+    adapter = OandaV20Adapter({"token": "secret"}, transport=httpx.MockTransport(handler))
+    bars = await adapter.fetch_candles("GOLD", Timeframe.MIN_5, limit=1)
+
+    assert bars[0].timestamp == "2026-07-15T10:00:00+00:00"
+    assert bars[0].close == 4031
+    assert adapter.manifest.canonical_instrument_id("XAU_USD") == "GOLD"

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,118 @@
+"""Tests for config and package entry-point adapter discovery."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from kline.models import AssetClass, Candle, InstrumentDefinition, Timeframe
+from kline.plugin_loader import load_configured_adapters
+from kline.ports import ProviderMeta, SourceManifest
+from kline.providers.base import ProviderError
+
+
+class ConfiguredAdapter:
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.manifest = SourceManifest(
+            source_id="configured_broker",
+            asset_class=AssetClass.COMMODITY,
+            meta=ProviderMeta(
+                name="configured_broker",
+                source_mode="configured_broker",
+                quality_flags=("broker_adapter",),
+                continuous=False,
+            ),
+        )
+
+    @property
+    def last_raw_response(self):
+        return None
+
+    def canonical_ticker(self, ticker: str) -> str:
+        return ticker
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.MIN_1]
+
+    async def fetch_candles(self, *_args, **_kwargs) -> list[Candle]:
+        return []
+
+    async def stream_candles(self, *_args, **_kwargs) -> AsyncIterator[Candle]:
+        if False:
+            yield Candle(timestamp="", open=0, high=0, low=0, close=0, volume=0)
+
+    async def fetch_instrument_definition(self, _ticker: str) -> InstrumentDefinition:
+        raise ProviderError("not implemented by fixture")
+
+
+@pytest.fixture
+def adapter_module(monkeypatch):
+    module = types.ModuleType("test_external_adapter")
+    module.create_adapter = lambda config: ConfiguredAdapter(config)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    return module
+
+
+def test_configured_adapter_loads_with_environment_credentials(
+    tmp_path: Path, monkeypatch, adapter_module
+):
+    monkeypatch.setenv("TEST_BROKER_TOKEN", "secret-from-env")
+    path = tmp_path / "adapters.json"
+    path.write_text(
+        json.dumps(
+            {
+                "adapters": [
+                    {
+                        "factory": f"{adapter_module.__name__}:create_adapter",
+                        "config": {
+                            "account": "paper",
+                            "token": "${TEST_BROKER_TOKEN}",
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    adapters = load_configured_adapters(str(path))
+    assert [adapter.manifest.source_id for adapter in adapters] == ["configured_broker"]
+    assert adapters[0].config == {"account": "paper", "token": "secret-from-env"}
+
+
+def test_missing_credential_fails_closed(tmp_path: Path, monkeypatch, adapter_module):
+    monkeypatch.delenv("MISSING_BROKER_TOKEN", raising=False)
+    path = tmp_path / "adapters.json"
+    path.write_text(
+        json.dumps(
+            {
+                "adapters": [
+                    {
+                        "factory": f"{adapter_module.__name__}:create_adapter",
+                        "config": {"token": "${MISSING_BROKER_TOKEN}"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProviderError, match="MISSING_BROKER_TOKEN"):
+        load_configured_adapters(str(path))
+
+
+def test_disabled_adapter_is_not_loaded(tmp_path: Path):
+    path = tmp_path / "adapters.json"
+    path.write_text(
+        json.dumps(
+            {"adapters": [{"factory": "does.not.exist:create", "enabled": False}]}
+        ),
+        encoding="utf-8",
+    )
+    assert load_configured_adapters(str(path)) == []

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -101,6 +101,8 @@ async def test_registered_broker_adapter_fits_without_api_changes(monkeypatch, t
     assert adapter.received_ticker == "BTCUSD"
     assert response.provider == "fake_broker"
     assert response.source_mode == "fake_broker_feed"
+    assert response.instrument_id == "BTC"
+    assert response.provider_symbol == "BTCUSD"
     assert response.execution_venue is True
     assert response.require_execution_venue is True
     assert response.candles[0].close == 123.0

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -2,13 +2,20 @@
 
 from datetime import datetime, timezone
 
+import pytest
+
 from kline.models import AssetClass, Timeframe
 from kline.provenance import freshness, provider_meta
 
 
 class TestProviderMeta:
     def test_every_asset_class_has_metadata(self):
-        for asset_class in AssetClass:
+        for asset_class in (
+            AssetClass.A_SHARE,
+            AssetClass.US_STOCK,
+            AssetClass.CRYPTO,
+            AssetClass.COMMODITY,
+        ):
             meta = provider_meta(asset_class)
             assert meta.name
             assert meta.source_mode
@@ -16,8 +23,30 @@ class TestProviderMeta:
     def test_every_source_is_flagged_research_only(self):
         # No kline source is an execution venue for a live order loop; the flag
         # is the durable guard against a consumer trusting it as one.
-        for asset_class in AssetClass:
+        for asset_class in (
+            AssetClass.A_SHARE,
+            AssetClass.US_STOCK,
+            AssetClass.CRYPTO,
+            AssetClass.COMMODITY,
+        ):
             assert "research_only" in provider_meta(asset_class).quality_flags
+
+    def test_extensible_asset_classes_fail_without_guessing_a_default(self):
+        for asset_class in (
+            AssetClass.FUTURES,
+            AssetClass.FOREX,
+            AssetClass.INDEX,
+            AssetClass.ETF,
+        ):
+            with pytest.raises(KeyError, match="No default source configured"):
+                provider_meta(asset_class)
+
+    def test_fred_factor_asset_classes_have_explicit_defaults_after_registration(self):
+        from kline.registry import init
+
+        init()
+        for asset_class in (AssetClass.MACRO, AssetClass.FLOW, AssetClass.EVENT):
+            assert provider_meta(asset_class).name == "fred"
 
     def test_crypto_is_spot_and_not_execution_venue(self):
         meta = provider_meta(AssetClass.CRYPTO)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -78,6 +78,13 @@ class TestSaveAndQuery:
         assert len(result) == 2
         assert result[0].timestamp == "2026-03-26"
 
+    def test_limit_returns_latest_rows_in_chronological_order(
+        self, store: KlineStore, sample_candles: list[Candle]
+    ):
+        store.save("AAPL", AssetClass.US_STOCK, Timeframe.DAY, sample_candles)
+        result = store.query("AAPL", AssetClass.US_STOCK, Timeframe.DAY, limit=2)
+        assert [item.timestamp for item in result] == ["2026-03-26", "2026-03-27"]
+
     def test_query_empty_returns_empty(self, store: KlineStore):
         result = store.query("NONEXIST", AssetClass.US_STOCK, Timeframe.DAY)
         assert result == []
@@ -111,3 +118,105 @@ class TestAssetClassIsolation:
 
         assert store.count("000001", AssetClass.A_SHARE, Timeframe.DAY) == 3
         assert store.count("000001", AssetClass.US_STOCK, Timeframe.DAY) == 1
+
+
+class TestSourceIsolation:
+    def test_same_candle_from_two_sources_does_not_collide(self, store: KlineStore):
+        source_a = [
+            Candle(timestamp="2026-03-25", open=100, high=105, low=99, close=103, volume=10)
+        ]
+        source_b = [
+            Candle(timestamp="2026-03-25", open=200, high=205, low=199, close=203, volume=20)
+        ]
+
+        store.save(
+            "GOLD",
+            AssetClass.COMMODITY,
+            Timeframe.DAY,
+            source_a,
+            source_id="source_a",
+        )
+        store.save(
+            "GOLD",
+            AssetClass.COMMODITY,
+            Timeframe.DAY,
+            source_b,
+            source_id="source_b",
+        )
+
+        result_a = store.query(
+            "GOLD", AssetClass.COMMODITY, Timeframe.DAY, source_id="source_a"
+        )
+        result_b = store.query(
+            "GOLD", AssetClass.COMMODITY, Timeframe.DAY, source_id="source_b"
+        )
+        assert result_a[0].close == 103
+        assert result_b[0].close == 203
+        assert store.count(
+            "GOLD", AssetClass.COMMODITY, Timeframe.DAY, source_id="source_a"
+        ) == 1
+        assert store.count(
+            "GOLD", AssetClass.COMMODITY, Timeframe.DAY, source_id="source_b"
+        ) == 1
+
+    def test_old_schema_is_migrated_without_source_guessing(self, tmp_path: Path):
+        import sqlite3
+
+        db_path = tmp_path / "legacy.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute(
+            "CREATE TABLE klines ("
+            "id INTEGER PRIMARY KEY, ticker VARCHAR NOT NULL, asset_class VARCHAR NOT NULL, "
+            "timeframe VARCHAR NOT NULL, timestamp VARCHAR NOT NULL, open FLOAT NOT NULL, "
+            "high FLOAT NOT NULL, low FLOAT NOT NULL, close FLOAT NOT NULL, volume FLOAT NOT NULL, "
+            "amount FLOAT, created_at DATETIME, updated_at DATETIME)"
+        )
+        connection.execute(
+            "CREATE UNIQUE INDEX ix_kline_lookup "
+            "ON klines (ticker, asset_class, timeframe, timestamp)"
+        )
+        connection.execute(
+            "INSERT INTO klines "
+            "(ticker, asset_class, timeframe, timestamp, open, high, low, close, volume) "
+            "VALUES ('GOLD', 'commodity', '1d', '2026-03-25', 1, 2, 0, 1, 10)"
+        )
+        connection.commit()
+        connection.close()
+
+        migrated = KlineStore(str(db_path))
+        assert migrated.count("GOLD", AssetClass.COMMODITY, Timeframe.DAY) == 1
+        migrated.save(
+            "GOLD",
+            AssetClass.COMMODITY,
+            Timeframe.DAY,
+            [Candle(timestamp="2026-03-25", open=3, high=4, low=2, close=3, volume=20)],
+            source_id="new_source",
+        )
+        assert migrated.count(
+            "GOLD", AssetClass.COMMODITY, Timeframe.DAY, source_id="new_source"
+        ) == 1
+
+
+class TestSourceObservations:
+    def test_latest_observation_is_kept_per_source_instrument(self, store: KlineStore):
+        common = {
+            "provider": "broker",
+            "ticker": "GOLD",
+            "asset_class": AssetClass.COMMODITY,
+            "timeframe": Timeframe.MIN_1,
+            "candle_count": 1,
+            "latest_timestamp": "2026-07-15T10:00:00",
+            "latency_ms": 12.5,
+            "quality_flags": [],
+        }
+        store.save_source_observation(source_id="source_a", success=True, **common)
+        store.save_source_observation(
+            source_id="source_a", success=False, error="timeout", **common
+        )
+        store.save_source_observation(source_id="source_b", success=True, **common)
+
+        observations = store.latest_source_observations()
+        assert len(observations) == 2
+        source_a = next(item for item in observations if item["source_id"] == "source_a")
+        assert source_a["success"] is False
+        assert source_a["error"] == "timeout"

--- a/tests/test_tiger_adapter.py
+++ b/tests/test_tiger_adapter.py
@@ -1,0 +1,60 @@
+from kline.models import Timeframe
+from kline.providers.tiger import TigerOpenFuturesAdapter
+
+
+class FakeQuoteClient:
+    def get_future_bars(self, contracts, **kwargs):
+        assert contracts == ["MGCmain"]
+        assert kwargs["period"] == "1m"
+        return [
+            {
+                "identifier": "MGCmain",
+                "time": 1784080800000,
+                "open": 4060.0,
+                "high": 4062.0,
+                "low": 4059.0,
+                "close": 4061.0,
+                "volume": 12,
+            }
+        ]
+
+    def get_future_trading_times(self, contract, trading_date=None):
+        assert contract == "MGCmain"
+        assert trading_date == "2026-07-15"
+        return [
+            {
+                "start": 1784080800000,
+                "end": 1784084400000,
+                "trading": True,
+                "bidding": False,
+                "zone": "UTC",
+            }
+        ]
+
+
+async def test_tiger_adapter_normalizes_quote_rows_without_execution_client():
+    adapter = TigerOpenFuturesAdapter(
+        {"contract": "MGCmain", "exchange": "COMEX"},
+        quote_client=FakeQuoteClient(),
+    )
+    candles = await adapter.fetch_candles("MGC", Timeframe.MIN_1, limit=10)
+
+    assert adapter.manifest.source_id == "tiger_openapi_comex"
+    assert adapter.manifest.meta.execution_venue is True
+    assert adapter.manifest.canonical_instrument_id("MGCmain") == "MGC_CONTINUOUS"
+    assert candles[0].close == 4061.0
+    assert candles[0].timestamp == "2026-07-15T02:00:00+00:00"
+    assert adapter.last_raw_response["response_body"][0]["identifier"] == "MGCmain"
+
+
+async def test_tiger_adapter_owns_market_sessions():
+    adapter = TigerOpenFuturesAdapter(
+        {"contract": "MGCmain", "exchange": "COMEX"},
+        quote_client=FakeQuoteClient(),
+    )
+
+    result = await adapter.fetch_market_sessions("MGC", trading_date="2026-07-15")
+
+    assert result["schema_version"] == "market-sessions-v1"
+    assert result["instrument_id"] == "MGC_CONTINUOUS"
+    assert len(result["trading_windows"]) == 1


### PR DESCRIPTION
## What
- merge the existing source-aware adapter and canonical instrument contract onto current main
- expose canonical instrument/provider/source identity in candle responses
- retain fail-closed Binance stream and explicit source policy behavior

## Why
Cloud Paper validates a complete trusted market-data envelope. Current datafeed main returns an older partial v1 payload, so the cloud scheduler cannot consume bounded historical candles without weakening validation.

## Validation
- `python3 -m pytest -q` → 70 passed
- `python3 -m ruff check src tests` → passed
- `gitleaks git --no-banner --redact --log-opts=origin/main..HEAD` → no leaks

Closes #2