### PR TITLE
test: publish phase 1 datafeed health matrix

### DIFF
--- a/docs/verification/phase1-matrix-observation-2026-08-20.json
+++ b/docs/verification/phase1-matrix-observation-2026-08-20.json
@@ -10,7 +10,7 @@
     "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
     "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
     "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
-    "build_sha": "f538b05",
+    "build_sha": "072b9ae",
     "registry_version": "weekly-macro-phase1-source-registry-v1",
     "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
     "identity_status": "declared"
@@ -39,7 +39,7 @@
     }
   },
   "database_unchanged": true,
-  "receipt_code_sha": "f538b05",
+  "receipt_code_sha": "072b9ae",
   "health": {
     "status": "ok",
     "service": "kline",
@@ -49,7 +49,7 @@
       "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
       "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
       "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
-        "build_sha": "f538b05",
+        "build_sha": "072b9ae",
       "registry_version": "weekly-macro-phase1-source-registry-v1",
       "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
       "identity_status": "declared"

--- a/docs/verification/phase1-matrix-observation-2026-08-20.json
+++ b/docs/verification/phase1-matrix-observation-2026-08-20.json
@@ -10,10 +10,10 @@
     "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
     "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
     "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
-    "build_sha": "4a9ce06",
+    "build_sha": "f538b05",
     "registry_version": "weekly-macro-phase1-source-registry-v1",
     "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
-    "identity_status": "verified"
+    "identity_status": "declared"
   },
   "counts": {
     "ready": 31,
@@ -39,7 +39,7 @@
     }
   },
   "database_unchanged": true,
-  "receipt_code_sha": "4a9ce06",
+  "receipt_code_sha": "f538b05",
   "health": {
     "status": "ok",
     "service": "kline",
@@ -49,10 +49,10 @@
       "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
       "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
       "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
-        "build_sha": "4a9ce06",
+        "build_sha": "f538b05",
       "registry_version": "weekly-macro-phase1-source-registry-v1",
       "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
-      "identity_status": "verified"
+      "identity_status": "declared"
     },
     "providers": {
       "sources": {

--- a/docs/verification/phase1-matrix-observation-2026-08-20.json
+++ b/docs/verification/phase1-matrix-observation-2026-08-20.json
@@ -10,7 +10,7 @@
     "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
     "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
     "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
-    "build_sha": "ece2bfb",
+    "build_sha": "4a9ce06",
     "registry_version": "weekly-macro-phase1-source-registry-v1",
     "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
     "identity_status": "verified"
@@ -39,7 +39,7 @@
     }
   },
   "database_unchanged": true,
