### PR TITLE
Add research crypto futures sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ fail TuShare-only A-share no token → setup instructions; Phase 1 indices need 
 Built-in sources: `tushare_pro`, `tencent_kline`, `sina_index`,
 `treasury_official_csv`, `treasury_official_csv_derived`, `yahoo_finance`,
 `yahoo_finance_index`, `yahoo_finance_etf`, `yahoo_finance_futures`,
-`binance_spot_public`, `binance_usdm_futures`, and the FRED macro/flow/event adapters.
+`binance_spot_public`, `binance_usdm_futures`, `binance_usdm_futures_research`,
+`hyperliquid_perpetual_public`, and the FRED macro/flow/event adapters.
 Tiger OpenAPI and OANDA v20 are credential-backed config adapters; see
 `configs/adapters.example.json`.
 
@@ -377,6 +378,8 @@ python -m kline
 | `yahoo_finance_futures` | `commodity` | Yahoo Finance | continuous futures contract | false | false | CL=F/GC=F/SI=F: 1m, 5m, 15m, 30m, 1h, 4h, 1d, 1w; other aliases: 1d, 1w |
 | `binance_spot_public` | `crypto` | Binance Spot API | spot | true | false | BTC/BTCUSDT: 1m, 5m, 15m, 30m, 1h, 4h, 1d, 1w; other symbols: no Phase 1 4h guarantee |
 | `binance_usdm_futures` | `commodity` | Binance USD-M Futures | USD-M futures | true | true | XAUUSDT: 1m, 5m, 15m, 30m, 1h, 4h |
+| `binance_usdm_futures_research` | `crypto` | Binance USD-M Futures | USD-M perpetuals | true | false | BTCUSDT/ETHUSDT: 4h, 1d, 1w |
+| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | HYPE: 4h, 1d, 1w |
 
 ## 技术栈
 
@@ -448,7 +451,7 @@ capability:
     - "quality=strict + source down/empty/stale/gap/out-of-order → error or blocked envelope"
     - "timeframe not supported → supported timeframes list"
     - "TuShare-only A-share request without token → setup instructions; Phase 1 index sources do not require TuShare"
-  sources: [tushare_pro, tencent_kline, sina_index, treasury_official_csv, treasury_official_csv_derived, yahoo_finance, yahoo_finance_index, yahoo_finance_etf, yahoo_finance_futures, binance_spot_public, binance_usdm_futures, fred_public_csv_macro, fred_public_csv_flow, fred_public_csv_event]
+  sources: [tushare_pro, tencent_kline, sina_index, treasury_official_csv, treasury_official_csv_derived, yahoo_finance, yahoo_finance_index, yahoo_finance_etf, yahoo_finance_futures, binance_spot_public, binance_usdm_futures, binance_usdm_futures_research, hyperliquid_perpetual_public, fred_public_csv_macro, fred_public_csv_flow, fred_public_csv_event]
 api_base_url: http://localhost:8100
 endpoints:
   - path: /api/instruments/{asset_class}/{ticker}
@@ -481,7 +484,7 @@ endpoints:
         default: 500
       - name: source
         type: string
-        enum: [auto, tushare_pro, yahoo_finance, yahoo_finance_index, yahoo_finance_etf, yahoo_finance_futures, binance_spot_public, binance_usdm_futures]
+        enum: [auto, tushare_pro, yahoo_finance, yahoo_finance_index, yahoo_finance_etf, yahoo_finance_futures, binance_spot_public, binance_usdm_futures, binance_usdm_futures_research, hyperliquid_perpetual_public]
         default: auto
       - name: cache_policy
         type: string

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -74,6 +74,28 @@ _PROVIDER_META: dict[AssetClass, ProviderMeta] = {
     ),
 }
 
