### PR TITLE
Date crypto weekly bars on completed Friday

### DIFF
--- a/src/kline/providers/binance_usdm.py
+++ b/src/kline/providers/binance_usdm.py
@@ -113,9 +113,11 @@ def _aggregate_completed_weeks(candles: list[Candle]) -> list[Candle]:
     for _, rows in sorted(groups.items()):
         if len(rows) < 7:
             continue
+        first_date = datetime.fromisoformat(rows[0].timestamp.replace("Z", "+00:00")).date()
+        week_end = date.fromisocalendar(first_date.isocalendar().year, first_date.isocalendar().week, 5)
         result.append(
             Candle(
-                timestamp=rows[-1].timestamp[:10],
+                timestamp=week_end.isoformat(),
                 open=rows[0].open,
                 high=max(row.high for row in rows),
                 low=min(row.low for row in rows),

--- a/src/kline/providers/hyperliquid.py
+++ b/src/kline/providers/hyperliquid.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 import math
 from typing import Any
 
@@ -42,9 +42,11 @@ def _completed_weekly(candles: list[Candle], *, cutoff: datetime) -> list[Candle
     for _, rows in sorted(groups.items()):
         if len(rows) < 7:
             continue
+        first_date = datetime.fromisoformat(rows[0].timestamp.replace("Z", "+00:00")).date()
+        week_end = date.fromisocalendar(first_date.isocalendar().year, first_date.isocalendar().week, 5)
         result.append(
             Candle(
-                timestamp=rows[-1].timestamp[:10],
+                timestamp=week_end.isoformat(),
                 open=rows[0].open,
                 high=max(row.high for row in rows),
                 low=min(row.low for row in rows),

--- a/tests/test_hyperliquid.py
+++ b/tests/test_hyperliquid.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
@@ -53,3 +54,21 @@ async def test_hyperliquid_rejects_unlisted_symbol():
     provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(lambda _: httpx.Response(200, json=[])))
     with pytest.raises(ProviderError, match="only enables HYPE"):
         await provider.fetch("BTC", Timeframe.HOUR_4)
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_weekly_bar_is_dated_on_completed_friday():
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["req"]["interval"] == "1d"
+        start = datetime(2026, 8, 10, tzinfo=timezone.utc)
+        rows = []
+        for offset in range(7):
+            stamp = start + timedelta(days=offset)
+            rows.append({**_row(int(stamp.timestamp() * 1000)), "T": int((stamp + timedelta(days=1)).timestamp() * 1000) - 1, "i": "1d"})
+        return httpx.Response(200, json=rows)
+
+    provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(handler))
+    candles = await provider.fetch("HYPE", Timeframe.WEEK, limit=1)
+
+    assert candles[0].timestamp == "2026-08-14"


### PR DESCRIPTION
## What
Dates completed BTC/ETH/HYPE perpetual weekly bars on the ISO week Friday.

## Why
Weekly Macro treats Saturday/Sunday as non-session rows and was discarding otherwise valid crypto weekly candles.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_binance_usdm.py tests/test_hyperliquid.py` → 14 passed
- Regression test asserts HYPE weekly timestamp `2026-08-14`.

Closes #35