-  "receipt_code_sha": "ece2bfb",
+  "receipt_code_sha": "4a9ce06",
   "health": {
     "status": "ok",
     "service": "kline",
@@ -49,7 +49,7 @@
       "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
       "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
       "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
-        "build_sha": "ece2bfb",
+        "build_sha": "4a9ce06",
       "registry_version": "weekly-macro-phase1-source-registry-v1",
       "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
       "identity_status": "verified"

--- a/docs/verification/phase1-matrix-observation-2026-08-20.json
+++ b/docs/verification/phase1-matrix-observation-2026-08-20.json
@@ -1,0 +1,1874 @@
+{
+  "schema_version": "phase1-matrix-receipt-v1",
+  "matrix_version": "weekly-macro-phase1-39-cell-v1",
+  "observed_at": "2026-08-20T06:59:24.637888+00:00",
+  "base_url": "http://127.0.0.1:18103",
+  "health_http_status": 200,
+  "health_contract_issues": [],
+  "runtime": {
+    "service_version": "0.3.0",
+    "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
+    "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
+    "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
+    "build_sha": "ece2bfb",
+    "registry_version": "weekly-macro-phase1-source-registry-v1",
+    "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
+    "identity_status": "verified"
+  },
+  "counts": {
+    "ready": 31,
+    "unavailable": 0,
+    "blocked": 8
+  },
+  "database_before": {
+    "exists": true,
+    "verified": true,
+    "counts": {
+      "klines": 0,
+      "source_observations": 0,
+      "raw_upstream_responses": 0
+    }
+  },
+  "database_after": {
+    "exists": true,
+    "verified": true,
+    "counts": {
+      "klines": 0,
+      "source_observations": 0,
+      "raw_upstream_responses": 0
+    }
+  },
+  "database_unchanged": true,
+  "receipt_code_sha": "ece2bfb",
+  "health": {
+    "status": "ok",
+    "service": "kline",
+    "version": "0.3.0",
+    "runtime": {
+      "service_version": "0.3.0",
+      "runtime_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
+      "module_root": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
+      "working_directory": "/Users/wendy/.codex/worktrees/datafeed-issue-13",
+        "build_sha": "ece2bfb",
+      "registry_version": "weekly-macro-phase1-source-registry-v1",
+      "database_path": "/private/tmp/datafeed-phase1-matrix.uvlJjN/kline.db",
+      "identity_status": "verified"
+    },
+    "providers": {
+      "sources": {
+        "binance_spot_public": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "crypto",
+          "provider": "binance_spot",
+          "source_mode": "binance_spot_public",
+          "market_type": "spot",
+          "realtime_supported": true,
+          "execution_venue": false,
+          "supported_symbols": [],
+          "supported_timeframes": [
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "4h",
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "BTC": [
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "4h",
+              "1d",
+              "1w"
+            ],
+            "BTCUSDT": [
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "4h",
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "public_api",
+            "spot",
+            "research_only",
+            "not_execution_venue"
+          ]
+        },
+        "binance_usdm_futures": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "commodity",
+          "provider": "binance_usdm_futures",
+          "source_mode": "binance_usdm_futures",
+          "market_type": "usd_m_futures",
+          "realtime_supported": true,
+          "execution_venue": true,
+          "supported_symbols": [
+            "XAUUSDT"
+          ],
+          "supported_timeframes": [
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "4h",
+            "1d"
+          ],
+          "supported_timeframes_by_symbol": {},
+          "quality_flags": [
+            "public_api",
+            "usd_m_futures",
+            "live",
+            "execution_venue"
+          ]
+        },
+        "yahoo_finance": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "us_stock",
+          "provider": "yahoo_finance",
+          "source_mode": "yahoo_finance",
+          "market_type": "equity",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [],
+          "supported_timeframes": [
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "1d",
+            "1w",
+            "4h"
+          ],
+          "supported_timeframes_by_symbol": {},
+          "quality_flags": [
+            "delayed_possible",
+            "market_hours",
+            "research_only"
+          ]
+        },
+        "yahoo_finance_futures": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "commodity",
+          "provider": "yahoo_finance",
+          "source_mode": "yahoo_finance_futures",
+          "market_type": "futures_continuous_contract",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "CL=F",
+            "GC=F",
+            "SI=F"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "CL=F": [
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "4h",
+              "1d",
+              "1w"
+            ],
+            "GC=F": [
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "4h",
+              "1d",
+              "1w"
+            ],
+            "SI=F": [
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "4h",
+              "1d",
+              "1w"
+            ],
+            "BZ=F": [
+              "1d",
+              "1w"
+            ],
+            "NG=F": [
+              "1d",
+              "1w"
+            ],
+            "HG=F": [
+              "1d",
+              "1w"
+            ],
+            "PL=F": [
+              "1d",
+              "1w"
+            ],
+            "ZC=F": [
+              "1d",
+              "1w"
+            ],
+            "ZW=F": [
+              "1d",
+              "1w"
+            ],
+            "ZS=F": [
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "continuous_contract",
+            "market_hours",
+            "research_only"
+          ]
+        },
+        "tushare_pro": {
+          "available": false,
+          "configured": false,
+          "availability_basis": "not_live_probed",
+          "asset_class": "a_share",
+          "provider": "tushare",
+          "source_mode": "tushare_pro",
+          "market_type": "equity",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [],
+          "supported_timeframes": [],
+          "supported_timeframes_by_symbol": {},
+          "quality_flags": [
+            "eod",
+            "market_hours",
+            "research_only"
+          ]
+        },
+        "tencent_kline": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "index",
+          "provider": "tencent_finance",
+          "source_mode": "tencent_kline",
+          "market_type": "index",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "sh000001",
+            "sh000688",
+            "sh000015"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "SH000001": [
+              "1d",
+              "1w"
+            ],
+            "SH000688": [
+              "1d",
+              "1w"
+            ],
+            "SH000015": [
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "public_api",
+            "market_hours",
+            "research_only"
+          ]
+        },
+        "treasury_official_csv": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "macro",
+          "provider": "treasury_official",
+          "source_mode": "treasury_official_csv",
+          "market_type": "treasury_par_yield",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "2 Yr",
+            "10 Yr"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "2 YR": [
+              "1d",
+              "1w"
+            ],
+            "10 YR": [
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "official_api",
+            "daily_level",
+            "research_only"
+          ]
+        },
+        "treasury_official_csv_derived": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "macro",
+          "provider": "treasury_official",
+          "source_mode": "treasury_official_csv_derived",
+          "market_type": "treasury_curve_spread",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "10 Yr-2 Yr"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "10 YR-2 YR": [
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "official_api",
+            "derived_level",
+            "research_only"
+          ]
+        },
+        "yahoo_finance_index": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "index",
+          "provider": "yahoo_finance",
+          "source_mode": "yahoo_finance_index",
+          "market_type": "index",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "DX-Y.NYB",
+            "^GSPC",
+            "^IXIC",
+            "^VIX",
+            "^N225",
+            "^KS11"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "DX-Y.NYB": [
+              "1d",
+              "1w",
+              "4h"
+            ],
+            "^GSPC": [
+              "1d",
+              "1w"
+            ],
+            "^IXIC": [
+              "1d",
+              "1w"
+            ],
+            "^VIX": [
+              "1d",
+              "1w"
+            ],
+            "^N225": [
+              "1d",
+              "1w"
+            ],
+            "^KS11": [
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "delayed_possible",
+            "market_hours",
+            "research_only"
+          ]
+        },
+        "yahoo_finance_etf": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "etf",
+          "provider": "yahoo_finance",
+          "source_mode": "yahoo_finance_etf",
+          "market_type": "etf",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "SCHD"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {
+            "SCHD": [
+              "1d",
+              "1w"
+            ]
+          },
+          "quality_flags": [
+            "delayed_possible",
+            "market_hours",
+            "research_only"
+          ]
+        },
+        "fred_public_csv_macro": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "macro",
+          "provider": "fred",
+          "source_mode": "fred_public_csv_macro",
+          "market_type": "economic_series",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "DTWEXBGS",
+            "DGS2",
+            "DGS10",
+            "T10Y2Y",
+            "DFII10",
+            "GVZCLS",
+            "DFF"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {},
+          "quality_flags": [
+            "public_api",
+            "daily_factor",
+            "research_only"
+          ]
+        },
+        "fred_public_csv_flow": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "flow",
+          "provider": "fred",
+          "source_mode": "fred_public_csv_flow",
+          "market_type": "economic_series",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "DTWEXBGS",
+            "DGS2",
+            "DGS10",
+            "T10Y2Y",
+            "DFII10",
+            "GVZCLS",
+            "DFF"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {},
+          "quality_flags": [
+            "public_api",
+            "daily_factor",
+            "research_only"
+          ]
+        },
+        "fred_public_csv_event": {
+          "available": false,
+          "configured": true,
+          "availability_basis": "not_live_probed",
+          "asset_class": "event",
+          "provider": "fred",
+          "source_mode": "fred_public_csv_event",
+          "market_type": "economic_series",
+          "realtime_supported": false,
+          "execution_venue": false,
+          "supported_symbols": [
+            "DTWEXBGS",
+            "DGS2",
+            "DGS10",
+            "T10Y2Y",
+            "DFII10",
+            "GVZCLS",
+            "DFF"
+          ],
+          "supported_timeframes": [
+            "1d",
+            "1w"
+          ],
+          "supported_timeframes_by_symbol": {},
+          "quality_flags": [
+            "public_api",
+            "daily_factor",
+            "research_only"
+          ]
+        }
+      }
+    },
+    "storage": {
+      "status": "ok",
+      "integrity": "ok",
+      "candle_rows": 0,
+      "source_count": 0
+    },
+    "storage_coverage": [],
+    "latest_observations": []
+  },
+  "read_only_tool": true,
+  "cells": [
+    {
+      "asset_key": "dxy",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "DX-Y.NYB",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "DX-Y.NYB",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "dxy",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "DX-Y.NYB",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "DX-Y.NYB",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "dxy",
+      "timeframe": "4h",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "DX-Y.NYB",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "DX-Y.NYB",
+        "timeframe": "4h",
+        "raw_timeframe": "1h",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "fixed_4h",
+          "input_timeframe": "1h",
+          "bucket_timezone": "UTC",
+          "anchor_hour": 0,
+          "anchor_minute": 0,
+          "dropped_incomplete_buckets": 4
+        }
+      }
+    },
+    {
+      "asset_key": "us2y",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "treasury_official_csv",
+      "provider_symbol": "2 Yr",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "treasury_official_csv"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "treasury_official",
+        "source_mode": "treasury_official_csv",
+        "provider_symbol": "2 Yr",
+        "timeframe": "1d",
+        "source_id": "treasury_official_csv",
+        "endpoint": "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/{year}/all",
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "rate_level",
+        "unit": "percent",
+        "observation_count": 3,
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "us2y",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "treasury_official_csv",
+      "provider_symbol": "2 Yr",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "treasury_official_csv"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "treasury_official",
+        "source_mode": "treasury_official_csv",
+        "provider_symbol": "2 Yr",
+        "timeframe": "1w",
+        "source_id": "treasury_official_csv",
+        "endpoint": "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/{year}/all",
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "rate_level",
+        "unit": "percent",
+        "observation_count": 3,
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "level_last_observation",
+          "rule": "completed_iso_week_last_level",
+          "input_timeframe": "1d",
+          "bucket_timezone": "America/New_York",
+          "input_source": {
+            "source_id": "treasury_official_csv",
+            "provider_symbol": "2 Yr"
+          }
+        }
+      }
+    },
+    {
+      "asset_key": "us10y",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "treasury_official_csv",
+      "provider_symbol": "10 Yr",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "treasury_official_csv"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "treasury_official",
+        "source_mode": "treasury_official_csv",
+        "provider_symbol": "10 Yr",
+        "timeframe": "1d",
+        "source_id": "treasury_official_csv",
+        "endpoint": "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/{year}/all",
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "rate_level",
+        "unit": "percent",
+        "observation_count": 3,
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "us10y",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "treasury_official_csv",
+      "provider_symbol": "10 Yr",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "treasury_official_csv"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "treasury_official",
+        "source_mode": "treasury_official_csv",
+        "provider_symbol": "10 Yr",
+        "timeframe": "1w",
+        "source_id": "treasury_official_csv",
+        "endpoint": "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/{year}/all",
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "rate_level",
+        "unit": "percent",
+        "observation_count": 3,
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "level_last_observation",
+          "rule": "completed_iso_week_last_level",
+          "input_timeframe": "1d",
+          "bucket_timezone": "America/New_York",
+          "input_source": {
+            "source_id": "treasury_official_csv",
+            "provider_symbol": "10 Yr"
+          }
+        }
+      }
+    },
+    {
+      "asset_key": "us2s10s",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "treasury_official_csv_derived",
+      "provider_symbol": "10 Yr-2 Yr",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "treasury_official_csv_derived"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "treasury_official",
+        "source_mode": "treasury_official_csv_derived",
+        "provider_symbol": "10 Yr-2 Yr",
+        "timeframe": "1d",
+        "source_id": "treasury_official_csv_derived",
+        "endpoint": "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/{year}/all",
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "spread",
+        "unit": "basis_points",
+        "derivation": {
+          "rule": "same_date_10y_minus_2y",
+          "scale": 100,
+          "input_source": "treasury_official_csv",
+          "input_columns": [
+            "10 Yr",
+            "2 Yr"
+          ]
+        },
+        "observation_count": 3,
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "us2s10s",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "treasury_official_csv_derived",
+      "provider_symbol": "10 Yr-2 Yr",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "treasury_official_csv_derived"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "treasury_official",
+        "source_mode": "treasury_official_csv_derived",
+        "provider_symbol": "10 Yr-2 Yr",
+        "timeframe": "1w",
+        "source_id": "treasury_official_csv_derived",
+        "endpoint": "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-rates.csv/{year}/all",
+        "dataset": "daily_treasury_yield_curve",
+        "series_kind": "spread",
+        "unit": "basis_points",
+        "derivation": {
+          "rule": "same_date_10y_minus_2y",
+          "scale": 100,
+          "input_source": "treasury_official_csv",
+          "input_columns": [
+            "10 Yr",
+            "2 Yr"
+          ]
+        },
+        "observation_count": 3,
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "level_last_observation",
+          "rule": "completed_iso_week_last_level",
+          "input_timeframe": "1d",
+          "bucket_timezone": "America/New_York",
+          "input_source": {
+            "source_id": "treasury_official_csv_derived",
+            "provider_symbol": "10 Yr-2 Yr"
+          }
+        }
+      }
+    },
+    {
+      "asset_key": "sp500",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^GSPC",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^GSPC",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "sp500",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^GSPC",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^GSPC",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "nasdaq",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^IXIC",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^IXIC",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "nasdaq",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^IXIC",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^IXIC",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "us_dividend",
+      "timeframe": "1d",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_etf",
+      "provider_symbol": "SCHD",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_etf"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "Yahoo OHLC invariant failed for SCHD at 2011-12-23"
+      ],
+      "source_identity": {
+        "provider_symbol": "SCHD",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_etf",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        },
+        "requested_source": "yahoo_finance_etf",
+        "requested_ticker": "SCHD"
+      }
+    },
+    {
+      "asset_key": "us_dividend",
+      "timeframe": "1w",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_etf",
+      "provider_symbol": "SCHD",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_etf"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "Yahoo OHLC invariant failed for SCHD at 2011-12-23"
+      ],
+      "source_identity": {
+        "provider_symbol": "SCHD",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_etf",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        },
+        "requested_source": "yahoo_finance_etf",
+        "requested_ticker": "SCHD"
+      }
+    },
+    {
+      "asset_key": "vix",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^VIX",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^VIX",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "vix",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^VIX",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^VIX",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "bitcoin",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "binance_spot_public",
+      "provider_symbol": "BTCUSDT",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "binance_spot_public"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "binance_spot",
+        "source_mode": "binance_spot_public",
+        "provider_symbol": "BTCUSDT",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "bitcoin",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "binance_spot_public",
+      "provider_symbol": "BTCUSDT",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "binance_spot_public"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "binance_spot",
+        "source_mode": "binance_spot_public",
+        "provider_symbol": "BTCUSDT",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "bitcoin",
+      "timeframe": "4h",
+      "status": "ready",
+      "http_status": 200,
+      "source": "binance_spot_public",
+      "provider_symbol": "BTCUSDT",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "binance_spot_public"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "binance_spot",
+        "source_mode": "binance_spot_public",
+        "provider_symbol": "BTCUSDT",
+        "timeframe": "4h",
+        "raw_timeframe": "4h",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "shanghai",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "tencent_kline",
+      "provider_symbol": "sh000001",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "tencent_kline"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "tencent_finance",
+        "source_mode": "tencent_kline",
+        "provider_symbol": "sh000001",
+        "timeframe": "1d",
+        "source_id": "tencent_kline",
+        "endpoint": "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get",
+        "price_adjustment": "qfq",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "shanghai",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "tencent_kline",
+      "provider_symbol": "sh000001",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "tencent_kline"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "tencent_finance",
+        "source_mode": "tencent_kline",
+        "provider_symbol": "sh000001",
+        "timeframe": "1w",
+        "source_id": "tencent_kline",
+        "endpoint": "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get",
+        "price_adjustment": "qfq",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "Asia/Shanghai",
+          "input_source": {
+            "source_id": "tencent_kline",
+            "provider_symbol": "sh000001"
+          }
+        }
+      }
+    },
+    {
+      "asset_key": "star50",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "tencent_kline",
+      "provider_symbol": "sh000688",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "tencent_kline"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "tencent_finance",
+        "source_mode": "tencent_kline",
+        "provider_symbol": "sh000688",
+        "timeframe": "1d",
+        "source_id": "tencent_kline",
+        "endpoint": "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get",
+        "price_adjustment": "qfq",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "star50",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "tencent_kline",
+      "provider_symbol": "sh000688",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "tencent_kline"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "tencent_finance",
+        "source_mode": "tencent_kline",
+        "provider_symbol": "sh000688",
+        "timeframe": "1w",
+        "source_id": "tencent_kline",
+        "endpoint": "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get",
+        "price_adjustment": "qfq",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "Asia/Shanghai",
+          "input_source": {
+            "source_id": "tencent_kline",
+            "provider_symbol": "sh000688"
+          }
+        }
+      }
+    },
+    {
+      "asset_key": "china_dividend",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "tencent_kline",
+      "provider_symbol": "sh000015",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "tencent_kline"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "tencent_finance",
+        "source_mode": "tencent_kline",
+        "provider_symbol": "sh000015",
+        "timeframe": "1d",
+        "source_id": "tencent_kline",
+        "endpoint": "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get",
+        "price_adjustment": "qfq",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "china_dividend",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "tencent_kline",
+      "provider_symbol": "sh000015",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "tencent_kline"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "tencent_finance",
+        "source_mode": "tencent_kline",
+        "provider_symbol": "sh000015",
+        "timeframe": "1w",
+        "source_id": "tencent_kline",
+        "endpoint": "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get",
+        "price_adjustment": "qfq",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "Asia/Shanghai",
+          "input_source": {
+            "source_id": "tencent_kline",
+            "provider_symbol": "sh000015"
+          }
+        }
+      }
+    },
+    {
+      "asset_key": "nikkei",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^N225",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^N225",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "nikkei",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^N225",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^N225",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "kospi",
+      "timeframe": "1d",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^KS11",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^KS11",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        }
+      }
+    },
+    {
+      "asset_key": "kospi",
+      "timeframe": "1w",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_index",
+      "provider_symbol": "^KS11",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_index"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_index",
+        "provider_symbol": "^KS11",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        }
+      }
+    },
+    {
+      "asset_key": "wti",
+      "timeframe": "1d",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "CL=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "No data for commodity CL=F (resolved to CL=F)"
+      ],
+      "source_identity": {
+        "provider_symbol": "CL=F",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        },
+        "requested_source": "yahoo_finance_futures",
+        "requested_ticker": "CL=F"
+      }
+    },
+    {
+      "asset_key": "wti",
+      "timeframe": "1w",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "CL=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "No data for commodity CL=F (resolved to CL=F)"
+      ],
+      "source_identity": {
+        "provider_symbol": "CL=F",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        },
+        "requested_source": "yahoo_finance_futures",
+        "requested_ticker": "CL=F"
+      }
+    },
+    {
+      "asset_key": "wti",
+      "timeframe": "4h",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "CL=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "provider_symbol": "CL=F",
+        "timeframe": "4h",
+        "raw_timeframe": "1h",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "fixed_4h",
+          "input_timeframe": "1h",
+          "bucket_timezone": "UTC",
+          "anchor_hour": 0,
+          "anchor_minute": 0,
+          "dropped_incomplete_buckets": 13
+        }
+      }
+    },
+    {
+      "asset_key": "gold",
+      "timeframe": "1d",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "GC=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "No data for commodity GC=F (resolved to GC=F)"
+      ],
+      "source_identity": {
+        "provider_symbol": "GC=F",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        },
+        "requested_source": "yahoo_finance_futures",
+        "requested_ticker": "GC=F"
+      }
+    },
+    {
+      "asset_key": "gold",
+      "timeframe": "1w",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "GC=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "No data for commodity GC=F (resolved to GC=F)"
+      ],
+      "source_identity": {
+        "provider_symbol": "GC=F",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        },
+        "requested_source": "yahoo_finance_futures",
+        "requested_ticker": "GC=F"
+      }
+    },
+    {
+      "asset_key": "gold",
+      "timeframe": "4h",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "GC=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "provider_symbol": "GC=F",
+        "timeframe": "4h",
+        "raw_timeframe": "1h",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "fixed_4h",
+          "input_timeframe": "1h",
+          "bucket_timezone": "UTC",
+          "anchor_hour": 0,
+          "anchor_minute": 0,
+          "dropped_incomplete_buckets": 13
+        }
+      }
+    },
+    {
+      "asset_key": "silver",
+      "timeframe": "1d",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "SI=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "No data for commodity SI=F (resolved to SI=F)"
+      ],
+      "source_identity": {
+        "provider_symbol": "SI=F",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "timeframe": "1d",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "native",
+        "aggregation": {
+          "kind": "none",
+          "rule": "native_passthrough"
+        },
+        "requested_source": "yahoo_finance_futures",
+        "requested_ticker": "SI=F"
+      }
+    },
+    {
+      "asset_key": "silver",
+      "timeframe": "1w",
+      "status": "blocked",
+      "http_status": 502,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "SI=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": "upstream_error",
+      "access_issues": [
+        "No data for commodity SI=F (resolved to SI=F)"
+      ],
+      "source_identity": {
+        "provider_symbol": "SI=F",
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "timeframe": "1w",
+        "raw_timeframe": "1d",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "completed_iso_week",
+          "input_timeframe": "1d",
+          "bucket_timezone": "UTC"
+        },
+        "requested_source": "yahoo_finance_futures",
+        "requested_ticker": "SI=F"
+      }
+    },
+    {
+      "asset_key": "silver",
+      "timeframe": "4h",
+      "status": "ready",
+      "http_status": 200,
+      "source": "yahoo_finance_futures",
+      "provider_symbol": "SI=F",
+      "cache_policy": "bypass",
+      "quality_policy": "strict",
+      "fallback_policy": "none",
+      "served_from": "upstream",
+      "attempted_sources": [
+        "yahoo_finance_futures"
+      ],
+      "reject_reason": null,
+      "access_issues": [],
+      "source_identity": {
+        "provider": "yahoo_finance",
+        "source_mode": "yahoo_finance_futures",
+        "provider_symbol": "SI=F",
+        "timeframe": "4h",
+        "raw_timeframe": "1h",
+        "timeframe_origin": "aggregated",
+        "aggregation": {
+          "kind": "ohlc_resample",
+          "rule": "fixed_4h",
+          "input_timeframe": "1h",
+          "bucket_timezone": "UTC",
+          "anchor_hour": 0,
+          "anchor_minute": 0,
+          "dropped_incomplete_buckets": 10
+        }
+      }
+    }
+  ]
+}

