### PR TITLE
feat: support weekly FRED macro levels

### DIFF
--- a/src/kline/providers/fred.py
+++ b/src/kline/providers/fred.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from csv import DictReader
+from datetime import date
 from io import StringIO
 
 import httpx
@@ -18,7 +19,7 @@ class FredCsvProvider:
         self.last_raw_response: dict | None = None
 
     def supported_timeframes(self) -> list[Timeframe]:
-        return [Timeframe.DAY]
+        return [Timeframe.DAY, Timeframe.WEEK]
 
     async def fetch(
         self,
@@ -29,8 +30,17 @@ class FredCsvProvider:
         end: str | None = None,
         limit: int = 500,
     ) -> list[Candle]:
+        if timeframe == Timeframe.WEEK:
+            daily = await self.fetch(
+                ticker,
+                Timeframe.DAY,
+                start=start,
+                end=end,
+                limit=max(limit * 7, 500),
+            )
+            return _aggregate_weekly_levels(daily)[-max(1, limit):]
         if timeframe != Timeframe.DAY:
-            raise ProviderError("FRED supports daily observations only")
+            raise ProviderError("FRED supports daily and weekly observations only")
         series_id = ticker.upper().strip()
         url = "https://fred.stlouisfed.org/graph/fredgraph.csv"
         try:
@@ -74,3 +84,24 @@ class FredCsvProvider:
         if not candles:
             raise ProviderError(f"FRED returned no usable observations for {series_id}")
         return candles[-max(1, limit) :]
+
+
+def _aggregate_weekly_levels(candles: list[Candle]) -> list[Candle]:
+    """Aggregate daily FRED levels to completed ISO weeks.
+
+    Treasury yields and curve spreads are levels, not OHLC prices.  The
+    weekly output therefore repeats the last observed level in the week and
+    never invents a high/low range or a bond-price candle.
+    """
+
+    groups: dict[tuple[int, int], list[Candle]] = {}
+    for candle in candles:
+        trading_date = date.fromisoformat(candle.timestamp[:10])
+        iso = trading_date.isocalendar()
+        groups.setdefault((int(iso.year), int(iso.week)), []).append(candle)
+    output: list[Candle] = []
+    for rows in groups.values():
+        rows.sort(key=lambda item: item.timestamp)
+        value = rows[-1].close
+        output.append(Candle(timestamp=rows[-1].timestamp, open=value, high=value, low=value, close=value, volume=0))
+    return sorted(output, key=lambda item: item.timestamp)

--- a/tests/test_weekly_macro_coverage.py
+++ b/tests/test_weekly_macro_coverage.py
@@ -39,6 +39,23 @@ async def test_fred_treasury_curve_aliases_and_basis_point_scale():
     assert bars[0].open == bars[0].high == bars[0].low == bars[0].close
 
 
+@pytest.mark.asyncio
+async def test_fred_weekly_aggregation_preserves_last_level_and_semantics():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text="observation_date,DGS2\n2026-08-10,4.1\n2026-08-12,4.2\n2026-08-14,4.3\n2026-08-17,4.4\n",
+            request=request,
+        )
+
+    provider = FredCsvProvider(transport=httpx.MockTransport(handler))
+    bars = await provider.fetch("DGS2", Timeframe.WEEK, start="2026-08-10", limit=10)
+    assert len(bars) == 2
+    assert bars[0].timestamp == "2026-08-14T00:00:00+00:00"
+    assert bars[0].open == bars[0].high == bars[0].low == bars[0].close == 4.3
+    assert bars[1].close == 4.4
+
+
 def test_market_hours_weekend_gap_is_not_blocked_as_intraday_gap():
     meta = ProviderMeta(
         name="test", source_mode="market_hours", quality_flags=(), continuous=False,


### PR DESCRIPTION
## What
Allow the FRED adapter to serve `1w` macro responses by aggregating its daily observations into completed ISO-week levels.

## Why
Weekly Macro K-line requests nominal Treasury yields and 2s10s through the canonical FRED source. FRED is a daily observation service, so the source adapter must own the level aggregation instead of rejecting the requested weekly timeframe or making the Weekly client silently fall back.

Weekly rate/spread bars repeat the last observed level; they do not invent a high/low price range.

## Validation
- `PYTHONPATH=src python3 -m pytest -q --import-mode=importlib tests/test_fred_provider.py tests/test_weekly_macro_coverage.py` — 6 passed
