### PR TITLE
Record Cloud Paper datafeed contract in registry

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -3,10 +3,11 @@
 ## 要去哪里
 多资产 K 线数据服务:ticker+timeframe → 标准化 OHLCV + provenance(provider/fresh/synthetic 标记),A股/美股/加密/商品全覆盖;近期喂养 trading-system 与 tokenpulse,远期可作为独立 API 产品外卖。
 
-## 现在在哪里(2026-07-21)
+## 现在在哪里(2026-07-28)
 - V1 运行中:tushare/yahoo/binance 多源,ports-and-adapters,realtime strict 失败即显式报错、永不隐藏降级。
+- `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
+- Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- 无排队任务;最后一次推送 2026-07-15。
 
 ## 下一步
-- 按晨会需求排;若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。
+- 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。


### PR DESCRIPTION
## What

Update the thin registry to record the canonical source-aware envelope now on main and the Alibaba Cloud Paper consumer.

## Why

The previous registry still claimed the last push was July 15 and did not describe the current execution-venue contract or its authority boundary.

## Validation

- REGISTRY.md only
- git diff --check: pass
- gitleaks: no leaks
- no code, runtime, credential, or deployment change

Closes #4