--- a/docs/verification/phase1-matrix.md
+++ b/docs/verification/phase1-matrix.md
@@ -1,0 +1,42 @@
+# Phase 1 39-cell matrix
+
+The committed matrix is [`ops/phase1_matrix.py`](../../ops/phase1_matrix.py). It
+contains exactly 17 assets and 39 required cells: daily and weekly for every
+asset, plus 4H for DXY, Bitcoin, WTI, Gold, and Silver.
+
+Run the read-only HTTP verifier against a disposable local runtime:
+
+```bash
+PYTHONPATH=src:. python3 ops/verify_phase1_matrix.py \
+  --base-url http://127.0.0.1:18100 \
+  --db-path /tmp/datafeed-phase1-matrix/kline.db \
+  > /tmp/datafeed-phase1-matrix.json
+```
+
+Every request is a GET with:
+
+```text
+cache_policy=bypass&quality=strict&fallback_policy=none
+```
+
+The verifier does not write SQLite/cache rows, restart services, or change
+launchd/.env. When `--db-path` is supplied it opens that database in read-only
+mode and records before/after counts; `database_unchanged` must be `true`. Use
+a temporary `KLINE_DB_PATH` when the service under test must also be isolated
+from the resident 8100 process. A matrix result is
+`ready` only when the response contains non-empty candles and no reject reason;
+HTTP/source/quality failures remain visible as `unavailable` or `blocked` with
+the source, provider symbol, timeframe, and failure reason.
+
+The health envelope must identify `runtime`, `build_sha` (or explicitly
+`unknown`), `registry_version`, module/runtime roots, and the database path.
+The `providers.sources` section is capability/configuration evidence (`configured`
+is separate from `available`, which remains false until a live probe); the
+matrix cells are the live request evidence and must not be inferred from
+registration alone.
+
+On 2026-08-20, an isolated local run on the canonical implementation returned
+31 `ready` and 8 `blocked` cells. The blocked cells were disclosed rather than
+silently substituted: SCHD had a Yahoo historical OHLC invariant rejection,
+and the three Yahoo futures had upstream no-data responses in that run. This
+receipt is observational, not a deployment or 8100 cutover claim.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Operational verification helpers for the canonical datafeed."""

--- a/ops/phase1_matrix.py
+++ b/ops/phase1_matrix.py
@@ -1,0 +1,139 @@
+"""The committed 17-asset / 39-cell Phase 1 verification matrix."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PHASE1_MATRIX_VERSION = "weekly-macro-phase1-39-cell-v1"
+PHASE1_POLICIES = {
+    "cache_policy": "bypass",
+    "quality": "strict",
+    "quality_policy": "strict",
+    "fallback_policy": "none",
+}
+
+_ASSETS: tuple[tuple[str, str, str, str, tuple[str, ...]], ...] = (
+    ("dxy", "index", "DX-Y.NYB", "yahoo_finance_index", ("1d", "1w", "4h")),
+    ("us2y", "macro", "DGS2", "treasury_official_csv", ("1d", "1w")),
+    ("us10y", "macro", "DGS10", "treasury_official_csv", ("1d", "1w")),
+    ("us2s10s", "macro", "T10Y2Y", "treasury_official_csv_derived", ("1d", "1w")),
+    ("sp500", "index", "^GSPC", "yahoo_finance_index", ("1d", "1w")),
+    ("nasdaq", "index", "^IXIC", "yahoo_finance_index", ("1d", "1w")),
+    ("us_dividend", "etf", "SCHD", "yahoo_finance_etf", ("1d", "1w")),
+    ("vix", "index", "^VIX", "yahoo_finance_index", ("1d", "1w")),
+    ("bitcoin", "crypto", "BTC", "binance_spot_public", ("1d", "1w", "4h")),
+    ("shanghai", "index", "sh000001", "tencent_kline", ("1d", "1w")),
+    ("star50", "index", "sh000688", "tencent_kline", ("1d", "1w")),
+    ("china_dividend", "index", "sh000015", "tencent_kline", ("1d", "1w")),
+    ("nikkei", "index", "^N225", "yahoo_finance_index", ("1d", "1w")),
+    ("kospi", "index", "^KS11", "yahoo_finance_index", ("1d", "1w")),
+    ("wti", "commodity", "CL=F", "yahoo_finance_futures", ("1d", "1w", "4h")),
+    ("gold", "commodity", "GC=F", "yahoo_finance_futures", ("1d", "1w", "4h")),
+    ("silver", "commodity", "SI=F", "yahoo_finance_futures", ("1d", "1w", "4h")),
+)
+
+_EXPECTED_SOURCES = {
+    "dxy": "yahoo_finance_index",
+    "us2y": "treasury_official_csv",
+    "us10y": "treasury_official_csv",
+    "us2s10s": "treasury_official_csv_derived",
+    "sp500": "yahoo_finance_index",
+    "nasdaq": "yahoo_finance_index",
+    "us_dividend": "yahoo_finance_etf",
+    "vix": "yahoo_finance_index",
+    "bitcoin": "binance_spot_public",
+    "shanghai": "tencent_kline",
+    "star50": "tencent_kline",
+    "china_dividend": "tencent_kline",
+    "nikkei": "yahoo_finance_index",
+    "kospi": "yahoo_finance_index",
+    "wti": "yahoo_finance_futures",
+    "gold": "yahoo_finance_futures",
+    "silver": "yahoo_finance_futures",
+}
+
+_EXPECTED_ASSETS = (
+    ("dxy", "index", "DX-Y.NYB", "yahoo_finance_index", ("1d", "1w", "4h")),
+    ("us2y", "macro", "DGS2", "treasury_official_csv", ("1d", "1w")),
+    ("us10y", "macro", "DGS10", "treasury_official_csv", ("1d", "1w")),
+    ("us2s10s", "macro", "T10Y2Y", "treasury_official_csv_derived", ("1d", "1w")),
+    ("sp500", "index", "^GSPC", "yahoo_finance_index", ("1d", "1w")),
+    ("nasdaq", "index", "^IXIC", "yahoo_finance_index", ("1d", "1w")),
+    ("us_dividend", "etf", "SCHD", "yahoo_finance_etf", ("1d", "1w")),
+    ("vix", "index", "^VIX", "yahoo_finance_index", ("1d", "1w")),
+    ("bitcoin", "crypto", "BTC", "binance_spot_public", ("1d", "1w", "4h")),
+    ("shanghai", "index", "sh000001", "tencent_kline", ("1d", "1w")),
+    ("star50", "index", "sh000688", "tencent_kline", ("1d", "1w")),
+    ("china_dividend", "index", "sh000015", "tencent_kline", ("1d", "1w")),
+    ("nikkei", "index", "^N225", "yahoo_finance_index", ("1d", "1w")),
+    ("kospi", "index", "^KS11", "yahoo_finance_index", ("1d", "1w")),
+    ("wti", "commodity", "CL=F", "yahoo_finance_futures", ("1d", "1w", "4h")),
+    ("gold", "commodity", "GC=F", "yahoo_finance_futures", ("1d", "1w", "4h")),
+    ("silver", "commodity", "SI=F", "yahoo_finance_futures", ("1d", "1w", "4h")),
+)
+
+_EXPECTED_PROVIDER_SYMBOLS = {
+    "dxy": "DX-Y.NYB",
+    "us2y": "2 Yr",
+    "us10y": "10 Yr",
+    "us2s10s": "10 Yr-2 Yr",
+    "sp500": "^GSPC",
+    "nasdaq": "^IXIC",
+    "us_dividend": "SCHD",
+    "vix": "^VIX",
+    "bitcoin": "BTCUSDT",
+    "shanghai": "sh000001",
+    "star50": "sh000688",
+    "china_dividend": "sh000015",
+    "nikkei": "^N225",
+    "kospi": "^KS11",
+    "wti": "CL=F",
+    "gold": "GC=F",
+    "silver": "SI=F",
+}
+
+
+def required_cells() -> tuple[dict[str, Any], ...]:
+    """Return detached matrix cells in stable asset/timeframe order."""
+
+    return tuple(
+        {
+            "asset_key": asset_key,
+            "asset_class": asset_class,
+            "ticker": ticker,
+            "source": source,
+            "timeframe": timeframe,
+            **PHASE1_POLICIES,
+        }
+        for asset_key, asset_class, ticker, source, timeframes in _ASSETS
+        for timeframe in timeframes
+    )
+
+
+def expected_provider_symbol(asset_key: str) -> str:
+    return _EXPECTED_PROVIDER_SYMBOLS[asset_key]
+
+
+def validate_matrix() -> None:
+    """Fail fast if the committed matrix drifts from the 39-cell contract."""
+
+    cells = required_cells()
+    keys = [(cell["asset_key"], cell["timeframe"]) for cell in cells]
+    if len(_ASSETS) != 17:
+        raise ValueError(f"phase1_asset_count:{len(_ASSETS)}")
+    if len(cells) != 39:
+        raise ValueError(f"phase1_cell_count:{len(cells)}")
+    if len(set(keys)) != len(keys):
+        raise ValueError("phase1_duplicate_cells")
+    if _ASSETS != _EXPECTED_ASSETS:
+        raise ValueError("phase1_canonical_asset_tuple_mismatch")
+    actual_sources = {asset[0]: asset[3] for asset in _ASSETS}
+    if actual_sources != _EXPECTED_SOURCES:
+        raise ValueError("phase1_source_registry_mismatch")
+    actual_4h = {asset[0] for asset in _ASSETS if "4h" in asset[4]}
+    if actual_4h != {"dxy", "bitcoin", "wti", "gold", "silver"}:
+        raise ValueError("phase1_4h_registry_mismatch")
+
+
+validate_matrix()