+BINANCE_USDM_RESEARCH_META = ProviderMeta(
+    name="binance_usdm_futures",
+    source_mode="binance_usdm_futures_research",
+    quality_flags=("public_api", "usd_m_futures", "research_only", "not_execution_venue"),
+    continuous=True,
+    execution_venue=False,
+    realtime_supported=True,
+    market_type="usd_m_futures",
+    supported_symbols=("BTCUSDT", "ETHUSDT"),
+)
+
+HYPERLIQUID_PERP_META = ProviderMeta(
+    name="hyperliquid",
+    source_mode="hyperliquid_perpetual_public",
+    quality_flags=("public_api", "perpetual", "research_only", "not_execution_venue"),
+    continuous=True,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="perpetual_futures",
+    supported_symbols=("HYPE",),
+)
+
 BINANCE_USDM_FUTURES_META = ProviderMeta(
     name="binance_usdm_futures",
     source_mode="binance_usdm_futures",
@@ -102,6 +124,10 @@ _SOURCE_ALIASES = {
     "binance_spot_public": "binance_spot_public",
     "binance_usdm": "binance_usdm_futures",
     "binance_usdm_futures": "binance_usdm_futures",
+    "binance_usdm_futures_research": "binance_usdm_futures_research",
+    "binance_futures_research": "binance_usdm_futures_research",
+    "hyperliquid_perpetual_public": "hyperliquid_perpetual_public",
+    "hyperliquid_perp": "hyperliquid_perpetual_public",
     "yahoo": "yahoo",
     "yahoo_finance": "yahoo_finance",
     "yahoo_finance_index": "yahoo_finance_index",
@@ -124,6 +150,8 @@ _SOURCE_ALIASES = {
 _SOURCE_ASSET_CLASSES = {
     "binance_spot_public": AssetClass.CRYPTO,
     "binance_usdm_futures": AssetClass.COMMODITY,
+    "binance_usdm_futures_research": AssetClass.CRYPTO,
+    "hyperliquid_perpetual_public": AssetClass.CRYPTO,
     "yahoo_finance": AssetClass.US_STOCK,
     "yahoo_finance_futures": AssetClass.COMMODITY,
     "tushare_pro": AssetClass.A_SHARE,
@@ -141,6 +169,8 @@ _SOURCE_ASSET_CLASSES = {
 _SOURCE_META = {
     "binance_spot_public": _PROVIDER_META[AssetClass.CRYPTO],
     "binance_usdm_futures": BINANCE_USDM_FUTURES_META,
+    "binance_usdm_futures_research": BINANCE_USDM_RESEARCH_META,
+    "hyperliquid_perpetual_public": HYPERLIQUID_PERP_META,
     "yahoo_finance": _PROVIDER_META[AssetClass.US_STOCK],
     "yahoo_finance_futures": _PROVIDER_META[AssetClass.COMMODITY],
     "tushare_pro": _PROVIDER_META[AssetClass.A_SHARE],
@@ -244,6 +274,39 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         meta=BINANCE_USDM_FUTURES_META,
         ticker_aliases={"GOLD": "XAUUSDT", "XAUUSD": "XAUUSDT", "XAUUSDT": "XAUUSDT"},
         canonical_instrument_ids={"GOLD": "GOLD", "XAUUSD": "GOLD", "XAUUSDT": "GOLD"},
+    ),
+    "binance_usdm_futures_research": SourceManifest(
+        source_id="binance_usdm_futures_research",
+        asset_class=AssetClass.CRYPTO,
+        meta=BINANCE_USDM_RESEARCH_META,
+        default_for_asset_class=False,
+        ticker_aliases={
+            "BTC": "BTCUSDT",
+            "BTCUSDT": "BTCUSDT",
+            "ETH": "ETHUSDT",
+            "ETHUSDT": "ETHUSDT",
+        },
+        canonical_instrument_ids={
+            "BTC": "BTCUSDT.BINANCE",
+            "BTCUSDT": "BTCUSDT.BINANCE",
+            "ETH": "ETHUSDT.BINANCE",
+            "ETHUSDT": "ETHUSDT.BINANCE",
+        },
+        symbol_timeframes={
+            "BTCUSDT": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+            "ETHUSDT": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+        },
+        enforce_symbol_allowlist=True,
+    ),
+    "hyperliquid_perpetual_public": SourceManifest(
+        source_id="hyperliquid_perpetual_public",
+        asset_class=AssetClass.CRYPTO,
+        meta=HYPERLIQUID_PERP_META,
+        default_for_asset_class=False,
+        ticker_aliases={"HYPE": "HYPE"},
+        canonical_instrument_ids={"HYPE": "HYPE.HYPERLIQUID"},
+        symbol_timeframes={"HYPE": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK)},
+        enforce_symbol_allowlist=True,
     ),
     "yahoo_finance": SourceManifest(
         source_id="yahoo_finance",

--- a/src/kline/providers/binance_usdm.py
+++ b/src/kline/providers/binance_usdm.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 from decimal import Decimal
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, AsyncIterator
 
 import httpx
@@ -42,15 +42,20 @@ _ALIASES = {
     "GOLD": "XAUUSDT",
     "XAUUSD": "XAUUSDT",
     "XAUUSDT": "XAUUSDT",
+    "BTC": "BTCUSDT",
+    "BTCUSDT": "BTCUSDT",
+    "ETH": "ETHUSDT",
+    "ETHUSDT": "ETHUSDT",
 }
 
 
-def _normalize_symbol(ticker: str) -> str:
+def _normalize_symbol(ticker: str, allowed_symbols: set[str]) -> str:
     symbol = _ALIASES.get(ticker.upper().strip(), ticker.upper().strip())
-    if symbol != "XAUUSDT":
+    if symbol not in allowed_symbols:
+        enabled = ", ".join(sorted(allowed_symbols))
         raise ProviderError(
-            f"Symbol {ticker} is not enabled for Binance USD-M Futures live mode",
-            suggestions=["Use XAUUSDT for live gold futures candles"],
+            f"Symbol {ticker} is not enabled for Binance USD-M Futures",
+            suggestions=[f"Use one of the explicitly enabled symbols: {enabled}"],
         )
     return symbol
 
@@ -94,6 +99,33 @@ def _candle_from_ws_kline(item: dict[str, Any]) -> Candle:
     )
 
 
+def _aggregate_completed_weeks(candles: list[Candle]) -> list[Candle]:
+    groups: dict[tuple[int, int], list[Candle]] = {}
+    current_date = datetime.now(timezone.utc).date()
+    for candle in candles:
+        stamp = datetime.fromisoformat(candle.timestamp.replace("Z", "+00:00"))
+        if stamp.date() >= current_date:
+            continue
+        iso = stamp.date().isocalendar()
+        groups.setdefault((iso.year, iso.week), []).append(candle)
+    result: list[Candle] = []
+    for _, rows in sorted(groups.items()):
+        if len(rows) < 7:
+            continue
+        result.append(
+            Candle(
+                timestamp=rows[-1].timestamp[:10],
+                open=rows[0].open,
+                high=max(row.high for row in rows),
+                low=min(row.low for row in rows),
+                close=rows[-1].close,
+                volume=sum(row.volume for row in rows),
+                amount=sum(row.amount or 0 for row in rows),
+            )
+        )
+    return result
+
+
 def _decimal_rate_from_percent(value: str) -> str:
     return format(Decimal(value) / Decimal(100), "f")
 
@@ -106,18 +138,22 @@ def _required_filter(filters: list[dict[str, Any]], filter_type: str) -> dict[st
 
 
 class BinanceUsdmFuturesProvider:
-    """Fetch and stream XAUUSDT candles from Binance USD-M Futures."""
+    """Fetch and stream an explicit allowlist from Binance USD-M Futures."""
 
     def __init__(
         self,
         timeout: float = 30,
         transport: httpx.AsyncBaseTransport | None = None,
         websocket_connect: Any | None = None,
+        allowed_symbols: set[str] | None = None,
     ) -> None:
         self._timeout = timeout
         self._transport = transport
         self._websocket_connect = websocket_connect
+        self._allowed_symbols = set(allowed_symbols or {"XAUUSDT"})
         self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform = None
+        self.source_identity: dict[str, Any] = {}
 
     def supported_timeframes(self) -> list[Timeframe]:
         return list(_TF_MAP.keys())
@@ -133,13 +169,39 @@ class BinanceUsdmFuturesProvider:
     ) -> list[Candle]:
         self.last_raw_response = None
         interval = _TF_MAP.get(timeframe)
+        if timeframe == Timeframe.WEEK:
+            symbol = _normalize_symbol(ticker, self._allowed_symbols)
+            daily = await self.fetch(symbol, Timeframe.DAY, start=start, end=end, limit=max(limit * 7 + 8, 100))
+            candles = _aggregate_completed_weeks(daily)
+            if limit:
+                candles = candles[-limit:]
+            if not candles:
+                raise ProviderError(f"No completed weekly data returned for {symbol}")
+            self.timeframe_transform = {
+                "raw_timeframe": Timeframe.DAY.value,
+                "timeframe_origin": "aggregated",
+                "aggregation": {
+                    "kind": "ohlc_resample",
+                    "rule": "completed_iso_week",
+                    "input_timeframe": Timeframe.DAY.value,
+                    "bucket_timezone": "UTC",
+                },
+            }
+            self.source_identity = {"provider_symbol": symbol, "contract_type": "perpetual"}
+            return candles
         if not interval:
             raise ProviderError(
                 f"Timeframe {timeframe.value} not supported for Binance USD-M Futures",
                 suggestions=[f"Supported: {[t.value for t in self.supported_timeframes()]}"],
             )
 
-        symbol = _normalize_symbol(ticker)
+        symbol = _normalize_symbol(ticker, self._allowed_symbols)
+        self.source_identity = {"provider_symbol": symbol, "contract_type": "perpetual"}
+        self.timeframe_transform = {
+            "raw_timeframe": timeframe.value,
+            "timeframe_origin": "native",
+            "aggregation": {"kind": "none", "rule": "native_passthrough"},
+        }
         client_kwargs: dict[str, Any] = {"timeout": self._timeout}
         if self._transport is not None:
             client_kwargs["transport"] = self._transport
@@ -212,7 +274,7 @@ class BinanceUsdmFuturesProvider:
                 suggestions=[f"Supported: {[t.value for t in self.supported_timeframes()]}"],
             )
 
-        symbol = _normalize_symbol(ticker)
+        symbol = _normalize_symbol(ticker, self._allowed_symbols)
         stream_name = f"{symbol.lower()}@kline_{interval}"
         url = f"{BINANCE_USDM_WS_URL}{stream_name}"
 
@@ -249,7 +311,7 @@ class BinanceUsdmFuturesProvider:
             ) from e
 
     async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
-        symbol = _normalize_symbol(ticker)
+        symbol = _normalize_symbol(ticker, self._allowed_symbols)
         params = {"symbol": symbol}
         client_kwargs: dict[str, Any] = {"timeout": self._timeout}
         if self._transport is not None:

--- a/src/kline/providers/hyperliquid.py
+++ b/src/kline/providers/hyperliquid.py
@@ -1,0 +1,200 @@
+"""Hyperliquid public perpetual candles for research-only market context."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import math
+from typing import Any
+
+import httpx
+
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.providers.base import ProviderError
+
+
+HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info"
+
+_TF_MAP = {
+    Timeframe.HOUR_4: ("4h", 4 * 60 * 60 * 1000),
+    Timeframe.DAY: ("1d", 24 * 60 * 60 * 1000),
+}
+
+
+def _parse_bound(value: str | None) -> int | None:
+    if not value:
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
+def _completed_weekly(candles: list[Candle], *, cutoff: datetime) -> list[Candle]:
+    groups: dict[tuple[int, int], list[Candle]] = {}
+    for candle in candles:
+        stamp = datetime.fromisoformat(candle.timestamp.replace("Z", "+00:00"))
+        if stamp > cutoff:
+            continue
+        iso = stamp.date().isocalendar()
+        groups.setdefault((iso.year, iso.week), []).append(candle)
+    result: list[Candle] = []
+    for _, rows in sorted(groups.items()):
+        if len(rows) < 7:
+            continue
+        result.append(
+            Candle(
+                timestamp=rows[-1].timestamp[:10],
+                open=rows[0].open,
+                high=max(row.high for row in rows),
+                low=min(row.low for row in rows),
+                close=rows[-1].close,
+                volume=sum(row.volume for row in rows),
+                amount=sum(row.amount or 0 for row in rows),
+            )
+        )
+    return result
+
+
+class HyperliquidPerpetualProvider:
+    """Fetch HYPE perpetual candles from Hyperliquid's public info endpoint."""
+
+    def __init__(self, timeout: float = 30, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self._timeout = timeout
+        self._transport = transport
+        self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform: TimeframeTransform | None = None
+        self.source_identity: dict[str, Any] = {}
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK]
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        symbol = ticker.upper().strip()
+        if symbol != "HYPE":
+            raise ProviderError("Hyperliquid perpetual source only enables HYPE", suggestions=["Use ticker HYPE"])
+        if timeframe == Timeframe.WEEK:
+            daily = await self.fetch(
+                symbol,
+                Timeframe.DAY,
+                start=start,
+                end=end,
+                limit=max(limit * 7 + 8, 100),
+            )
+            cutoff = datetime.now(timezone.utc)
+            candles = _completed_weekly(daily, cutoff=cutoff)
+            if not candles:
+                raise ProviderError("No completed weekly data returned for HYPE")
+            if limit:
+                candles = candles[-limit:]
+            self.timeframe_transform = TimeframeTransform(
+                raw_timeframe=Timeframe.DAY,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "kind": "ohlc_resample",
+                    "rule": "completed_iso_week",
+                    "input_timeframe": "1d",
+                    "bucket_timezone": "UTC",
+                },
+            )
+            return candles
+
+        interval, interval_ms = _TF_MAP.get(timeframe, (None, None))
+        if interval is None or interval_ms is None:
+            raise ProviderError("Hyperliquid perpetual source supports only 4h, 1d, and 1w")
+        now = datetime.now(timezone.utc)
+        start_ms = _parse_bound(start)
+        end_ms = _parse_bound(end)
+        if start_ms is None:
+            start_ms = int((now - timedelta(milliseconds=interval_ms * max(limit + 2, 20))).timestamp() * 1000)
+        if end_ms is None:
+            end_ms = int(now.timestamp() * 1000)
+        else:
+            end_ms -= 1
+        payload = {
+            "type": "candleSnapshot",
+            "req": {"coin": symbol, "interval": interval, "startTime": start_ms, "endTime": end_ms},
+        }
+        self.last_raw_response = {
+            "request_payload": payload,
+            "response_body": None,
+            "status_code": None,
+            "error": None,
+        }
+        client_kwargs: dict[str, Any] = {"timeout": self._timeout}
+        if self._transport is not None:
+            client_kwargs["transport"] = self._transport
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            try:
+                response = await client.post(
+                    HYPERLIQUID_INFO_URL,
+                    json=payload,
+                    headers={"User-Agent": "datafeed-research/1.0"},
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.HTTPStatusError as exc:
+                self.last_raw_response["status_code"] = exc.response.status_code
+                self.last_raw_response["error"] = exc.response.text[:500]
+                raise ProviderError(f"Hyperliquid API error {exc.response.status_code}") from exc
+            except (httpx.RequestError, ValueError) as exc:
+                self.last_raw_response["error"] = str(exc)
+                raise ProviderError(f"Hyperliquid request failed: {exc}") from exc
+        self.last_raw_response["status_code"] = 200
+        self.last_raw_response["response_body"] = data
+        if not isinstance(data, list):
+            raise ProviderError("Hyperliquid returned a non-list candle payload")
+        candles: list[Candle] = []
+        for item in data:
+            try:
+                open_value = float(item["o"])
+                high_value = float(item["h"])
+                low_value = float(item["l"])
+                close_value = float(item["c"])
+                volume = float(item["v"])
+                stamp = datetime.fromtimestamp(float(item["t"]) / 1000, tz=timezone.utc)
+            except (KeyError, TypeError, ValueError, OverflowError) as exc:
+                raise ProviderError("Hyperliquid candle payload is malformed") from exc
+            if not all(math.isfinite(value) for value in (open_value, high_value, low_value, close_value, volume)):
+                raise ProviderError("Hyperliquid candle contains a non-finite value")
+            if high_value < max(open_value, close_value) or low_value > min(open_value, close_value) or volume < 0:
+                raise ProviderError("Hyperliquid OHLC invariant failed")
+            end_stamp = datetime.fromtimestamp(float(item.get("T", item["t"])) / 1000, tz=timezone.utc)
+            if end_stamp > now:
+                continue
+            candles.append(
+                Candle(
+                    timestamp=stamp.isoformat().replace("+00:00", "Z"),
+                    open=open_value,
+                    high=high_value,
+                    low=low_value,
+                    close=close_value,
+                    volume=volume,
+                    amount=None,
+                )
+            )
+        candles.sort(key=lambda row: row.timestamp)
+        if limit:
+            candles = candles[-limit:]
+        if not candles:
+            raise ProviderError("No completed Hyperliquid candles returned for HYPE")
+        self.timeframe_transform = TimeframeTransform(
+            raw_timeframe=timeframe,
+            timeframe_origin="native",
+            aggregation={"kind": "none", "rule": "native_passthrough"},
+        )
+        self.source_identity = {
+            "provider_symbol": symbol,
+            "venue": "hyperliquid",
+            "contract_type": "perpetual",
+            "settlement": "USDC",
+        }
+        return candles

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -15,6 +15,7 @@ from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 from kline.providers.commodity import CommodityProvider
 from kline.providers.crypto import CryptoProvider
 from kline.providers.fred import FredCsvProvider
+from kline.providers.hyperliquid import HyperliquidPerpetualProvider
 from kline.providers.sina import SinaIndexProvider
 from kline.providers.treasury import TreasuryCsvProvider
 from kline.providers.us import USStockProvider
@@ -122,6 +123,18 @@ def init(settings: Settings | None = None) -> None:
             _live_providers["binance_usdm_futures"],
         )
     )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("binance_usdm_futures_research", AssetClass.CRYPTO),
