### PR TITLE
feat: add Tencent A-share index candles

### DIFF
--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -107,6 +107,8 @@ _SOURCE_ALIASES = {
     "yahoo_finance_futures": "yahoo_finance_futures",
     "tushare": "tushare_pro",
     "tushare_pro": "tushare_pro",
+    "tencent": "tencent_kline",
+    "tencent_kline": "tencent_kline",
     "fred": "fred_public_csv",
     "fred_public_csv": "fred_public_csv",
 }
@@ -117,6 +119,7 @@ _SOURCE_ASSET_CLASSES = {
     "yahoo_finance": AssetClass.US_STOCK,
     "yahoo_finance_futures": AssetClass.COMMODITY,
     "tushare_pro": AssetClass.A_SHARE,
+    "tencent_kline": AssetClass.INDEX,
     "yahoo_finance_index": AssetClass.INDEX,
     "yahoo_finance_etf": AssetClass.ETF,
     "fred_public_csv_macro": AssetClass.MACRO,
@@ -151,6 +154,17 @@ _YAHOO_ETF_META = ProviderMeta(
     realtime_supported=False,
     market_type="etf",
     supported_symbols=("SCHD",),
+)
+
+_TENCENT_INDEX_META = ProviderMeta(
+    name="tencent_finance",
+    source_mode="tencent_kline",
+    quality_flags=("public_api", "market_hours", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="index",
+    supported_symbols=("sh000001", "sh000688", "sh000015"),
 )
 
 _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
@@ -292,6 +306,36 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.A_SHARE,
         meta=_PROVIDER_META[AssetClass.A_SHARE],
         default_for_asset_class=True,
+    ),
+    "tencent_kline": SourceManifest(
+        source_id="tencent_kline",
+        asset_class=AssetClass.INDEX,
+        meta=_TENCENT_INDEX_META,
+        ticker_aliases={
+            "SH000001": "sh000001",
+            "000001.SH": "sh000001",
+            "SH000688": "sh000688",
+            "000688.SH": "sh000688",
+            "SH000015": "sh000015",
+            "000015.SH": "sh000015",
+        },
+        canonical_instrument_ids={
+            "SH000001": "shanghai",
+            "000001.SH": "shanghai",
+            "SH000688": "star50",
+            "000688.SH": "star50",
+            "SH000015": "china_dividend",
+            "000015.SH": "china_dividend",
+            "sh000001": "shanghai",
+            "sh000688": "star50",
+            "sh000015": "china_dividend",
+        },
+        symbol_timeframes={
+            "SH000001": (Timeframe.DAY, Timeframe.WEEK),
+            "SH000688": (Timeframe.DAY, Timeframe.WEEK),
+            "SH000015": (Timeframe.DAY, Timeframe.WEEK),
+        },
+        enforce_symbol_allowlist=True,
     ),
     "yahoo_finance_index": SourceManifest(
         source_id="yahoo_finance_index",

--- a/src/kline/providers/ashare.py
+++ b/src/kline/providers/ashare.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import logging
 from datetime import date, timedelta
+from hashlib import sha256
+import math
+from typing import Any, Callable, Mapping
 
+import httpx
 import tushare as ts
 
-from kline.models import Candle, Timeframe
+from kline.models import Candle, Timeframe, TimeframeTransform
 from kline.providers.base import ProviderError
 
 logger = logging.getLogger(__name__)
@@ -18,6 +22,14 @@ _TF_MAP = {
     Timeframe.WEEK: "W",
 }
 _INDEX_CODES = {"000001.SH", "000688.SH", "000015.SH"}
+
+_TENCENT_KLINE_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
+_TENCENT_INDEX_SYMBOLS = frozenset({"sh000001", "sh000688", "sh000015"})
+_TENCENT_INDEX_ALIASES = {
+    "000001.sh": "sh000001",
+    "000688.sh": "sh000688",
+    "000015.sh": "sh000015",
+}
 
 
 def _to_tushare_code(ticker: str) -> str:
@@ -150,3 +162,355 @@ def _aggregate_weekly(candles: list[Candle]) -> list[Candle]:
             )
         )
     return output
