### PR TITLE
fix: bound Yahoo default history window

### DIFF
--- a/src/kline/providers/us.py
+++ b/src/kline/providers/us.py
@@ -26,15 +26,18 @@ _TF_MAP = {
     Timeframe.WEEK: "1wk",
 }
 
-# yfinance period limits per interval
-_MAX_PERIOD = {
+# yfinance period limits per interval.  Yahoo's ``max`` history can contain
+# malformed legacy OHLC rows for otherwise healthy instruments.  The default
+# window is intentionally bounded; callers that need an exact historical
+# range must provide both ``start`` and ``end``.
+_DEFAULT_PERIOD = {
     Timeframe.MIN_1: "7d",
     Timeframe.MIN_5: "60d",
     Timeframe.MIN_15: "60d",
     Timeframe.MIN_30: "60d",
     Timeframe.HOUR_1: "730d",
-    Timeframe.DAY: "max",
-    Timeframe.WEEK: "max",
+    Timeframe.DAY: "5y",
+    Timeframe.WEEK: "5y",
 }
 
 
@@ -177,7 +180,9 @@ class USStockProvider:
                 kwargs["start"] = start
                 kwargs["end"] = end
             else:
-                kwargs["period"] = _MAX_PERIOD.get(timeframe, "2y")
+                period = _DEFAULT_PERIOD.get(timeframe, "2y")
+                kwargs["period"] = period
+                request_params["period"] = period
             df = stock.history(**kwargs)
         except Exception as e:
             self.last_raw_response["error"] = str(e)

--- a/tests/test_timeframe_contract.py
+++ b/tests/test_timeframe_contract.py
@@ -117,6 +117,60 @@ async def test_yahoo_daily_excludes_current_calendar_day(monkeypatch):
     assert [item.timestamp for item in candles] == [(today - timedelta(days=1)).isoformat()]
 
 
+@pytest.mark.asyncio
+async def test_yahoo_default_daily_history_is_bounded_and_recorded(monkeypatch):
+    yesterday = date.today() - timedelta(days=1)
+    calls: dict = {}
+
+    class FakeTicker:
+        def history(self, **kwargs):
+            calls.update(kwargs)
+            return _daily_frame(
+                [(yesterday.isoformat(), 100, 105, 99, 104)],
+            )
+
+    monkeypatch.setattr("kline.providers.us.yf.Ticker", lambda ticker: FakeTicker())
+    provider = USStockProvider()
+
+    candles = await provider.fetch("SCHD", Timeframe.DAY, limit=10)
+
+    assert len(candles) == 1
+    assert calls["interval"] == "1d"
+    assert calls["period"] == "5y"
+    assert provider.last_raw_response is not None
+    assert provider.last_raw_response["request_params"]["period"] == "5y"
+
+
+@pytest.mark.asyncio
+async def test_yahoo_explicit_range_does_not_add_default_period(monkeypatch):
+    calls: dict = {}
+
+    class FakeTicker:
+        def history(self, **kwargs):
+            calls.update(kwargs)
+            return _daily_frame(
+                [("2026-08-18", 100, 105, 99, 104)],
+            )
+
+    monkeypatch.setattr("kline.providers.us.yf.Ticker", lambda ticker: FakeTicker())
+    provider = USStockProvider()
+
+    await provider.fetch(
+        "CL=F",
+        Timeframe.DAY,
+        start="2026-08-18",
+        end="2026-08-19",
+        limit=10,
+    )
+
+    assert calls["interval"] == "1d"
+    assert calls["start"] == "2026-08-18"
+    assert calls["end"] == "2026-08-19"
+    assert "period" not in calls
+    assert provider.last_raw_response is not None
+    assert "period" not in provider.last_raw_response["request_params"]
+
+
 def test_yahoo_symbol_timeframe_allowlist_is_explicit():
     index = source_manifest("yahoo_finance_index", AssetClass.INDEX)
     etf = source_manifest("yahoo_finance_etf", AssetClass.ETF)


### PR DESCRIPTION
## What
- Bound default Yahoo history requests to a five-year window instead of `period=max`.
- Preserve explicit `start`/`end` ranges without adding the default period.
- Record the effective default period in raw request provenance.

## Why
Yahoo historical responses for SCHD and commodity futures contain malformed legacy rows outside the current research window. Validating the entire `max` response blocked otherwise current daily/weekly candles.

## Validation
- Full datafeed tests: 123 passed
- Ruff and gitleaks clean
- Real isolated HTTP smoke: SCHD, CL=F, GC=F, SI=F daily/weekly all returned upstream candles with typed native/weekly aggregation metadata
- Full 39-cell isolated matrix: 38 ready, 1 unavailable (Tencent sh000015 timeout), 0 blocked; `health_contract_issues=[]`; `database_unchanged=true`

## Scope
No fallback, source switching, A-share, launchd, `.env`, database, or trading changes.

Closes #19