+            BinanceUsdmFuturesProvider(timeout=s.request_timeout, allowed_symbols={"BTCUSDT", "ETHUSDT"}),
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("hyperliquid_perpetual_public", AssetClass.CRYPTO),
+            HyperliquidPerpetualProvider(timeout=s.request_timeout),
+        )
+    )
 
     # A-share requires TuShare token
     if s.tushare_token:
@@ -189,7 +202,8 @@ def get_adapter_for_source(source: str, asset_class: AssetClass) -> MarketDataPo
                 "Use auto, tencent_kline, treasury_official_csv, "
                 "sina_index, "
                 "treasury_official_csv_derived, binance_spot_public, "
-                "binance_usdm_futures, yahoo_finance, yahoo_finance_futures, "
+                "binance_usdm_futures, binance_usdm_futures_research, "
+                "hyperliquid_perpetual_public, yahoo_finance, yahoo_finance_futures, "
                 "tushare_pro, or a registered adapter source"
             ],
         ) from e

--- a/tests/test_binance_usdm.py
+++ b/tests/test_binance_usdm.py
@@ -114,6 +114,25 @@ async def test_binance_usdm_rejects_non_xau_symbols():
     assert "not enabled" in str(exc.value)
 
 
+@pytest.mark.parametrize("ticker", ["BTC", "BTCUSDT", "ETH", "ETHUSDT"])
+async def test_research_provider_accepts_explicit_crypto_futures_symbols(ticker: str):
+    seen_params: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_params.update(dict(request.url.params))
+        return httpx.Response(200, json=[_kline(_open_ms(10, 0), "100.0")])
+
+    provider = BinanceUsdmFuturesProvider(
+        transport=httpx.MockTransport(handler),
+        allowed_symbols={"BTCUSDT", "ETHUSDT"},
+    )
+    candles = await provider.fetch(ticker, Timeframe.HOUR_4, limit=1)
+
+    assert seen_params["symbol"] == ("BTCUSDT" if ticker.startswith("BTC") else "ETHUSDT")
+    assert seen_params["interval"] == "4h"
+    assert candles[0].close == 3300.70
+
+
 async def test_xauusdt_instrument_definition_preserves_exchange_constraints():
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/fapi/v1/exchangeInfo"

