### PR TITLE
feat: cover weekly macro market sources

### DIFF
--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -90,7 +90,7 @@ FRED_META = ProviderMeta(
     execution_venue=False,
     realtime_supported=False,
     market_type="economic_series",
-    supported_symbols=("DTWEXBGS", "DFII10", "GVZCLS", "DFF"),
+    supported_symbols=("DTWEXBGS", "DGS2", "DGS10", "T10Y2Y", "DFII10", "GVZCLS", "DFF"),
 )
 
 _SOURCE_ALIASES = {
@@ -101,6 +101,8 @@ _SOURCE_ALIASES = {
     "binance_usdm_futures": "binance_usdm_futures",
     "yahoo": "yahoo",
     "yahoo_finance": "yahoo_finance",
+    "yahoo_finance_index": "yahoo_finance_index",
+    "yahoo_finance_etf": "yahoo_finance_etf",
     "yahoo_finance_futures": "yahoo_finance_futures",
     "tushare": "tushare_pro",
     "tushare_pro": "tushare_pro",
@@ -114,6 +116,11 @@ _SOURCE_ASSET_CLASSES = {
     "yahoo_finance": AssetClass.US_STOCK,
     "yahoo_finance_futures": AssetClass.COMMODITY,
     "tushare_pro": AssetClass.A_SHARE,
+    "yahoo_finance_index": AssetClass.INDEX,
+    "yahoo_finance_etf": AssetClass.ETF,
+    "fred_public_csv_macro": AssetClass.MACRO,
+    "fred_public_csv_flow": AssetClass.FLOW,
+    "fred_public_csv_event": AssetClass.EVENT,
 }
 
 _SOURCE_META = {
@@ -123,6 +130,25 @@ _SOURCE_META = {
     "yahoo_finance_futures": _PROVIDER_META[AssetClass.COMMODITY],
     "tushare_pro": _PROVIDER_META[AssetClass.A_SHARE],
 }
+
+_YAHOO_INDEX_META = ProviderMeta(
+    name="yahoo_finance",
+    source_mode="yahoo_finance_index",
+    quality_flags=("delayed_possible", "market_hours", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="index",
+)
+_YAHOO_ETF_META = ProviderMeta(
+    name="yahoo_finance",
+    source_mode="yahoo_finance_etf",
+    quality_flags=("delayed_possible", "market_hours", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="etf",
+)
 
 _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
     "binance_spot_public": SourceManifest(
@@ -158,12 +184,27 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         meta=_PROVIDER_META[AssetClass.A_SHARE],
         default_for_asset_class=True,
     ),
+    "yahoo_finance_index": SourceManifest(
+        source_id="yahoo_finance_index",
+        asset_class=AssetClass.INDEX,
+        meta=_YAHOO_INDEX_META,
+        default_for_asset_class=True,
+    ),
+    "yahoo_finance_etf": SourceManifest(
+        source_id="yahoo_finance_etf",
+        asset_class=AssetClass.ETF,
+        meta=_YAHOO_ETF_META,
+        default_for_asset_class=True,
+    ),
 }
 
 
 def fred_source_manifest(asset_class: AssetClass) -> SourceManifest:
     aliases = {
         "DXY": "DTWEXBGS",
+        "US2Y": "DGS2",
+        "US10Y": "DGS10",
+        "US2S10S": "T10Y2Y",
         "US10Y_REAL": "DFII10",
         "GLD_FLOW": "GVZCLS",
         "FED_CPI_EVENTS": "DFF",
@@ -200,14 +241,31 @@ def default_source(asset_class: AssetClass) -> str:
 def normalize_source(source: str, asset_class: AssetClass) -> str:
     source_key = source.strip().lower()
     if source_key in _EXTRA_SOURCE_MANIFESTS:
-        return source_key
+        extra = _EXTRA_SOURCE_MANIFESTS[source_key]
+        if extra.asset_class == asset_class:
+            return source_key
+        # The generic yahoo source is registered for US stocks at startup;
+        # preserve asset-class-specific aliases for indexes and ETFs.
+        if source_key not in {"yahoo_finance", "yahoo"}:
+            return source_key
     normalized = _SOURCE_ALIASES.get(source_key)
     if normalized is None:
         raise KeyError(source)
     if normalized == "auto":
         return default_source(asset_class)
     if normalized == "yahoo":
-        return "yahoo_finance_futures" if asset_class == AssetClass.COMMODITY else "yahoo_finance"
+        if asset_class == AssetClass.COMMODITY:
+            return "yahoo_finance_futures"
+        if asset_class == AssetClass.INDEX:
+            return "yahoo_finance_index"
+        if asset_class == AssetClass.ETF:
+            return "yahoo_finance_etf"
+        return "yahoo_finance"
+    if normalized == "yahoo_finance":
+        if asset_class == AssetClass.INDEX:
+            return "yahoo_finance_index"
+        if asset_class == AssetClass.ETF:
+            return "yahoo_finance_etf"
     return normalized
 
 

--- a/src/kline/providers/ashare.py
+++ b/src/kline/providers/ashare.py
@@ -17,10 +17,13 @@ _TF_MAP = {
     Timeframe.DAY: "D",
     Timeframe.WEEK: "W",
 }
+_INDEX_CODES = {"000001.SH", "000688.SH", "000015.SH"}
 
 
 def _to_tushare_code(ticker: str) -> str:
     """Convert 6-digit code to TuShare format: 000001 → 000001.SZ"""
+    if "." in ticker:
+        return ticker.upper().strip()
     if ticker.startswith("6"):
         return f"{ticker}.SH"
     if ticker.startswith(("4", "8")):
@@ -69,11 +72,18 @@ class AShareProvider:
             end_date = date.today().strftime("%Y%m%d")
 
         try:
-            df = self._pro.daily(
-                ts_code=ts_code,
-                start_date=start_date,
-                end_date=end_date,
-            )
+            if ts_code in _INDEX_CODES:
+                df = self._pro.index_daily(
+                    ts_code=ts_code,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+            else:
+                df = self._pro.daily(
+                    ts_code=ts_code,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
         except Exception as e:
             raise ProviderError(
                 f"TuShare request failed for {ticker}: {e}",
@@ -108,8 +118,35 @@ class AShareProvider:
         # TuShare returns newest-first, we want oldest-first
         candles.sort(key=lambda c: c.timestamp)
 
+        if timeframe == Timeframe.WEEK:
+            candles = _aggregate_weekly(candles)
+
         if limit and len(candles) > limit:
             candles = candles[-limit:]
 
         logger.info(f"Fetched {len(candles)} candles for {ticker} ({timeframe.value})")
         return candles
+
+
+def _aggregate_weekly(candles: list[Candle]) -> list[Candle]:
+    """Aggregate sorted daily candles into completed Monday-Friday weeks."""
+    groups: dict[tuple[int, int], list[Candle]] = {}
+    for candle in candles:
+        day = date.fromisoformat(candle.timestamp[:10])
+        key = day.isocalendar()[:2]
+        groups.setdefault((int(key[0]), int(key[1])), []).append(candle)
+    output: list[Candle] = []
+    for rows in groups.values():
+        rows.sort(key=lambda item: item.timestamp)
+        output.append(
+            Candle(
+                timestamp=rows[-1].timestamp,
+                open=rows[0].open,
+                high=max(row.high for row in rows),
+                low=min(row.low for row in rows),
+                close=rows[-1].close,
+                volume=sum(row.volume for row in rows),
+                amount=sum(row.amount or 0 for row in rows),
+            )
+        )
+    return output

--- a/src/kline/providers/fred.py
+++ b/src/kline/providers/fred.py
@@ -50,6 +50,7 @@ class FredCsvProvider:
             "body_preview": response.text[:500],
         }
         candles: list[Candle] = []
+        scale = 100.0 if series_id == "T10Y2Y" else 1.0
         for row in DictReader(StringIO(response.text)):
             raw = str(row.get(series_id, "")).strip()
             observation_date = str(row.get("observation_date", "")).strip()
@@ -59,7 +60,7 @@ class FredCsvProvider:
                 continue
             if end and observation_date > end[:10]:
                 continue
-            value = float(raw)
+            value = float(raw) * scale
             candles.append(
                 Candle(
                     timestamp=f"{observation_date}T00:00:00+00:00",

--- a/src/kline/quality.py
+++ b/src/kline/quality.py
@@ -76,7 +76,7 @@ def analyze_candles(
                 if "out_of_order" not in flags:
                     flags.append("out_of_order")
                     issues.append("candles are not strictly sorted oldest to newest")
-            elif (meta.continuous or strict) and delta > expected * 1.5:
+            elif meta.continuous and delta > expected * 1.5:
                 if "gap" not in flags:
                     flags.append("gap")
                     issues.append("one or more candle intervals are missing")

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -41,6 +41,8 @@ def init(settings: Settings | None = None) -> None:
 
     # Always available
     _providers[AssetClass.US_STOCK] = USStockProvider()
+    _providers[AssetClass.INDEX] = USStockProvider()
+    _providers[AssetClass.ETF] = USStockProvider()
     _providers[AssetClass.CRYPTO] = CryptoProvider(timeout=s.request_timeout)
     _providers[AssetClass.COMMODITY] = CommodityProvider()
     _live_providers["binance_usdm_futures"] = BinanceUsdmFuturesProvider(timeout=s.request_timeout)
@@ -49,6 +51,18 @@ def init(settings: Settings | None = None) -> None:
         ProviderBackedMarketDataAdapter(
             source_manifest("yahoo_finance", AssetClass.US_STOCK),
             _providers[AssetClass.US_STOCK],
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("yahoo_finance_index", AssetClass.INDEX),
+            _providers[AssetClass.INDEX],
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("yahoo_finance_etf", AssetClass.ETF),
+            _providers[AssetClass.ETF],
         )
     )
     for factor_asset_class in (AssetClass.MACRO, AssetClass.FLOW, AssetClass.EVENT):

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -35,11 +35,12 @@ class TestProviderMeta:
         for asset_class in (
             AssetClass.FUTURES,
             AssetClass.FOREX,
-            AssetClass.INDEX,
-            AssetClass.ETF,
         ):
             with pytest.raises(KeyError, match="No default source configured"):
                 provider_meta(asset_class)
+
+        for asset_class in (AssetClass.INDEX, AssetClass.ETF):
+            assert provider_meta(asset_class).name == "yahoo_finance"
 
     def test_fred_factor_asset_classes_have_explicit_defaults_after_registration(self):
         from kline.registry import init

--- a/tests/test_weekly_macro_coverage.py
+++ b/tests/test_weekly_macro_coverage.py
@@ -1,0 +1,53 @@
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from kline.models import AssetClass, Timeframe
+from kline.provenance import normalize_source, source_manifest
+from kline.providers.ashare import _to_tushare_code
+from kline.providers.fred import FredCsvProvider
+from kline.ports import ProviderMeta
+from kline.quality import analyze_candles
+from kline.models import Candle
+
+
+def test_yahoo_index_and_etf_manifests_are_explicit():
+    assert normalize_source("yahoo_finance", AssetClass.INDEX) == "yahoo_finance_index"
+    assert normalize_source("yahoo_finance", AssetClass.ETF) == "yahoo_finance_etf"
+    assert source_manifest("yahoo_finance_index", AssetClass.INDEX).canonical_ticker("^GSPC") == "^GSPC"
+    assert source_manifest("yahoo_finance_etf", AssetClass.ETF).canonical_ticker("SCHD") == "SCHD"
+
+
+def test_tushare_index_symbols_preserve_exchange_suffix():
+    assert _to_tushare_code("000001.SH") == "000001.SH"
+    assert _to_tushare_code("000688.SH") == "000688.SH"
+    assert _to_tushare_code("000001") == "000001.SZ"
+
+
+@pytest.mark.asyncio
+async def test_fred_treasury_curve_aliases_and_basis_point_scale():
+    def handler(request: httpx.Request) -> httpx.Response:
+        series_id = request.url.params["id"]
+        assert series_id == "T10Y2Y"
+        return httpx.Response(200, text="observation_date,T10Y2Y\n2026-08-14,0.35\n", request=request)
+
+    provider = FredCsvProvider(transport=httpx.MockTransport(handler))
+    bars = await provider.fetch("T10Y2Y", Timeframe.DAY, limit=10)
+    assert bars[0].close == 35.0
+    assert bars[0].open == bars[0].high == bars[0].low == bars[0].close
+
+
+def test_market_hours_weekend_gap_is_not_blocked_as_intraday_gap():
+    meta = ProviderMeta(
+        name="test", source_mode="market_hours", quality_flags=(), continuous=False,
+        market_type="index",
+    )
+    candles = [
+        Candle(timestamp="2026-08-13", open=1, high=2, low=1, close=2, volume=0),
+        Candle(timestamp="2026-08-17", open=2, high=3, low=2, close=3, volume=0),
+    ]
+    report = analyze_candles(candles, Timeframe.DAY, meta, strict=True)
+    assert "gap" not in report.quality_flags
+    assert report.reject_reason is None


### PR DESCRIPTION
## What
- add explicit Yahoo index and ETF source manifests
- preserve A-share index symbols and aggregate weekly candles
- add Treasury FRED aliases with 2s10s basis-point scaling
- avoid treating expected market-hours weekend gaps as strict data gaps

## Validation
- `PYTHONPATH=/Users/wendy/work/datafeed-issue-2/src python3 -m pytest -q --import-mode=importlib` (74 passed)
- `git diff --check`

This is the upstream source coverage required by zinan92/equity-research #865.