### PR TITLE
feat: add official Treasury level candles

### DIFF
--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -109,6 +109,10 @@ _SOURCE_ALIASES = {
     "tushare_pro": "tushare_pro",
     "tencent": "tencent_kline",
     "tencent_kline": "tencent_kline",
+    "treasury": "treasury_official_csv",
+    "treasury_official": "treasury_official_csv",
+    "treasury_official_csv": "treasury_official_csv",
+    "treasury_official_csv_derived": "treasury_official_csv_derived",
     "fred": "fred_public_csv",
     "fred_public_csv": "fred_public_csv",
 }
@@ -120,6 +124,8 @@ _SOURCE_ASSET_CLASSES = {
     "yahoo_finance_futures": AssetClass.COMMODITY,
     "tushare_pro": AssetClass.A_SHARE,
     "tencent_kline": AssetClass.INDEX,
+    "treasury_official_csv": AssetClass.MACRO,
+    "treasury_official_csv_derived": AssetClass.MACRO,
     "yahoo_finance_index": AssetClass.INDEX,
     "yahoo_finance_etf": AssetClass.ETF,
     "fred_public_csv_macro": AssetClass.MACRO,
@@ -165,6 +171,27 @@ _TENCENT_INDEX_META = ProviderMeta(
     realtime_supported=False,
     market_type="index",
     supported_symbols=("sh000001", "sh000688", "sh000015"),
+)
+
+_TREASURY_META = ProviderMeta(
+    name="treasury_official",
+    source_mode="treasury_official_csv",
+    quality_flags=("official_api", "daily_level", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="treasury_par_yield",
+    supported_symbols=("2 Yr", "10 Yr"),
+)
+_TREASURY_DERIVED_META = ProviderMeta(
+    name="treasury_official",
+    source_mode="treasury_official_csv_derived",
+    quality_flags=("official_api", "derived_level", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="treasury_curve_spread",
+    supported_symbols=("10 Yr-2 Yr",),
 )
 
 _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
@@ -335,6 +362,53 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
             "SH000688": (Timeframe.DAY, Timeframe.WEEK),
             "SH000015": (Timeframe.DAY, Timeframe.WEEK),
         },
+        enforce_symbol_allowlist=True,
+    ),
+    "treasury_official_csv": SourceManifest(
+        source_id="treasury_official_csv",
+        asset_class=AssetClass.MACRO,
+        meta=_TREASURY_META,
+        default_for_asset_class=False,
+        ticker_aliases={
+            "US2Y": "2 Yr",
+            "DGS2": "2 Yr",
+            "2Y": "2 Yr",
+            "US10Y": "10 Yr",
+            "DGS10": "10 Yr",
+            "10Y": "10 Yr",
+        },
+        canonical_instrument_ids={
+            "US2Y": "us2y",
+            "DGS2": "us2y",
+            "2Y": "us2y",
+            "2 YR": "us2y",
+            "US10Y": "us10y",
+            "DGS10": "us10y",
+            "10Y": "us10y",
+            "10 YR": "us10y",
+        },
+        symbol_timeframes={
+            "2 YR": (Timeframe.DAY, Timeframe.WEEK),
+            "10 YR": (Timeframe.DAY, Timeframe.WEEK),
+        },
+        enforce_symbol_allowlist=True,
+    ),
+    "treasury_official_csv_derived": SourceManifest(
+        source_id="treasury_official_csv_derived",
+        asset_class=AssetClass.MACRO,
+        meta=_TREASURY_DERIVED_META,
+        ticker_aliases={
+            "US2S10S": "10 Yr-2 Yr",
+            "T10Y2Y": "10 Yr-2 Yr",
+            "2S10S": "10 Yr-2 Yr",
+        },
+        canonical_instrument_ids={
+            "US2S10S": "us2s10s",
+            "T10Y2Y": "us2s10s",
+            "2S10S": "us2s10s",
+            "10 YR-2 YR": "us2s10s",
+        },
+        symbol_timeframes={"10 YR-2 YR": (Timeframe.DAY, Timeframe.WEEK)},
         enforce_symbol_allowlist=True,
     ),
     "yahoo_finance_index": SourceManifest(

--- a/src/kline/providers/treasury.py
+++ b/src/kline/providers/treasury.py
@@ -1,0 +1,384 @@
+"""Official U.S. Treasury daily par-yield levels and derived 2s10s spread."""
+
+from __future__ import annotations
+
+from csv import DictReader
+from datetime import date, timedelta
+from hashlib import sha256
+from io import StringIO
+import math
+from typing import Any, Callable
+
+import httpx
+
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.providers.base import ProviderError
+
+
+TREASURY_CSV_TEMPLATE = (
+    "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/"
+    "daily-treasury-rates.csv/{year}/all"
+)
+_TREASURY_COLUMNS = {"2 Yr": "US2Y", "10 Yr": "US10Y"}
+_LEVEL_ALIASES = {
+    "US2Y": "2 Yr",
+    "DGS2": "2 Yr",
+    "2Y": "2 Yr",
+    "2 YR": "2 Yr",
+    "US10Y": "10 Yr",
+    "DGS10": "10 Yr",
+    "10Y": "10 Yr",
+    "10 YR": "10 Yr",
+}
+_SPREAD_ALIASES = {
+    "US2S10S": "10 Yr-2 Yr",
+    "T10Y2Y": "10 Yr-2 Yr",
+    "2S10S": "10 Yr-2 Yr",
+}
+_MISSING_VALUES = frozenset({"", ".", "N/A", "NA", "NULL"})
+
+
+class TreasuryCsvProvider:
+    """Fetch official Treasury par-yield CSV rows as level candles.
+
+    A provider instance is bound to either one official maturity column or the
+    derived same-date 10Y-minus-2Y series.  It never consults FRED or another
+    source when the official CSV is unavailable.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 30,
+        transport: httpx.AsyncBaseTransport | None = None,
+        derived_spread: bool = False,
+        today: Callable[[], date] | None = None,
+    ) -> None:
+        self._timeout = timeout
+        self._transport = transport
+        self._derived_spread = derived_spread
+        self._today = today or date.today
+        self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform: TimeframeTransform | None = None
+        self.source_identity: dict[str, Any] = {}
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.DAY, Timeframe.WEEK]
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        self.last_raw_response = None
+        self.timeframe_transform = None
+        self.source_identity = {}
+        series = self._resolve_series(ticker)
+        self.timeframe_transform = _treasury_transform(timeframe, series)
+        self.source_identity = _source_identity(series, derived=self._derived_spread)
+        if timeframe not in self.supported_timeframes():
+            raise ProviderError(
+                f"Treasury source does not support {timeframe.value}",
+                suggestions=["Use timeframe=1d or timeframe=1w"],
+            )
+
+        self.last_raw_response = {
+            "request_params": {
+                "endpoint_template": TREASURY_CSV_TEMPLATE,
+                "requested_ticker": ticker,
+                "provider_symbol": series,
+                "requested_timeframe": timeframe.value,
+                "raw_timeframe": Timeframe.DAY.value,
+                "years": [],
+            },
+            "response_body": {"responses": []},
+            "status_code": None,
+            "error": None,
+        }
+
+        try:
+            requested_start = _parse_date(start, "start")
+            requested_end = _parse_date(end, "end")
+            today = self._today()
+            completion_boundary = min(requested_end or today, today)
+            if requested_start and requested_start >= completion_boundary:
+                raise ProviderError("Treasury date range contains no closed observations")
+            query_start = requested_start or (
+                completion_boundary
+                - timedelta(days=max(limit * (7 if timeframe == Timeframe.WEEK else 3), 365))
+            )
+            if query_start >= completion_boundary:
+                raise ProviderError("Treasury date range is empty")
+            csv_texts = await self._fetch_years(
+                range(query_start.year, completion_boundary.year + 1)
+            )
+            candles = _parse_treasury_csv(
+                csv_texts,
+                series=series,
+                derived_spread=self._derived_spread,
+                start=requested_start,
+                end=completion_boundary,
+            )
+            if timeframe == Timeframe.WEEK:
+                candles = _aggregate_completed_level_weeks(
+                    candles,
+                    completion_boundary=completion_boundary,
+                )
+        except ProviderError as error:
+            if self.last_raw_response is not None:
+                self.last_raw_response["error"] = str(error)
+            raise
+
+        if not candles:
+            error = ProviderError(
+                f"Treasury returned no usable closed observations for {ticker} ({timeframe.value})",
+                suggestions=["Check the requested range and official Treasury publication status"],
+            )
+            self.last_raw_response["error"] = str(error)
+            raise error
+        if limit and len(candles) > limit:
+            candles = candles[-limit:]
+        self.last_raw_response["request_params"]["public_row_count"] = len(candles)
+        self.source_identity["observation_count"] = len(candles)
+        return candles
+
+    def _resolve_series(self, ticker: str) -> str:
+        normalized = ticker.strip().upper()
+        if self._derived_spread:
+            series = _SPREAD_ALIASES.get(normalized, ticker.strip())
+            if series != "10 Yr-2 Yr":
+                raise ProviderError(
+                    f"Unsupported Treasury spread symbol: {ticker}",
+                    suggestions=["Use US2S10S or T10Y2Y"],
+                )
+            return series
+        series = _LEVEL_ALIASES.get(normalized, ticker.strip())
+        if series not in _TREASURY_COLUMNS:
+            raise ProviderError(
+                f"Unsupported Treasury maturity symbol: {ticker}",
+                suggestions=["Use US2Y/DGS2 or US10Y/DGS10"],
+            )
+        return series
+
+    async def _fetch_years(self, years: range) -> list[str]:
+        raw = self.last_raw_response
+        assert raw is not None
+        texts: list[str] = []
+        headers = {"Accept": "text/csv", "User-Agent": "Mozilla/5.0"}
+        async with httpx.AsyncClient(
+            timeout=self._timeout,
+            transport=self._transport,
+            follow_redirects=True,
+            headers=headers,
+        ) as client:
+            for year in years:
+                params = {
+                    "_format": "csv",
+                    "type": "daily_treasury_yield_curve",
+                }
+                url = TREASURY_CSV_TEMPLATE.format(year=year)
+                raw["request_params"]["years"].append({"year": year, "params": params})
+                try:
+                    response = await client.get(url, params=params)
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raw["status_code"] = exc.response.status_code
+                    raw["error"] = str(exc)
+                    raise ProviderError(
+                        f"Official Treasury CSV request failed for {year}: {exc}"
+                    ) from exc
+                except httpx.RequestError as exc:
+                    raw["error"] = str(exc)
+                    raise ProviderError(
+                        f"Official Treasury CSV request failed for {year}: {exc}"
+                    ) from exc
+                raw["status_code"] = response.status_code
+                text = response.text
+                raw["response_body"]["responses"].append(
+                    {
+                        "year": year,
+                        "status_code": response.status_code,
+                        "body_sha256": sha256(text.encode("utf-8")).hexdigest(),
+                        "body": text,
+                    }
+                )
+                texts.append(text)
+        return texts
+
+
+def _parse_date(value: str | None, field: str) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError as exc:
+        raise ProviderError(f"Treasury {field} date is invalid: {value}") from exc
+
+
+def _source_identity(series: str, *, derived: bool) -> dict[str, Any]:
+    if not derived:
+        return {
+            "source_id": "treasury_official_csv",
+            "provider_symbol": series,
+            "endpoint": TREASURY_CSV_TEMPLATE,
+            "dataset": "daily_treasury_yield_curve",
+            "series_kind": "rate_level",
+            "unit": "percent",
+        }
+    return {
+        "source_id": "treasury_official_csv_derived",
+        "provider_symbol": series,
+        "endpoint": TREASURY_CSV_TEMPLATE,
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "spread",
+        "unit": "basis_points",
+        "derivation": {
+            "rule": "same_date_10y_minus_2y",
+            "scale": 100,
+            "input_source": "treasury_official_csv",
+            "input_columns": ["10 Yr", "2 Yr"],
+        },
+    }
+
+
+def _treasury_transform(timeframe: Timeframe, series: str) -> TimeframeTransform:
+    if timeframe == Timeframe.WEEK:
+        return TimeframeTransform(
+            raw_timeframe=Timeframe.DAY,
+            timeframe_origin="aggregated",
+            aggregation={
+                "kind": "level_last_observation",
+                "rule": "completed_iso_week_last_level",
+                "input_timeframe": Timeframe.DAY.value,
+                "bucket_timezone": "America/New_York",
+                "input_source": {
+                    "source_id": (
+                        "treasury_official_csv_derived"
+                        if series == "10 Yr-2 Yr"
+                        else "treasury_official_csv"
+                    ),
+                    "provider_symbol": series,
+                },
+            },
+        )
+    return TimeframeTransform(
+        raw_timeframe=Timeframe.DAY,
+        timeframe_origin="native",
+        aggregation={"kind": "none", "rule": "native_passthrough"},
+    )
+
+
+def _parse_treasury_csv(
+    texts: list[str],
+    *,
+    series: str,
+    derived_spread: bool,
+    start: date | None,
+    end: date,
+) -> list[Candle]:
+    values_by_date: dict[date, float] = {}
+    required = ["2 Yr", "10 Yr"] if derived_spread else [series]
+    for text in texts:
+        reader = DictReader(StringIO(text))
+        headers = set(reader.fieldnames or ())
+        missing_headers = [column for column in required if column not in headers]
+        if "Date" not in headers or missing_headers:
+            raise ProviderError(
+                "Official Treasury CSV schema is missing required columns: "
+                + ", ".join([*(["Date"] if "Date" not in headers else []), *missing_headers])
+            )
+        for row in reader:
+            raw_date = str(row.get("Date", "")).strip()
+            if not raw_date:
+                raise ProviderError("Official Treasury CSV row has a missing Date")
+            try:
+                observation_date = date.fromisoformat(raw_date)
+            except ValueError:
+                try:
+                    month, day, year = (int(part) for part in raw_date.split("/"))
+                    observation_date = date(year, month, day)
+                except (TypeError, ValueError) as exc:
+                    raise ProviderError(f"Official Treasury date is malformed: {raw_date}") from exc
+            if observation_date < (start or date.min) or observation_date >= end:
+                continue
+            if derived_spread:
+                two_year = _parse_numeric(row.get("2 Yr"), "2 Yr", observation_date)
+                ten_year = _parse_numeric(row.get("10 Yr"), "10 Yr", observation_date)
+                if two_year is None or ten_year is None:
+                    raise ProviderError(
+                        "Official Treasury required same-date input is missing: "
+                        f"{observation_date}"
+                    )
+                value = (ten_year - two_year) * 100
+            else:
+                value = _parse_numeric(row.get(series), series, observation_date)
+                if value is None:
+                    raise ProviderError(
+                        "Official Treasury required observation is missing: "
+                        f"{series} {observation_date}"
+                    )
+            if observation_date in values_by_date:
+                raise ProviderError(
+                    f"Official Treasury CSV returned duplicate date: {observation_date}"
+                )
+            values_by_date[observation_date] = value
+
+    return [
+        Candle(
+            timestamp=observation_date.isoformat(),
+            open=value,
+            high=value,
+            low=value,
+            close=value,
+            volume=0,
+        )
+        for observation_date, value in sorted(values_by_date.items())
+    ]
+
+
+def _parse_numeric(raw: Any, column: str, observation_date: date) -> float | None:
+    text = "" if raw is None else str(raw).strip()
+    if text.upper() in _MISSING_VALUES:
+        return None
+    try:
+        value = float(text)
+    except (TypeError, ValueError) as exc:
+        raise ProviderError(
+            f"Official Treasury value is malformed: {column} {observation_date}"
+        ) from exc
+    if not math.isfinite(value):
+        raise ProviderError(f"Official Treasury value is non-finite: {column} {observation_date}")
+    return value
+
+
+def _aggregate_completed_level_weeks(
+    candles: list[Candle], *, completion_boundary: date
+) -> list[Candle]:
+    groups: dict[tuple[int, int], list[Candle]] = {}
+    for candle in candles:
+        observation_date = date.fromisoformat(candle.timestamp)
+        iso = observation_date.isocalendar()
+        week_end = date.fromisocalendar(iso.year, iso.week, 5)
+        if week_end >= completion_boundary:
+            continue
+        groups.setdefault((int(iso.year), int(iso.week)), []).append(candle)
+
+    output: list[Candle] = []
+    for rows in groups.values():
+        rows.sort(key=lambda item: item.timestamp)
+        value = rows[-1].close
+        output.append(
+            Candle(
+                timestamp=rows[-1].timestamp,
+                open=value,
+                high=value,
+                low=value,
+                close=value,
+                volume=0,
+            )
+        )
+    return sorted(output, key=lambda item: item.timestamp)

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -12,6 +12,7 @@ from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 from kline.providers.commodity import CommodityProvider
 from kline.providers.crypto import CryptoProvider
 from kline.providers.fred import FredCsvProvider
+from kline.providers.treasury import TreasuryCsvProvider
 from kline.providers.us import USStockProvider
 from kline.provenance import (
     all_source_manifests,
@@ -78,6 +79,18 @@ def init(settings: Settings | None = None) -> None:
                 FredCsvProvider(timeout=s.request_timeout),
             )
         )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("treasury_official_csv", AssetClass.MACRO),
+            TreasuryCsvProvider(timeout=s.request_timeout),
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("treasury_official_csv_derived", AssetClass.MACRO),
+            TreasuryCsvProvider(timeout=s.request_timeout, derived_spread=True),
+        )
+    )
     register_adapter(
         ProviderBackedMarketDataAdapter(
             source_manifest("binance_spot_public", AssetClass.CRYPTO),
@@ -160,8 +173,10 @@ def get_adapter_for_source(source: str, asset_class: AssetClass) -> MarketDataPo
         raise ProviderError(
             f"Unknown source: {source}",
             suggestions=[
-                "Use auto, tencent_kline, binance_spot_public, binance_usdm_futures, "
-                "yahoo_finance, yahoo_finance_futures, tushare_pro, or a registered adapter source"
+                "Use auto, tencent_kline, treasury_official_csv, "
+                "treasury_official_csv_derived, binance_spot_public, "
+                "binance_usdm_futures, yahoo_finance, yahoo_finance_futures, "
+                "tushare_pro, or a registered adapter source"
             ],
         ) from e
 

--- a/tests/test_treasury_provider.py
+++ b/tests/test_treasury_provider.py
@@ -1,0 +1,243 @@
+"""Focused tests for official Treasury level and spread candles."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+import pytest
+
+from kline.models import AssetClass, Timeframe
+from kline.providers.base import ProviderError
+from kline.providers.treasury import TreasuryCsvProvider
+from kline.provenance import normalize_source, source_manifest
+
+
+_CSV = """Date,2 Yr,10 Yr
+08/10/2026,4.00,4.50
+08/11/2026,4.10,4.60
+08/12/2026,4.05,N/A
+08/13/2026,4.20,4.70
+08/14/2026,4.30,4.80
+08/17/2026,4.40,4.90
+08/18/2026,4.50,5.00
+08/19/2026,4.60,5.10
+08/20/2026,4.70,5.20
+"""
+_HEADER_ONLY = "Date,2 Yr,10 Yr\n"
+
+
+def _transport(text: str = _CSV) -> httpx.MockTransport:
+    def handle(request: httpx.Request) -> httpx.Response:
+        year = request.url.path.split("/")[-2]
+        body = text if year == "2026" else _HEADER_ONLY
+        return httpx.Response(200, text=body, request=request)
+
+    return httpx.MockTransport(handle)
+
+
+@pytest.mark.asyncio
+async def test_treasury_daily_parses_official_two_year_column_and_excludes_today():
+    provider = TreasuryCsvProvider(
+        transport=_transport(),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    candles = await provider.fetch(
+        "DGS2",
+        Timeframe.DAY,
+        start="2026-08-10",
+        end="2026-08-21",
+        limit=20,
+    )
+
+    assert [item.timestamp for item in candles] == [
+        "2026-08-10",
+        "2026-08-11",
+        "2026-08-12",
+        "2026-08-13",
+        "2026-08-14",
+        "2026-08-17",
+        "2026-08-18",
+        "2026-08-19",
+    ]
+    assert candles[-1].open == candles[-1].high == candles[-1].low == candles[-1].close == 4.60
+    assert provider.source_identity["source_id"] == "treasury_official_csv"
+    assert provider.source_identity["provider_symbol"] == "2 Yr"
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.timeframe_origin == "native"
+    assert provider.last_raw_response["response_body"]["responses"]
+
+
+@pytest.mark.asyncio
+async def test_treasury_weekly_keeps_last_completed_level_only():
+    provider = TreasuryCsvProvider(
+        transport=_transport(),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    candles = await provider.fetch(
+        "US2Y",
+        Timeframe.WEEK,
+        start="2026-08-10",
+        end="2026-08-21",
+        limit=10,
+    )
+
+    assert [item.timestamp for item in candles] == ["2026-08-14"]
+    assert candles[0].open == candles[0].high == candles[0].low == candles[0].close == 4.30
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.DAY
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
+    assert provider.timeframe_transform.aggregation["rule"] == "completed_iso_week_last_level"
+
+
+@pytest.mark.asyncio
+async def test_treasury_spread_uses_same_date_inputs_and_basis_points():
+    provider = TreasuryCsvProvider(
+        transport=_transport(),
+        derived_spread=True,
+        today=lambda: date(2026, 8, 20),
+    )
+
+    candles = await provider.fetch(
+        "T10Y2Y",
+        Timeframe.DAY,
+        start="2026-08-10",
+        end="2026-08-12",
+        limit=10,
+    )
+
+    assert [item.timestamp for item in candles] == ["2026-08-10", "2026-08-11"]
+    assert candles[0].close == pytest.approx(50.0)
+    assert candles[1].close == pytest.approx(50.0)
+    assert candles[0].open == candles[0].high == candles[0].low == candles[0].close
+    assert provider.source_identity["source_id"] == "treasury_official_csv_derived"
+    assert provider.source_identity["derivation"]["rule"] == "same_date_10y_minus_2y"
+    assert provider.source_identity["derivation"]["input_columns"] == ["10 Yr", "2 Yr"]
+
+
+@pytest.mark.asyncio
+async def test_treasury_missing_same_date_inputs_fail_closed():
+    csv = "Date,2 Yr,10 Yr\n08/10/2026,4.00,N/A\n"
+    provider = TreasuryCsvProvider(
+        transport=_transport(csv),
+        derived_spread=True,
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="required same-date input is missing"):
+        await provider.fetch(
+            "US2S10S",
+            Timeframe.DAY,
+            start="2026-08-10",
+            end="2026-08-11",
+            limit=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_treasury_mixed_valid_and_missing_level_rows_do_not_return_partial_series():
+    provider = TreasuryCsvProvider(
+        transport=_transport(),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="required observation is missing"):
+        await provider.fetch(
+            "US10Y",
+            Timeframe.DAY,
+            start="2026-08-10",
+            end="2026-08-14",
+            limit=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_treasury_malformed_csv_schema_is_not_ready():
+    provider = TreasuryCsvProvider(
+        transport=_transport("Date,2 Yr\n08/10/2026,4.00\n"),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="missing required columns"):
+        await provider.fetch(
+            "US10Y",
+            Timeframe.DAY,
+            start="2026-08-10",
+            end="2026-08-11",
+            limit=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_treasury_malformed_csv_row_with_blank_date_is_not_partial_success():
+    provider = TreasuryCsvProvider(
+        transport=_transport("Date,2 Yr,10 Yr\n,4.00,4.50\n"),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="missing Date"):
+        await provider.fetch(
+            "DGS2",
+            Timeframe.DAY,
+            start="2026-08-10",
+            end="2026-08-11",
+            limit=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_treasury_transport_error_has_explicit_failure():
+    def handle(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("official source unavailable", request=request)
+
+    provider = TreasuryCsvProvider(
+        transport=httpx.MockTransport(handle),
+        today=lambda: date(2026, 8, 20),
+    )
+
+    with pytest.raises(ProviderError, match="Official Treasury CSV request failed"):
+        await provider.fetch(
+            "DGS2",
+            Timeframe.DAY,
+            start="2026-08-10",
+            end="2026-08-11",
+            limit=10,
+        )
+
+    assert provider.last_raw_response["error"]
+
+
+@pytest.mark.asyncio
+async def test_treasury_reused_provider_does_not_leak_previous_identity_on_bad_ticker():
+    provider = TreasuryCsvProvider(
+        transport=_transport(),
+        today=lambda: date(2026, 8, 20),
+    )
+    await provider.fetch(
+        "DGS2",
+        Timeframe.DAY,
+        start="2026-08-10",
+        end="2026-08-11",
+        limit=10,
+    )
+
+    with pytest.raises(ProviderError, match="Unsupported Treasury maturity"):
+        await provider.fetch("DGS30", Timeframe.DAY, limit=10)
+
+    assert provider.source_identity == {}
+    assert provider.timeframe_transform is None
+
+
+def test_treasury_manifests_are_explicit_and_timeframe_bound():
+    levels = source_manifest("treasury_official_csv", AssetClass.MACRO)
+    spread = source_manifest("treasury_official_csv_derived", AssetClass.MACRO)
+
+    assert normalize_source("treasury", AssetClass.MACRO) == "treasury_official_csv"
+    assert levels.canonical_ticker("DGS2") == "2 Yr"
+    assert levels.canonical_ticker("DGS10") == "10 Yr"
+    assert spread.canonical_ticker("T10Y2Y") == "10 Yr-2 Yr"
+    assert levels.supports_timeframe("DGS2", Timeframe.DAY)
+    assert levels.supports_timeframe("DGS2", Timeframe.WEEK)
+    assert not levels.supports_timeframe("DGS2", Timeframe.HOUR_4)


### PR DESCRIPTION
## What
- Add official U.S. Treasury daily yield-curve OHLC-style level candles for 2Y, 10Y, and 2s10s.
- Keep source identity explicit for Treasury raw levels and derived same-date spread values.
- Emit completed daily and weekly candles with strict no-fallback semantics.

## Why
Weekly Macro K-line needs auditable U.S. 2Y, U.S. 10Y, and 2s10s data without relying on unavailable TuShare access or an implicit generic macro provider.

## Validation
- Full datafeed tests: 115 passed
- Real official Treasury HTTP smoke: DGS2, DGS10, T10Y2Y daily and weekly all ready
- Ruff, diff check, and gitleaks clean

## Scope
No launchd, `.env`, database, or resident 8100 service changes.

Closes #12