+
+
+class TencentIndexProvider:
+    """Fetch the Phase 1 A-share index candles from Tencent Finance.
+
+    The Tencent endpoint is intentionally bound to the three explicit Shanghai
+    index symbols.  A bare ``000xxx`` code is never guessed here because
+    ``000001`` is both the Shanghai Composite index and a Shenzhen equity.
+    Public weekly candles are derived from closed daily rows; the current ISO
+    week is therefore never promoted as a completed week.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 30,
+        transport: httpx.AsyncBaseTransport | None = None,
+        today: Callable[[], date] | None = None,
+    ) -> None:
+        self._timeout = timeout
+        self._transport = transport
+        self._today = today or date.today
+        self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform: TimeframeTransform | None = None
+        self.source_identity: dict[str, Any] = {}
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.DAY, Timeframe.WEEK]
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        self.last_raw_response = None
+        symbol = _normalize_tencent_index_symbol(ticker)
+        self.source_identity = {
+            "source_id": "tencent_kline",
+            "provider_symbol": symbol,
+            "endpoint": _TENCENT_KLINE_URL,
+            "price_adjustment": "qfq",
+        }
+        if symbol not in _TENCENT_INDEX_SYMBOLS:
+            raise ProviderError(
+                f"Unsupported Tencent index symbol: {ticker}; explicit market-prefixed symbol required",
+                suggestions=[
+                    "Use explicit market-prefixed symbols: sh000001, sh000688, sh000015",
+                ],
+            )
+        if timeframe not in self.supported_timeframes():
+            raise ProviderError(
+                f"Tencent index timeframe {timeframe.value} is not supported",
+                suggestions=[f"Supported: {[item.value for item in self.supported_timeframes()]}"] ,
+            )
+
+        self.timeframe_transform = _tencent_transform(timeframe, symbol)
+        self.last_raw_response = {
+            "request_params": {
+                "endpoint": _TENCENT_KLINE_URL,
+                "provider_symbol": symbol,
+                "raw_timeframe": Timeframe.DAY.value,
+                "requested_timeframe": timeframe.value,
+                "requests": [],
+            },
+            "response_body": {"responses": []},
+            "status_code": None,
+            "error": None,
+        }
+
+        try:
+            today = self._today()
+            requested_start = _parse_optional_date(start, "start")
+            requested_end = _parse_optional_date(end, "end")
+            if requested_start and requested_end and requested_start >= requested_end:
+                raise ProviderError("Tencent index date range is empty")
+            completion_boundary = min(requested_end or today, today)
+            if requested_start and requested_start >= completion_boundary:
+                raise ProviderError("Tencent index date range contains no closed sessions")
+
+            if timeframe == Timeframe.DAY:
+                query_start = requested_start
+                query_end = requested_end or today
+                if requested_end and query_start is None:
+                    query_start = query_end - timedelta(days=max(limit * 3, 365))
+                rows = await self._fetch_daily_rows(
+                    symbol,
+                    start=query_start,
+                    end=query_end,
+                    limit=limit,
+                    paginate=bool(query_start or requested_end),
+                )
+                candles = _parse_tencent_rows(rows, ticker=symbol)
+                candles = _closed_daily_rows(
+                    candles,
+                    start=requested_start,
+                    end=completion_boundary,
+                )
+            else:
+                query_start = requested_start or (completion_boundary - timedelta(days=max(limit * 7 + 30, 365)))
+                rows = await self._fetch_daily_rows(
+                    symbol,
+                    start=query_start,
+                    end=requested_end or today,
+                    limit=limit,
+                    paginate=True,
+                )
+                candles = _parse_tencent_rows(rows, ticker=symbol)
+                candles = _closed_daily_rows(
+                    candles,
+                    start=requested_start,
+                    end=completion_boundary,
+                )
+                candles = _aggregate_tencent_completed_weeks(
+                    candles,
+                    completion_boundary=completion_boundary,
+                    requested_start=requested_start,
+                )
+        except ProviderError as error:
+            if self.last_raw_response is not None:
+                self.last_raw_response["error"] = str(error)
+            raise
+
+        if not candles:
+            error = ProviderError(
+                f"Tencent returned no closed candles for {ticker} ({timeframe.value})",
+                suggestions=[
+                    "Check the requested date range and whether a completed market week is available",
+                ],
+            )
+            self.last_raw_response["error"] = str(error)
+            raise error
+        if limit and len(candles) > limit:
+            candles = candles[-limit:]
+        self.last_raw_response["request_params"]["public_row_count"] = len(candles)
+        logger.info("Fetched %s Tencent candles for %s (%s)", len(candles), symbol, timeframe.value)
+        return candles
+
+    async def _fetch_daily_rows(
+        self,
+        symbol: str,
+        *,
+        start: date | None,
+        end: date | None,
+        limit: int,
+        paginate: bool,
+    ) -> list[Any]:
+        if not paginate:
+            windows = [(None, None, min(max(limit + 1, 1), 500))]
+        else:
+            if start is None or end is None or start >= end:
+                return []
+            windows = []
+            cursor = start
+            while cursor < end:
+                window_end = min(cursor + timedelta(days=365), end)
+                windows.append((cursor, window_end, 500))
+                cursor = window_end + timedelta(days=1)
+
+        rows: list[Any] = []
+        for window_start, window_end, window_limit in windows:
+            rows.extend(
+                await self._fetch_daily_window(
+                    symbol,
+                    start=window_start,
+                    end=window_end,
+                    limit=window_limit,
+                )
+            )
+        return rows
+
+    async def _fetch_daily_window(
+        self,
+        symbol: str,
+        *,
+        start: date | None,
+        end: date | None,
+        limit: int,
+    ) -> list[Any]:
+        start_text = start.isoformat() if start else ""
+        end_text = end.isoformat() if end else ""
+        param = f"{symbol},day,{start_text},{end_text},{min(limit, 500)},qfq"
+        request_params = {"param": param}
+        raw = self.last_raw_response
+        assert raw is not None
+        raw["request_params"]["requests"].append(request_params)
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                transport=self._transport,
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(_TENCENT_KLINE_URL, params=request_params)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raw["status_code"] = exc.response.status_code
+            raw["error"] = str(exc)
+            raise ProviderError(f"Tencent K-line request failed for {symbol}: {exc}") from exc
+        except httpx.RequestError as exc:
+            raw["error"] = str(exc)
+            raise ProviderError(f"Tencent K-line request failed for {symbol}: {exc}") from exc
+
+        raw["status_code"] = response.status_code
+        body = response.text
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raw["response_body"]["responses"].append({"request": request_params, "body_sha256": sha256(body.encode()).hexdigest()})
+            raw["error"] = "non_json_response"
+            raise ProviderError(f"Tencent returned non-JSON K-line data for {symbol}") from exc
+        raw["response_body"]["responses"].append({"request": request_params, "payload": payload})
+
+        if not isinstance(payload, Mapping) or payload.get("code") != 0:
+            error = str(payload.get("msg") if isinstance(payload, Mapping) else "invalid_response")
+            raw["error"] = error
+            raise ProviderError(f"Tencent K-line response rejected for {symbol}: {error}")
+        data = payload.get("data")
+        if not isinstance(data, Mapping):
+            raw["error"] = "empty_data"
+            raise ProviderError(f"Tencent returned no data for {symbol}")
+        item = data.get(symbol)
+        if not isinstance(item, Mapping):
+            returned = ",".join(sorted(str(key) for key in data.keys())) or "none"
+            raw["error"] = "wrong_symbol_response"
+            raise ProviderError(
+                f"Tencent returned wrong symbol for {symbol}; returned symbols: {returned}"
+            )
+        rows = item.get("day")
+        if not isinstance(rows, list) or not rows:
+            raw["error"] = "empty_rows"
+            raise ProviderError(f"Tencent returned no daily K-line rows for {symbol}")
+        return rows
+
+
+def _normalize_tencent_index_symbol(ticker: str) -> str:
+    normalized = ticker.strip().lower()
+    return _TENCENT_INDEX_ALIASES.get(normalized, normalized)
+
+
+def _parse_optional_date(value: str | None, field: str) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError as exc:
+        raise ProviderError(f"Tencent index {field} date is invalid: {value}") from exc
+
+
+def _tencent_transform(timeframe: Timeframe, symbol: str) -> TimeframeTransform:
+    if timeframe == Timeframe.WEEK:
+        return TimeframeTransform(
+            raw_timeframe=Timeframe.DAY,
+            timeframe_origin="aggregated",
+            aggregation={
+                "kind": "ohlc_resample",
+                "rule": "completed_iso_week",
+                "input_timeframe": Timeframe.DAY.value,
+                "bucket_timezone": "Asia/Shanghai",
+                "input_source": {
+                    "source_id": "tencent_kline",
+                    "provider_symbol": symbol,
+                },
+            },
+        )
+    return TimeframeTransform(
+        raw_timeframe=Timeframe.DAY,
+        timeframe_origin="native",
+        aggregation={"kind": "none", "rule": "native_passthrough"},
+    )
+
+
+def _parse_tencent_rows(rows: list[Any], *, ticker: str) -> list[Candle]:
+    candles: list[Candle] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, (list, tuple)) or len(row) != 6:
+            raise ProviderError(f"Tencent K-line row {index} is malformed for {ticker}")
+        try:
+            timestamp = date.fromisoformat(str(row[0])).isoformat()
+            values = [float(row[position]) for position in range(1, 6)]
+        except (TypeError, ValueError) as exc:
+            raise ProviderError(f"Tencent K-line row {index} has invalid values for {ticker}") from exc
+        if not all(math.isfinite(value) for value in values):
+            raise ProviderError(f"Tencent K-line row {index} has non-finite values for {ticker}")
+        open_value, close_value, high_value, low_value, volume = values
+        if high_value < max(open_value, close_value) or low_value > min(open_value, close_value):
+            raise ProviderError(f"Tencent OHLC invariant failed for {ticker} at {timestamp}")
+        if volume < 0:
+            raise ProviderError(f"Tencent volume is negative for {ticker} at {timestamp}")
+        candles.append(
+            Candle(
+                timestamp=timestamp,
+                open=open_value,
+                high=high_value,
+                low=low_value,
+                close=close_value,
+                volume=volume,
+            )
+        )
+    for previous, current in zip(candles, candles[1:]):
+        if current.timestamp == previous.timestamp:
+            raise ProviderError(f"Tencent returned duplicate dates for {ticker}")
+        if current.timestamp < previous.timestamp:
+            raise ProviderError(f"Tencent returned out-of-order dates for {ticker}")
+    return candles
+
+
+def _closed_daily_rows(
+    candles: list[Candle], *, start: date | None, end: date
+) -> list[Candle]:
+    return [
+        candle
+        for candle in candles
+        if (start is None or date.fromisoformat(candle.timestamp) >= start)
+        and date.fromisoformat(candle.timestamp) < end
+    ]
+
+
+def _aggregate_tencent_completed_weeks(
+    candles: list[Candle],
+    *,
+    completion_boundary: date,
+    requested_start: date | None,
+) -> list[Candle]:
+    groups: dict[tuple[int, int], list[Candle]] = {}
+    for candle in candles:
+        trading_date = date.fromisoformat(candle.timestamp)
+        iso = trading_date.isocalendar()
+        week_start = date.fromisocalendar(iso.year, iso.week, 1)
+        week_end = date.fromisocalendar(iso.year, iso.week, 5)
+        if week_end >= completion_boundary:
+            continue
+        if requested_start and week_start < requested_start:
+            continue
+        groups.setdefault((int(iso.year), int(iso.week)), []).append(candle)
+
+    output: list[Candle] = []
+    for rows in groups.values():
+        rows.sort(key=lambda item: item.timestamp)
+        output.append(
+            Candle(
+                timestamp=rows[-1].timestamp,
+                open=rows[0].open,
+                high=max(row.high for row in rows),
+                low=min(row.low for row in rows),
+                close=rows[-1].close,
+                volume=sum(row.volume for row in rows),
+            )
+        )
+    return sorted(output, key=lambda item: item.timestamp)

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -6,7 +6,7 @@ from kline.config import Settings, ensure_data_dir, get_settings
 from kline.models import AssetClass, Timeframe
 from kline.plugin_loader import load_configured_adapters, load_entrypoint_adapters
 from kline.ports import MarketDataPort, ProviderBackedMarketDataAdapter
-from kline.providers.ashare import AShareProvider
+from kline.providers.ashare import AShareProvider, TencentIndexProvider
 from kline.providers.base import Provider, ProviderError
 from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 from kline.providers.commodity import CommodityProvider
@@ -57,6 +57,12 @@ def init(settings: Settings | None = None) -> None:
         ProviderBackedMarketDataAdapter(
             source_manifest("yahoo_finance_index", AssetClass.INDEX),
             _providers[AssetClass.INDEX],
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("tencent_kline", AssetClass.INDEX),
+            TencentIndexProvider(timeout=s.request_timeout),
         )
     )
     register_adapter(
@@ -154,8 +160,8 @@ def get_adapter_for_source(source: str, asset_class: AssetClass) -> MarketDataPo
         raise ProviderError(
             f"Unknown source: {source}",
             suggestions=[
-                "Use auto, binance_spot_public, binance_usdm_futures, yahoo_finance, "
-                "yahoo_finance_futures, tushare_pro, or a registered adapter source"
+                "Use auto, tencent_kline, binance_spot_public, binance_usdm_futures, "
+                "yahoo_finance, yahoo_finance_futures, tushare_pro, or a registered adapter source"
             ],
         ) from e
 
@@ -165,7 +171,7 @@ def get_adapter_for_source(source: str, asset_class: AssetClass) -> MarketDataPo
             f"Source adapter not configured: {normalized}",
             suggestions=[
                 f"Register an adapter for {normalized}",
-                "For A-share data, set KLINE_TUSHARE_TOKEN if source=tushare_pro",
+                "For A-share equity data, set KLINE_TUSHARE_TOKEN if source=tushare_pro",
             ],
         )
     if adapter.manifest.asset_class != manifest.asset_class:

--- a/tests/test_tencent_a_share.py
+++ b/tests/test_tencent_a_share.py
@@ -1,0 +1,303 @@
+"""Focused contract tests for the Tencent A-share index source."""
+
+from __future__ import annotations
+
+from datetime import date
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from kline.api import get_candles
+from kline.models import (
+    AssetClass,
+    CachePolicy,
+    Candle,
+    FallbackPolicy,
+    QualityPolicy,
+    Timeframe,
+)
+from kline.ports import ProviderBackedMarketDataAdapter
+from kline.providers.ashare import TencentIndexProvider
+from kline.providers.base import ProviderError
+from kline.provenance import canonical_ticker_for_source, source_manifest
+
+
+def _rows(*dates: str) -> list[list[str]]:
+    return [[stamp, "100", "101", "102", "99", "1000"] for stamp in dates]
+
+
+def _handler(rows: list[list[str]], *, response_symbol: str | None = None):
+    def handle(request: httpx.Request) -> httpx.Response:
+        symbol = request.url.params["param"].split(",", 1)[0]
+        returned_symbol = response_symbol or symbol
+        return httpx.Response(
+            200,
+            json={
+                "code": 0,
+                "msg": "",
+                "data": {returned_symbol: {"day": rows}},
+            },
+            request=request,
+        )
+
+    return handle
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("symbol", ["sh000001", "sh000688", "sh000015"])
+async def test_tencent_index_daily_keeps_explicit_symbol_and_excludes_today(symbol: str):
+    transport = httpx.MockTransport(
+        _handler(_rows("2026-08-18", "2026-08-19", "2026-08-20"))
+    )
+    provider = TencentIndexProvider(
+        transport=transport,
+        today=lambda: date(2026, 8, 20),
+    )
+
+    candles = await provider.fetch(symbol, Timeframe.DAY, limit=10)
+
+    assert [item.timestamp for item in candles] == ["2026-08-18", "2026-08-19"]
+    assert provider.source_identity["provider_symbol"] == symbol
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.DAY
+    assert provider.timeframe_transform.timeframe_origin == "native"
+    assert provider.timeframe_transform.aggregation["rule"] == "native_passthrough"
+    assert provider.last_raw_response["request_params"]["requests"][0]["param"].startswith(
+        f"{symbol},day"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("symbol", ["sh000001", "sh000688", "sh000015"])
+async def test_tencent_index_weekly_aggregates_only_completed_weeks_with_input_identity(symbol: str):
+    transport = httpx.MockTransport(
+        _handler(
+            _rows(
+                "2026-08-10",
+                "2026-08-11",
+                "2026-08-12",
+                "2026-08-13",
+                "2026-08-14",
+                "2026-08-17",
+                "2026-08-18",
+                "2026-08-19",
+                "2026-08-20",
+            )
+        )
+    )
+    provider = TencentIndexProvider(
+        transport=transport,
+        today=lambda: date(2026, 8, 20),
+    )
+
+    candles = await provider.fetch(
+        symbol,
+        Timeframe.WEEK,
+        start="2026-08-10",
+        end="2026-08-21",
+        limit=10,
+    )
+
+    assert [item.timestamp for item in candles] == ["2026-08-14"]
+    assert candles[0].open == 100
+    assert candles[0].close == 101
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.DAY
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
+    aggregation = provider.timeframe_transform.aggregation
+    assert aggregation["rule"] == "completed_iso_week"
+    assert aggregation["input_source"] == {
+        "source_id": "tencent_kline",
+        "provider_symbol": symbol,
+    }
+
+
+@pytest.mark.asyncio
+async def test_tencent_index_historical_end_without_start_still_fetches_rows():
+    provider = TencentIndexProvider(
+        transport=httpx.MockTransport(
+            _handler(_rows("2026-08-13", "2026-08-14", "2026-08-15"))
+        ),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    candles = await provider.fetch(
+        "sh000001",
+        Timeframe.DAY,
+        end="2026-08-16",
+        limit=10,
+    )
+
+    assert [item.timestamp for item in candles] == ["2026-08-13", "2026-08-14", "2026-08-15"]
+
+
+@pytest.mark.asyncio
+async def test_tencent_index_rejects_current_partial_week():
+    transport = httpx.MockTransport(
+        _handler(_rows("2026-08-17", "2026-08-18", "2026-08-19"))
+    )
+    provider = TencentIndexProvider(
+        transport=transport,
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="no closed candles"):
+        await provider.fetch(
+            "sh000001",
+            Timeframe.WEEK,
+            start="2026-08-17",
+            end="2026-08-21",
+            limit=10,
+        )
+
+    assert provider.last_raw_response["error"]
+
+
+@pytest.mark.asyncio
+async def test_tencent_index_rejects_bare_ambiguous_code_without_http_call():
+    called = False
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(500, request=request)
+
+    provider = TencentIndexProvider(transport=httpx.MockTransport(handle))
+
+    with pytest.raises(ProviderError, match="explicit market-prefixed"):
+        await provider.fetch("000001", Timeframe.DAY)
+
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rows", "response_symbol", "message"),
+    [
+        ([], None, "no daily K-line rows"),
+        ([["2026-08-19", "bad", "101", "102", "99", "1000"]], None, "invalid values"),
+        (_rows("2026-08-19"), "sz000001", "wrong symbol"),
+    ],
+)
+async def test_tencent_index_fails_closed_on_empty_malformed_or_wrong_symbol(
+    rows: list[list[str]], response_symbol: str | None, message: str
+):
+    provider = TencentIndexProvider(
+        transport=httpx.MockTransport(_handler(rows, response_symbol=response_symbol)),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match=message):
+        await provider.fetch("sh000001", Timeframe.DAY, limit=10)
+
+    assert provider.last_raw_response["error"]
+
+
+@pytest.mark.asyncio
+async def test_tencent_index_rejects_out_of_order_rows_instead_of_sorting_them():
+    provider = TencentIndexProvider(
+        transport=httpx.MockTransport(
+            _handler(_rows("2026-08-19", "2026-08-18"))
+        ),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="out-of-order"):
+        await provider.fetch("sh000001", Timeframe.DAY, limit=10)
+
+
+class _FailingTencentProvider:
+    def __init__(self) -> None:
+        self.called = False
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.DAY, Timeframe.WEEK]
+
+    async def fetch(self, *_args, **_kwargs):
+        self.called = True
+        raise ProviderError("Tencent returned wrong symbol")
+
+
+@pytest.mark.asyncio
+async def test_tencent_api_strict_bypass_none_does_not_read_cache_or_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    from kline.provenance import source_manifest
+    from kline.store import KlineStore
+
+    store = KlineStore(str(tmp_path / "kline.db"))
+    store.save(
+        "sh000001",
+        AssetClass.INDEX,
+        Timeframe.DAY,
+        [Candle(timestamp="2026-08-19", open=1, high=2, low=0, close=1.5, volume=10)],
+        source_id="tencent_kline",
+    )
+    failing_provider = _FailingTencentProvider()
+    adapter = ProviderBackedMarketDataAdapter(
+        source_manifest("tencent_kline", AssetClass.INDEX),
+        failing_provider,
+    )
+    monkeypatch.setattr("kline.api.get_store", lambda: store)
+    monkeypatch.setattr("kline.api.get_adapter_for_source", lambda *_args: adapter)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_candles(
+            asset_class=AssetClass.INDEX,
+            ticker="sh000001",
+            timeframe=Timeframe.DAY,
+            start=None,
+            end=None,
+            limit=1,
+            refresh=False,
+            source="tencent_kline",
+            cache_policy=CachePolicy.BYPASS,
+            quality=QualityPolicy.STRICT,
+            fallback_policy=FallbackPolicy.NONE,
+            require_execution_venue=False,
+            profile=None,
+            strict=False,
+            mode="research",
+        )
+
+    detail = exc.value.detail
+    assert failing_provider.called is True
+    assert detail["cache_policy"] == "bypass"
+    assert detail["quality_policy"] == "strict"
+    assert detail["fallback_policy"] == "none"
+    assert detail["attempted_sources"] == ["tencent_kline"]
+    assert detail["selected_source"] == "tencent_kline"
+    assert detail["provider_symbol"] == "sh000001"
+    assert detail["timeframe"] == "1d"
+    assert store.query(
+        "sh000001", AssetClass.INDEX, Timeframe.DAY, source_id="tencent_kline"
+    )[0].close == 1.5
+
+
+@pytest.mark.asyncio
+async def test_tencent_adapter_receipt_preserves_source_and_transform():
+    provider = TencentIndexProvider(
+        transport=httpx.MockTransport(_handler(_rows("2026-08-18", "2026-08-19"))),
+        today=lambda: date(2026, 8, 20),
+    )
+    manifest = source_manifest("tencent_kline", AssetClass.INDEX)
+    adapter = ProviderBackedMarketDataAdapter(manifest, provider)
+
+    receipt = await adapter.fetch_candles_with_receipt("sh000001", Timeframe.DAY, limit=10)
+
+    assert receipt.source_identity["source_id"] == "tencent_kline"
+    assert receipt.source_identity["provider_symbol"] == "sh000001"
+    assert receipt.timeframe_transform is not None
+    assert receipt.raw_response is not None
+
+
+def test_tencent_manifest_preserves_market_prefix_and_symbol_matrix():
+    manifest = source_manifest("tencent_kline", AssetClass.INDEX)
+
+    assert manifest.canonical_ticker("000001.SH") == "sh000001"
+    assert manifest.canonical_ticker("sh000688") == "sh000688"
+    assert canonical_ticker_for_source("tencent_kline", AssetClass.INDEX, "000015.SH") == "sh000015"
+    assert manifest.supports_timeframe("sh000001", Timeframe.DAY)
+    assert manifest.supports_timeframe("sh000001", Timeframe.WEEK)
+    assert not manifest.supports_timeframe("sh000001", Timeframe.HOUR_4)
+    assert not manifest.supports_timeframe("000001", Timeframe.DAY)


### PR DESCRIPTION
## What
- Add Tencent public OHLC source for Shanghai Composite, STAR 50, and Shanghai Dividend indices.
- Use explicit `sh`-prefixed symbols and preserve Tencent endpoint/source identity.
- Expose daily and completed weekly candles under strict no-fallback policies.

## Why
TuShare access is unavailable; the three required A-share indices need a real, reproducible public source without silently claiming a configured TuShare provider.

## Validation
- Focused provider/API tests: 26 passed
- Real Tencent HTTP smoke: `sh000001`, `sh000688`, `sh000015`, daily and weekly all ready
- `git diff --check` clean

## Scope
No TuShare token, `.env`, launchd, database, or resident 8100 service changes.

Closes #11