--- a/ops/verify_phase1_matrix.py
+++ b/ops/verify_phase1_matrix.py
@@ -146,6 +146,8 @@ def _health_contract_issues(status: int, health: Any, db_path: str | None = None
                 issues.append(f"health_runtime_{field}_missing")
         if runtime.get("registry_version") != "weekly-macro-phase1-source-registry-v1":
             issues.append("health_registry_version_mismatch")
+        if runtime.get("build_sha") == "unknown":
+            issues.append("health_build_sha_unknown")
         if db_path and isinstance(runtime.get("database_path"), str):
             if Path(runtime["database_path"]).resolve() != Path(db_path).resolve():
                 issues.append("health_database_path_mismatch")

--- a/ops/verify_phase1_matrix.py
+++ b/ops/verify_phase1_matrix.py
@@ -162,6 +162,8 @@ def _health_contract_issues(status: int, health: Any, db_path: str | None = None
             issues.append(f"health_source_availability_basis_invalid:{source}")
         elif type(entry.get("available")) is not bool:
             issues.append(f"health_source_available_invalid:{source}")
+        elif entry.get("availability_basis") == "not_live_probed" and entry.get("available") is not False:
+            issues.append(f"health_source_not_live_status_invalid:{source}")
     return issues
 
 
@@ -266,7 +268,10 @@ def main() -> int:
     args = parser.parse_args()
     receipt = verify(args.base_url, timeout=args.timeout, limit=args.limit, db_path=args.db_path)
     print(json.dumps(receipt, ensure_ascii=False, indent=2))
-    return 0 if not receipt["health_contract_issues"] and receipt["database_unchanged"] is True else 1
+    total_cells = sum(receipt["counts"].values())
+    has_ready = receipt["counts"]["ready"] > 0
+    matrix_valid = len(receipt["cells"]) == 39 and total_cells == 39 and has_ready
+    return 0 if not receipt["health_contract_issues"] and receipt["database_unchanged"] is True and matrix_valid else 1
 
 
 if __name__ == "__main__":

--- a/ops/verify_phase1_matrix.py
+++ b/ops/verify_phase1_matrix.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Read-only HTTP verification for the canonical Phase 1 39-cell matrix.
+
+The script only performs GET requests and writes no database or cache files.
+Run it against a disposable/canonical runtime when a strict no-persistence
+receipt is required; it does not restart services or alter launchd/.env.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sqlite3
+from typing import Any, Mapping
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+try:
+    from .phase1_matrix import PHASE1_MATRIX_VERSION, PHASE1_POLICIES, expected_provider_symbol, required_cells
+except ImportError:  # Direct ``python ops/verify_phase1_matrix.py`` execution.
+    from phase1_matrix import PHASE1_MATRIX_VERSION, PHASE1_POLICIES, expected_provider_symbol, required_cells
+
+
+def _get_json(url: str, *, timeout: float) -> tuple[int, Any]:
+    request = Request(url, headers={"Accept": "application/json"}, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return int(getattr(response, "status", 200)), json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        try:
+            body = json.loads(error.read().decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            body = {"error": type(error).__name__, "detail": str(error)}
+        return int(error.code), body
+    except (URLError, TimeoutError, OSError, ValueError) as error:
+        return 0, {"error": type(error).__name__, "detail": str(error)}
+
+
+def _detail_mapping(payload: Any) -> Mapping[str, Any]:
+    detail = payload.get("detail") if isinstance(payload, Mapping) else payload
+    return detail if isinstance(detail, Mapping) else payload if isinstance(payload, Mapping) else {}
+
+
+def _error_detail(payload: Any) -> tuple[str, str, Mapping[str, Any]]:
+    detail = _detail_mapping(payload)
+    reason = str(detail.get("reject_reason") or detail.get("error") or "http_error")
+    message = str(detail.get("detail") or detail.get("error") or reason)
+    return reason, message, detail
+
+
+def _cell_result(cell: Mapping[str, Any], status: int, payload: Any) -> dict[str, Any]:
+    if status == 200 and isinstance(payload, Mapping):
+        candles = payload.get("candles")
+        reject_reason = payload.get("reject_reason") or (None if isinstance(candles, list) and candles else "empty_data")
+        issues: list[str] = []
+        expected = {
+            "timeframe": cell["timeframe"],
+            "requested_source": cell["source"],
+            "selected_source": cell["source"],
+            "cache_policy": cell["cache_policy"],
+            "quality_policy": cell["quality_policy"],
+            "fallback_policy": cell["fallback_policy"],
+            "served_from": "upstream",
+            "is_synthetic": False,
+        }
+        for field, value in expected.items():
+            if payload.get(field) != value:
+                issues.append(f"{field}_mismatch")
+        if payload.get("attempted_sources") != [cell["source"]]:
+            issues.append("attempted_sources_mismatch")
+        expected_symbol = expected_provider_symbol(cell["asset_key"])
+        if payload.get("provider_symbol") != expected_symbol:
+            issues.append("provider_symbol_mismatch")
+        if not isinstance(payload.get("source_identity"), Mapping) or not payload["source_identity"]:
+            issues.append("source_identity_missing")
+        if cell["timeframe"] == "4h":
+            if payload.get("raw_timeframe") not in {"1h", "4h"}:
+                issues.append("raw_timeframe_missing")
+            if payload.get("timeframe_origin") not in {"native", "aggregated"}:
+                issues.append("timeframe_origin_missing")
+            if not isinstance(payload.get("aggregation"), Mapping) or not payload["aggregation"]:
+                issues.append("aggregation_missing")
+        if issues and isinstance(candles, list) and candles:
+            reject_reason = f"contract_mismatch:{issues[0]}"
+        cell_status = "ready" if isinstance(candles, list) and candles and not reject_reason and not issues else "blocked"
+        return {
+            **cell,
+            "status": cell_status,
+            "http_status": status,
+            "count": len(candles) if isinstance(candles, list) else 0,
+            "provider": payload.get("provider"),
+            "provider_symbol": payload.get("provider_symbol"),
+            "selected_source": payload.get("selected_source"),
+            "requested_source": payload.get("requested_source"),
+            "raw_timeframe": payload.get("raw_timeframe"),
+            "timeframe_origin": payload.get("timeframe_origin"),
+            "source_identity": payload.get("source_identity") or {},
+            "reject_reason": reject_reason,
+            "access_issues": [*payload.get("access_issues", []), *issues],
+            "attempted_sources": payload.get("attempted_sources") or [],
+            "served_from": payload.get("served_from"),
+            "cache_policy": payload.get("cache_policy"),
+            "quality_policy": payload.get("quality_policy"),
+            "fallback_policy": payload.get("fallback_policy"),
+        }
+    reason, message, detail = _error_detail(payload)
+    return {
+        **cell,
+        "status": "unavailable" if status in {0, 404} else "blocked",
+        "http_status": status,
+        "count": 0,
+        "provider": None,
+        "provider_symbol": detail.get("provider_symbol") or cell["ticker"],
+        "selected_source": detail.get("selected_source"),
+        "requested_source": detail.get("requested_source") or cell["source"],
+        "raw_timeframe": detail.get("raw_timeframe"),
+        "timeframe_origin": detail.get("timeframe_origin"),
+        "source_identity": {
+            **(dict(detail.get("source_identity")) if isinstance(detail.get("source_identity"), Mapping) else {}),
+            "requested_source": cell["source"],
+            "requested_ticker": cell["ticker"],
+        },
+        "reject_reason": reason,
+        "access_issues": [message],
+        "attempted_sources": detail.get("attempted_sources") or [cell["source"]],
+        "served_from": detail.get("served_from"),
+        "quality_policy": detail.get("quality_policy") or cell["quality_policy"],
+        "fallback_policy": detail.get("fallback_policy") or cell["fallback_policy"],
+        "cache_policy": detail.get("cache_policy") or cell["cache_policy"],
+    }
+
+
+def _health_contract_issues(status: int, health: Any, db_path: str | None = None) -> list[str]:
+    if status != 200 or not isinstance(health, Mapping):
+        return ["health_unavailable"]
+    issues: list[str] = []
+    runtime = health.get("runtime")
+    if not isinstance(runtime, Mapping):
+        issues.append("health_runtime_missing")
+    else:
+        for field in ("build_sha", "runtime_root", "module_root", "registry_version", "database_path"):
+            if not isinstance(runtime.get(field), str) or not runtime[field].strip():
+                issues.append(f"health_runtime_{field}_missing")
+        if runtime.get("registry_version") != "weekly-macro-phase1-source-registry-v1":
+            issues.append("health_registry_version_mismatch")
+        if db_path and isinstance(runtime.get("database_path"), str):
+            if Path(runtime["database_path"]).resolve() != Path(db_path).resolve():
+                issues.append("health_database_path_mismatch")
+    sources = ((health.get("providers") or {}).get("sources") if isinstance(health.get("providers"), Mapping) else None)
+    if not isinstance(sources, Mapping):
+        return [*issues, "health_sources_missing"]
+    for source in sorted({cell["source"] for cell in required_cells()}):
+        entry = sources.get(source)
+        if not isinstance(entry, Mapping):
+            issues.append(f"health_source_missing:{source}")
+        elif entry.get("configured") is not True:
+            issues.append(f"health_source_not_configured:{source}")
+        elif entry.get("availability_basis") not in {"not_live_probed", "live_probe"}:
+            issues.append(f"health_source_availability_basis_invalid:{source}")
+        elif type(entry.get("available")) is not bool:
+            issues.append(f"health_source_available_invalid:{source}")
+    return issues
+
+
+def _database_receipt(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    database = Path(path)
+    if not database.exists():
+        return {"exists": False, "verified": False}
+    try:
+        uri = f"file:{database.resolve()}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as connection:
+            counts = {}
+            for table in ("klines", "source_observations", "raw_upstream_responses"):
+                try:
+                    counts[table] = int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+                except sqlite3.Error:
+                    counts[table] = None
+        verified = all(isinstance(counts.get(table), int) for table in ("klines", "source_observations", "raw_upstream_responses"))
+        return {"exists": True, "verified": verified, "counts": counts}
+    except sqlite3.Error as error:
+        return {"exists": True, "verified": False, "error": type(error).__name__}
+
+
+def verify(
+    base_url: str,
+    *,
+    timeout: float = 30.0,
+    limit: int = 3,
+    db_path: str | None = None,
+) -> dict[str, Any]:
+    base = base_url.rstrip("/")
+    database_before = _database_receipt(db_path)
+    health_status, health = _get_json(f"{base}/api/health", timeout=timeout)
+    results: list[dict[str, Any]] = []
+    health_issues = _health_contract_issues(health_status, health, db_path)
+    for cell in required_cells():
+        if health_issues:
+            result = _cell_result(
+                cell,
+                503,
+                {
+                    "error": "health_contract_invalid",
+                    "detail": {
+                        "reject_reason": ";".join(health_issues),
+                        "source_identity": {"health_registry": "invalid"},
+                    },
+                },
+            )
+            results.append(result)
+            continue
+        query = {
+            "timeframe": cell["timeframe"],
+            "source": cell["source"],
+            "cache_policy": PHASE1_POLICIES["cache_policy"],
+            "quality": PHASE1_POLICIES["quality"],
+            "fallback_policy": PHASE1_POLICIES["fallback_policy"],
+            "limit": str(limit),
+        }
+        path = f"/api/candles/{cell['asset_class']}/{cell['ticker']}?{urlencode(query)}"
+        status, payload = _get_json(f"{base}{path}", timeout=timeout)
+        results.append(_cell_result(cell, status, payload))
+
+    counts = {
+        state: sum(1 for result in results if result["status"] == state)
+        for state in ("ready", "unavailable", "blocked")
+    }
+    database_after = _database_receipt(db_path)
+    return {
+        "schema_version": "phase1-matrix-receipt-v1",
+        "matrix_version": PHASE1_MATRIX_VERSION,
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "base_url": base,
+        "health_http_status": health_status,
+        "health_contract_issues": health_issues,
+        "runtime": health.get("runtime") if isinstance(health, Mapping) else None,
+        "health": health,
+        "counts": counts,
+        "cells": results,
+        "read_only_tool": True,
+        "database_before": database_before,
+        "database_after": database_after,
+        "database_unchanged": (
+            database_before == database_after
+            if (
+                database_before is not None
+                and database_after is not None
+                and database_before.get("verified") is True
+                and database_after.get("verified") is True
+            )
+            else None
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--db-path", required=True)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--limit", type=int, default=3)
+    args = parser.parse_args()
+    receipt = verify(args.base_url, timeout=args.timeout, limit=args.limit, db_path=args.db_path)
+    print(json.dumps(receipt, ensure_ascii=False, indent=2))
+    return 0 if not receipt["health_contract_issues"] and receipt["database_unchanged"] is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -30,7 +30,7 @@ from kline.provenance import (
     source_manifest,
 )
 from kline.quality import QualityReport, analyze_candles
-from kline.registry import get_adapter_for_source, get_store, provider_status
+from kline.registry import get_adapter_for_source, get_store, provider_status, runtime_status
 
 router = APIRouter()
 
@@ -488,61 +488,69 @@ async def _fetch_upstream_candles(
             if adapter is not None:
                 last_transform = getattr(adapter, "timeframe_transform", None)
                 last_identity = dict(getattr(adapter, "source_identity", None) or {})
-                _save_raw_if_available(
-                    adapter=adapter,
+            if policy.cache_policy != CachePolicy.BYPASS:
+                if adapter is not None:
+                    _save_raw_if_available(
+                        adapter=adapter,
+                        ticker=selected_ticker,
+                        asset_class=asset_class,
+                        timeframe=timeframe,
+                        meta=selected_meta,
+                        served_from="upstream",
+                        raw_response=raw_snapshot,
+                    )
+                get_store().save_source_observation(
+                    source_id=selected_source,
+                    provider=selected_meta.name,
                     ticker=selected_ticker,
                     asset_class=asset_class,
                     timeframe=timeframe,
-                    meta=selected_meta,
-                    served_from="upstream",
-                    raw_response=raw_snapshot,
+                    success=False,
+                    candle_count=0,
+                    latest_timestamp=None,
+                    latency_ms=(monotonic() - started_at) * 1000,
+                    quality_flags=list(selected_meta.quality_flags),
+                    error=str(error),
                 )
+            continue
+
+        if policy.cache_policy != CachePolicy.BYPASS:
+            _save_raw_if_available(
+                adapter=adapter,
+                ticker=selected_ticker,
+                asset_class=asset_class,
+                timeframe=timeframe,
+                meta=selected_meta,
+                served_from="upstream",
+                raw_response=raw_snapshot,
+            )
+        report = analyze_candles(
+            candles, timeframe, selected_meta, strict=policy.strict_quality
+        )
+        last_report = report
+        if policy.cache_policy != CachePolicy.BYPASS:
             get_store().save_source_observation(
                 source_id=selected_source,
                 provider=selected_meta.name,
                 ticker=selected_ticker,
                 asset_class=asset_class,
                 timeframe=timeframe,
-                success=False,
-                candle_count=0,
-                latest_timestamp=None,
+                success=report.reject_reason is None,
+                candle_count=len(candles),
+                latest_timestamp=report.latest_timestamp,
                 latency_ms=(monotonic() - started_at) * 1000,
-                quality_flags=list(selected_meta.quality_flags),
-                error=str(error),
+                quality_flags=_dedupe([*selected_meta.quality_flags, *report.quality_flags]),
+                error=report.reject_reason,
             )
-            continue
-
-        _save_raw_if_available(
-            adapter=adapter,
-            ticker=selected_ticker,
-            asset_class=asset_class,
-            timeframe=timeframe,
-            meta=selected_meta,
-            served_from="upstream",
-            raw_response=raw_snapshot,
-        )
-        report = analyze_candles(
-            candles, timeframe, selected_meta, strict=policy.strict_quality
-        )
-        last_report = report
-        get_store().save_source_observation(
-            source_id=selected_source,
-            provider=selected_meta.name,
-            ticker=selected_ticker,
-            asset_class=asset_class,
-            timeframe=timeframe,
-            success=report.reject_reason is None,
-            candle_count=len(candles),
-            latest_timestamp=report.latest_timestamp,
-            latency_ms=(monotonic() - started_at) * 1000,
-            quality_flags=_dedupe([*selected_meta.quality_flags, *report.quality_flags]),
-            error=report.reject_reason,
-        )
         if report.reject_reason:
             failures.append(f"{selected_source}: {report.reject_reason}")
             continue
 
-        if candles and timeframe not in (Timeframe.DAY, Timeframe.WEEK, Timeframe.HOUR_4):
+        if (
+            policy.cache_policy != CachePolicy.BYPASS
+            and candles
+            and timeframe not in (Timeframe.DAY, Timeframe.WEEK, Timeframe.HOUR_4)
+        ):
             get_store().save(
                 selected_ticker,
                 asset_class,
@@ -1069,6 +1077,7 @@ async def health() -> dict:
         "status": "ok",
         "service": "kline",
         "version": __version__,
+        "runtime": runtime_status(),
         "providers": provider_status(),
         "storage": get_store().storage_health(),
         "storage_coverage": coverage,

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -874,7 +874,7 @@ async def stream_candles(
 
     try:
         async for candle in adapter.stream_candles(ticker, timeframe):
-            if timeframe not in (Timeframe.DAY, Timeframe.HOUR_4, Timeframe.WEEK):
+            if policy.cache_policy != CachePolicy.BYPASS and timeframe not in (Timeframe.DAY, Timeframe.HOUR_4, Timeframe.WEEK):
                 get_store().save(
                     ticker,
                     asset_class,

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -28,6 +28,8 @@ _TF_SECONDS: dict[Timeframe, int] = {
     Timeframe.WEEK: 604_800,
 }
 
+PHASE1_SOURCE_REGISTRY_VERSION = "weekly-macro-phase1-source-registry-v1"
+
 # A continuous-market bar is considered fresh within this many bar-intervals.
 _FRESH_BAR_MULTIPLE = 3
 

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -267,5 +267,5 @@ def runtime_status() -> dict[str, str]:
         "build_sha": build_sha,
         "registry_version": PHASE1_SOURCE_REGISTRY_VERSION,
         "database_path": str(Path(settings.db_path).resolve()),
-        "identity_status": "verified" if build_sha != "unknown" else "partial",
+        "identity_status": "declared" if build_sha != "unknown" else "unknown",
     }

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 from kline.config import Settings, ensure_data_dir, get_settings
 from kline.models import AssetClass, Timeframe
 from kline.plugin_loader import load_configured_adapters, load_entrypoint_adapters
@@ -20,10 +23,12 @@ from kline.provenance import (
     register_source_manifest,
     source_manifest,
     fred_source_manifest,
+    PHASE1_SOURCE_REGISTRY_VERSION,
 )
 from kline.store import KlineStore
 
 _store: KlineStore | None = None
+_settings: Settings | None = None
 _providers: dict[AssetClass, Provider] = {}
 _live_providers: dict[str, Provider] = {}
 _adapters: dict[str, MarketDataPort] = {}
@@ -31,8 +36,9 @@ _adapters: dict[str, MarketDataPort] = {}
 
 def init(settings: Settings | None = None) -> None:
     """Initialize store and providers. Called once at app startup."""
-    global _store, _providers, _live_providers, _adapters
+    global _store, _providers, _live_providers, _adapters, _settings
     s = settings or get_settings()
+    _settings = s
     ensure_data_dir(s)
 
     _store = KlineStore(s.db_path)
@@ -224,7 +230,9 @@ def provider_status() -> dict:
                 else []
             )
         sources[source_id] = {
-            "available": adapter is not None,
+            "available": False,
+            "configured": adapter is not None,
+            "availability_basis": "not_live_probed",
             "asset_class": manifest.asset_class.value,
             "provider": meta.name,
             "source_mode": meta.source_mode,
@@ -241,3 +249,23 @@ def provider_status() -> dict:
         }
 
     return {"sources": sources}
+
+
+def runtime_status() -> dict[str, str]:
+    """Return runtime/build identity without probing or mutating external state."""
+
+    from kline import __version__
+
+    settings = _settings or get_settings()
+    build_sha = os.environ.get("KLINE_BUILD_SHA", "").strip() or "unknown"
+    runtime_root = os.environ.get("KLINE_RUNTIME_ROOT", "").strip()
+    return {
+        "service_version": __version__,
+        "runtime_root": runtime_root or str(Path.cwd().resolve()),
+        "module_root": str(Path(__file__).resolve().parents[2]),
+        "working_directory": str(Path.cwd().resolve()),
+        "build_sha": build_sha,
+        "registry_version": PHASE1_SOURCE_REGISTRY_VERSION,
+        "database_path": str(Path(settings.db_path).resolve()),
+        "identity_status": "verified" if build_sha != "unknown" else "partial",
+    }

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -412,12 +412,14 @@ async def test_explicit_fallback_is_visible_and_source_scoped(monkeypatch, store
     assert response.instrument_id == "GOLD"
     assert response.provider_symbol == "GC=F"
     assert any("primary unavailable" in issue for issue in response.access_issues)
+    # bypass is read-only: explicit fallback remains visible in the envelope,
+    # but neither attempted source writes cache rows.
     assert store.count(
         "GC=F",
         AssetClass.COMMODITY,
         Timeframe.MIN_1,
         source_id="yahoo_finance_futures",
-    ) == 1
+    ) == 0
     assert store.count(
         "XAUUSDT",
         AssetClass.COMMODITY,

--- a/tests/test_phase1_matrix.py
+++ b/tests/test_phase1_matrix.py
@@ -1,0 +1,136 @@
+"""Contract tests for the canonical Phase 1 17-asset / 39-cell matrix."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kline.api import get_candles, health
+from kline.config import Settings
+from kline.models import AssetClass, CachePolicy, Candle, FallbackPolicy, QualityPolicy, Timeframe
+from kline.ports import ProviderBackedMarketDataAdapter
+from kline.provenance import source_manifest
+from kline.registry import init, provider_status
+from kline.store import KlineStore
+from ops.phase1_matrix import PHASE1_MATRIX_VERSION, PHASE1_POLICIES, required_cells, validate_matrix
+from ops.verify_phase1_matrix import _cell_result, _health_contract_issues
+
+
+def test_phase1_matrix_has_exactly_17_assets_and_39_unique_cells():
+    validate_matrix()
+    cells = required_cells()
+
+    assert PHASE1_MATRIX_VERSION == "weekly-macro-phase1-39-cell-v1"
+    assert len({cell["asset_key"] for cell in cells}) == 17
+    assert len(cells) == 39
+    assert len({(cell["asset_key"], cell["timeframe"]) for cell in cells}) == 39
+    assert all(
+        {key: cell[key] for key in PHASE1_POLICIES} == PHASE1_POLICIES
+        for cell in cells
+    )
+
+
+def test_matrix_verifier_does_not_promote_wrong_policy_or_empty_200_to_ready():
+    cell = required_cells()[0]
+    wrong_policy = {
+        "candles": [{"timestamp": "2026-08-19", "open": 1, "high": 1, "low": 1, "close": 1}],
+        "requested_source": cell["source"],
+        "selected_source": cell["source"],
+        "cache_policy": "allow",
+        "quality_policy": "strict",
+        "fallback_policy": "none",
+        "served_from": "cache",
+        "attempted_sources": [cell["source"]],
+        "provider": "provider",
+        "provider_symbol": cell["ticker"],
+        "source_identity": {"provider": "provider"},
+    }
+    result = _cell_result(cell, 200, wrong_policy)
+    assert result["status"] == "blocked"
+    assert result["reject_reason"].startswith("contract_mismatch:")
+
+    empty = _cell_result(cell, 200, {"candles": [], "requested_source": cell["source"]})
+    assert empty["status"] == "blocked"
+    assert empty["reject_reason"] == "empty_data"
+
+
+def test_phase1_matrix_sources_and_timeframes_match_local_health(tmp_path):
+    init(Settings(db_path=str(tmp_path / "health.db"), load_entrypoint_adapters=False))
+    sources = provider_status()["sources"]
+
+    for cell in required_cells():
+        source = sources[cell["source"]]
+        assert source["available"] is False, cell
+        assert source["configured"] is True, cell
+        assert source["availability_basis"] == "not_live_probed"
+        manifest = source_manifest(cell["source"], AssetClass(cell["asset_class"]))
+        provider_symbol = manifest.canonical_ticker(cell["ticker"]).upper()
+        by_symbol = source["supported_timeframes_by_symbol"]
+        assert cell["timeframe"] in by_symbol[provider_symbol], cell
+
+
+@pytest.mark.asyncio
+async def test_bypass_matrix_policy_does_not_persist_cache_or_audit_rows(monkeypatch, tmp_path):
+    class Provider:
+        last_raw_response = {
+            "request_params": {"symbol": "BTCUSDT"},
+            "response_body": [["raw"]],
+            "status_code": 200,
+            "error": None,
+        }
+
+        def supported_timeframes(self):
+            return [Timeframe.MIN_1]
+
+        async def fetch(self, *_args, **_kwargs):
+            timestamp = datetime.now(timezone.utc).replace(second=0, microsecond=0).isoformat()
+            return [Candle(timestamp=timestamp, open=100, high=101, low=99, close=100.5, volume=10)]
+
+    store = KlineStore(str(tmp_path / "bypass.db"))
+    adapter = ProviderBackedMarketDataAdapter(
+        source_manifest("binance_spot_public", AssetClass.CRYPTO),
+        Provider(),
+    )
+    monkeypatch.setattr("kline.api.get_store", lambda: store)
+    monkeypatch.setattr("kline.api.get_adapter_for_source", lambda *_args: adapter)
+    before = (store.count_raw_responses(), len(store.latest_source_observations()))
+
+    response = await get_candles(
+        asset_class=AssetClass.CRYPTO,
+        ticker="BTC",
+        timeframe=Timeframe.MIN_1,
+        start=None,
+        end=None,
+        limit=1,
+        refresh=False,
+        source="binance_spot_public",
+        cache_policy=CachePolicy.BYPASS,
+        quality=QualityPolicy.STRICT,
+        fallback_policy=FallbackPolicy.NONE,
+        require_execution_venue=False,
+        profile=None,
+        strict=False,
+        mode="research",
+    )
+
+    after = (store.count_raw_responses(), len(store.latest_source_observations()))
+    assert response.served_from == "upstream"
+    assert before == after
+    assert store.count("BTCUSDT", AssetClass.CRYPTO, Timeframe.MIN_1, source_id="binance_spot_public") == 0
+
+
+@pytest.mark.asyncio
+async def test_health_exposes_runtime_and_registry_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("KLINE_BUILD_SHA", "test-phase1-sha")
+    init(Settings(db_path=str(tmp_path / "health.db"), load_entrypoint_adapters=False))
+
+    payload = await health()
+
+    assert payload["runtime"]["build_sha"] == "test-phase1-sha"
+    assert payload["runtime"]["registry_version"] == "weekly-macro-phase1-source-registry-v1"
+    assert payload["runtime"]["identity_status"] == "verified"
+    assert payload["runtime"]["database_path"].endswith("health.db")
+    assert payload["providers"]["sources"]["tencent_kline"]["availability_basis"] == "not_live_probed"
+    assert payload["providers"]["sources"]["treasury_official_csv"]["availability_basis"] == "not_live_probed"
+    assert _health_contract_issues(200, payload) == []

--- a/tests/test_phase1_matrix.py
+++ b/tests/test_phase1_matrix.py
@@ -129,7 +129,7 @@ async def test_health_exposes_runtime_and_registry_identity(tmp_path, monkeypatc
 
     assert payload["runtime"]["build_sha"] == "test-phase1-sha"
     assert payload["runtime"]["registry_version"] == "weekly-macro-phase1-source-registry-v1"
-    assert payload["runtime"]["identity_status"] == "verified"
+    assert payload["runtime"]["identity_status"] == "declared"
     assert payload["runtime"]["database_path"].endswith("health.db")
     assert payload["providers"]["sources"]["tencent_kline"]["availability_basis"] == "not_live_probed"
     assert payload["providers"]["sources"]["treasury_official_csv"]["availability_basis"] == "not_live_probed"

--- a/tests/test_phase1_matrix.py
+++ b/tests/test_phase1_matrix.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from kline.api import get_candles, health
+from kline.api import get_candles, health, stream_candles
 from kline.config import Settings
 from kline.models import AssetClass, CachePolicy, Candle, FallbackPolicy, QualityPolicy, Timeframe
 from kline.ports import ProviderBackedMarketDataAdapter
@@ -118,6 +118,52 @@ async def test_bypass_matrix_policy_does_not_persist_cache_or_audit_rows(monkeyp
     assert response.served_from == "upstream"
     assert before == after
     assert store.count("BTCUSDT", AssetClass.CRYPTO, Timeframe.MIN_1, source_id="binance_spot_public") == 0
+
+
+@pytest.mark.asyncio
+async def test_websocket_bypass_stream_does_not_persist_candles(monkeypatch, tmp_path):
+    class StreamAdapter:
+        async def stream_candles(self, *_args, **_kwargs):
+            yield Candle(
+                timestamp=datetime.now(timezone.utc).replace(second=0, microsecond=0).isoformat(),
+                open=100,
+                high=101,
+                low=99,
+                close=100.5,
+                volume=10,
+            )
+
+    class WebSocket:
+        def __init__(self):
+            self.messages = []
+
+        async def accept(self):
+            return None
+
+        async def send_json(self, payload):
+            self.messages.append(payload)
+
+        async def close(self, **_kwargs):
+            return None
+
+    store = KlineStore(str(tmp_path / "websocket.db"))
+    monkeypatch.setattr("kline.api.get_store", lambda: store)
+    monkeypatch.setattr("kline.api.get_adapter_for_source", lambda *_args: StreamAdapter())
+    websocket = WebSocket()
+
+    await stream_candles(
+        websocket,
+        AssetClass.CRYPTO,
+        "BTC",
+        timeframe=Timeframe.MIN_1,
+        source="binance_spot_public",
+        quality=QualityPolicy.STRICT,
+    )
+
+    assert websocket.messages[0]["cache_policy"] == "bypass"
+    assert store.count("BTC", AssetClass.CRYPTO, Timeframe.MIN_1, source_id="binance_spot_public") == 0
+    assert store.count_raw_responses() == 0
+    assert store.latest_source_observations() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
- Add the 17-asset × required-timeframe phase-1 health matrix runner and verifier.
- Preserve per-cell readiness, provider/source identity, policy, and failure metadata.
- Add read-only HTTP matrix evidence with committed observation receipt.

## Why
The Weekly Macro K-line data base needs an explicit coverage receipt instead of a binary health signal, while strict/no-fallback/bypass semantics must remain observable and database writes must be excluded from verification.

## Validation
- Full datafeed tests: 121 passed
- Matrix receipt: 39 cells, 31 ready, 8 blocked, 0 unavailable
- Temporary HTTP runtime proof: `database_unchanged=true`; SQLite before/after counts remain zero
- `health_contract_issues=[]`; runtime registry `weekly-macro-phase1-source-registry-v1`
- Ruff, diff check, and gitleaks clean

## Scope
Matrix verification uses an isolated temporary port/database. No launchd, `.env`, resident 8100 service, or production database changes.

Closes #13