--- a/tests/test_hyperliquid.py
+++ b/tests/test_hyperliquid.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from kline.models import Timeframe
+from kline.providers.base import ProviderError
+from kline.providers.hyperliquid import HyperliquidPerpetualProvider
+
+
+def _row(open_ms: int, close: str = "60.0") -> dict[str, object]:
+    return {
+        "t": open_ms,
+        "T": open_ms + 4 * 60 * 60 * 1000 - 1,
+        "s": "HYPE",
+        "i": "4h",
+        "o": "59.0",
+        "c": close,
+        "h": "61.0",
+        "l": "58.5",
+        "v": "100.0",
+        "n": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_native_4h_preserves_perpetual_identity():
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["type"] == "candleSnapshot"
+        assert payload["req"]["coin"] == "HYPE"
+        assert payload["req"]["interval"] == "4h"
+        return httpx.Response(200, json=[_row(1786838400000)])
+
+    provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(handler))
+    candles = await provider.fetch("HYPE", Timeframe.HOUR_4, limit=1)
+
+    assert len(candles) == 1
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.timeframe_origin == "native"
+    assert provider.source_identity == {
+        "provider_symbol": "HYPE",
+        "venue": "hyperliquid",
+        "contract_type": "perpetual",
+        "settlement": "USDC",
+    }
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_rejects_unlisted_symbol():
+    provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(lambda _: httpx.Response(200, json=[])))
+    with pytest.raises(ProviderError, match="only enables HYPE"):
+        await provider.fetch("BTC", Timeframe.HOUR_4)


### PR DESCRIPTION
## What
Adds explicit research-only Binance USD-M futures and Hyperliquid perpetual candle sources for BTC, ETH, and HYPE.

## Why
Weekly Macro now uses tradeable instruments; spot candles or the existing execution-only XAU source must not be silently reused.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_binance_usdm.py tests/test_hyperliquid.py tests/test_phase1_matrix.py tests/test_provenance.py` → 28 passed
- Live upstream smoke: BTC/ETH Binance USD-M 4H/1D/1W and HYPE Hyperliquid 4H/1D/1W returned real candles; weekly rows are explicit daily-to-week aggregation.
- Research sources set `execution_venue=false`, preserve venue/contract identity, and have no fallback.

Closes #27