### PR TITLE
fix: exclude incomplete FRED weeks

### DIFF
--- a/src/kline/providers/fred.py
+++ b/src/kline/providers/fred.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from csv import DictReader
-from datetime import date
+from datetime import date, timedelta
 from io import StringIO
 
 import httpx
@@ -38,7 +38,7 @@ class FredCsvProvider:
                 end=end,
                 limit=max(limit * 7, 500),
             )
-            return _aggregate_weekly_levels(daily)[-max(1, limit):]
+            return _aggregate_weekly_levels(daily, end=end)[-max(1, limit):]
         if timeframe != Timeframe.DAY:
             raise ProviderError("FRED supports daily and weekly observations only")
         series_id = ticker.upper().strip()
@@ -86,7 +86,7 @@ class FredCsvProvider:
         return candles[-max(1, limit) :]
 
 
-def _aggregate_weekly_levels(candles: list[Candle]) -> list[Candle]:
+def _aggregate_weekly_levels(candles: list[Candle], *, end: str | None = None) -> list[Candle]:
     """Aggregate daily FRED levels to completed ISO weeks.
 
     Treasury yields and curve spreads are levels, not OHLC prices.  The
@@ -94,13 +94,17 @@ def _aggregate_weekly_levels(candles: list[Candle]) -> list[Candle]:
     never invents a high/low range or a bond-price candle.
     """
 
+    cutoff = date.fromisoformat(end[:10]) if end else date.today()
     groups: dict[tuple[int, int], list[Candle]] = {}
     for candle in candles:
         trading_date = date.fromisoformat(candle.timestamp[:10])
         iso = trading_date.isocalendar()
         groups.setdefault((int(iso.year), int(iso.week)), []).append(candle)
     output: list[Candle] = []
-    for rows in groups.values():
+    for (iso_year, iso_week), rows in groups.items():
+        week_monday = date.fromisocalendar(iso_year, iso_week, 1)
+        if week_monday + timedelta(days=4) > cutoff:
+            continue
         rows.sort(key=lambda item: item.timestamp)
         value = rows[-1].close
         output.append(Candle(timestamp=rows[-1].timestamp, open=value, high=value, low=value, close=value, volume=0))

--- a/tests/test_weekly_macro_coverage.py
+++ b/tests/test_weekly_macro_coverage.py
@@ -44,16 +44,16 @@ async def test_fred_weekly_aggregation_preserves_last_level_and_semantics():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            text="observation_date,DGS2\n2026-08-10,4.1\n2026-08-12,4.2\n2026-08-14,4.3\n2026-08-17,4.4\n",
+            text="observation_date,DGS2\n2026-08-10,4.1\n2026-08-12,4.2\n2026-08-14,4.3\n2026-08-17,4.4\n2026-08-21,4.5\n",
             request=request,
         )
 
     provider = FredCsvProvider(transport=httpx.MockTransport(handler))
-    bars = await provider.fetch("DGS2", Timeframe.WEEK, start="2026-08-10", limit=10)
+    bars = await provider.fetch("DGS2", Timeframe.WEEK, start="2026-08-10", end="2026-08-22", limit=10)
     assert len(bars) == 2
     assert bars[0].timestamp == "2026-08-14T00:00:00+00:00"
     assert bars[0].open == bars[0].high == bars[0].low == bars[0].close == 4.3
-    assert bars[1].close == 4.4
+    assert bars[1].close == 4.5
 
 
 def test_market_hours_weekend_gap_is_not_blocked_as_intraday_gap():


### PR DESCRIPTION
## What
Exclude the current incomplete ISO week from FRED weekly level aggregation.

## Why
The Weekly Macro K-line must never publish a partial current week as a completed weekly bar when called mid-week or without an explicit Friday cutoff.

## Validation
- targeted FRED/datafeed tests: 6 passed
- complete weeks are retained as last-observation levels with equal OHLC semantics
