### PR TITLE
Unify BTC ETH HYPE on Hyperliquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ python -m kline
 | `binance_spot_public` | `crypto` | Binance Spot API | spot | true | false | BTC/BTCUSDT: 1m, 5m, 15m, 30m, 1h, 4h, 1d, 1w; other symbols: no Phase 1 4h guarantee |
 | `binance_usdm_futures` | `commodity` | Binance USD-M Futures | USD-M futures | true | true | XAUUSDT: 1m, 5m, 15m, 30m, 1h, 4h |
 | `binance_usdm_futures_research` | `crypto` | Binance USD-M Futures | USD-M perpetuals | true | false | BTCUSDT/ETHUSDT: 4h, 1d, 1w |
-| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | HYPE: 4h, 1d, 1w |
+| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | BTC/ETH/HYPE: 4h, 1d, 1w |
 
 ## 技术栈
 

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -93,7 +93,7 @@ HYPERLIQUID_PERP_META = ProviderMeta(
     execution_venue=False,
     realtime_supported=False,
     market_type="perpetual_futures",
-    supported_symbols=("HYPE",),
+    supported_symbols=("BTC", "ETH", "HYPE"),
 )
 
 BINANCE_USDM_FUTURES_META = ProviderMeta(
@@ -303,9 +303,13 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.CRYPTO,
         meta=HYPERLIQUID_PERP_META,
         default_for_asset_class=False,
-        ticker_aliases={"HYPE": "HYPE"},
-        canonical_instrument_ids={"HYPE": "HYPE.HYPERLIQUID"},
-        symbol_timeframes={"HYPE": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK)},
+        ticker_aliases={"BTC": "BTC", "ETH": "ETH", "HYPE": "HYPE"},
+        canonical_instrument_ids={"BTC": "BTC.HYPERLIQUID", "ETH": "ETH.HYPERLIQUID", "HYPE": "HYPE.HYPERLIQUID"},
+        symbol_timeframes={
+            "BTC": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+            "ETH": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+            "HYPE": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+        },
         enforce_symbol_allowlist=True,
     ),
     "yahoo_finance": SourceManifest(

--- a/src/kline/providers/hyperliquid.py
+++ b/src/kline/providers/hyperliquid.py
@@ -59,11 +59,12 @@ def _completed_weekly(candles: list[Candle], *, cutoff: datetime) -> list[Candle
 
 
 class HyperliquidPerpetualProvider:
-    """Fetch HYPE perpetual candles from Hyperliquid's public info endpoint."""
+    """Fetch an explicit crypto-perpetual allowlist from Hyperliquid."""
 
-    def __init__(self, timeout: float = 30, transport: httpx.AsyncBaseTransport | None = None) -> None:
+    def __init__(self, timeout: float = 30, transport: httpx.AsyncBaseTransport | None = None, allowed_symbols: set[str] | None = None) -> None:
         self._timeout = timeout
         self._transport = transport
+        self._allowed_symbols = {item.upper() for item in (allowed_symbols or {"BTC", "ETH", "HYPE"})}
         self.last_raw_response: dict[str, Any] | None = None
         self.timeframe_transform: TimeframeTransform | None = None
         self.source_identity: dict[str, Any] = {}
@@ -81,8 +82,11 @@ class HyperliquidPerpetualProvider:
         limit: int = 500,
     ) -> list[Candle]:
         symbol = ticker.upper().strip()
-        if symbol != "HYPE":
-            raise ProviderError("Hyperliquid perpetual source only enables HYPE", suggestions=["Use ticker HYPE"])
+        if symbol not in self._allowed_symbols:
+            raise ProviderError(
+                f"Hyperliquid perpetual source does not enable {symbol}",
+                suggestions=[f"Use one of: {', '.join(sorted(self._allowed_symbols))}"],
+            )
         if timeframe == Timeframe.WEEK:
             daily = await self.fetch(
                 symbol,
@@ -94,7 +98,7 @@ class HyperliquidPerpetualProvider:
             cutoff = datetime.now(timezone.utc)
             candles = _completed_weekly(daily, cutoff=cutoff)
             if not candles:
-                raise ProviderError("No completed weekly data returned for HYPE")
+                raise ProviderError(f"No completed weekly data returned for {symbol}")
             if limit:
                 candles = candles[-limit:]
             self.timeframe_transform = TimeframeTransform(
@@ -187,7 +191,7 @@ class HyperliquidPerpetualProvider:
         if limit:
             candles = candles[-limit:]
         if not candles:
-            raise ProviderError("No completed Hyperliquid candles returned for HYPE")
+            raise ProviderError(f"No completed Hyperliquid candles returned for {symbol}")
         self.timeframe_transform = TimeframeTransform(
             raw_timeframe=timeframe,
             timeframe_origin="native",

--- a/tests/test_hyperliquid.py
+++ b/tests/test_hyperliquid.py
@@ -52,8 +52,23 @@ async def test_hyperliquid_native_4h_preserves_perpetual_identity():
 @pytest.mark.asyncio
 async def test_hyperliquid_rejects_unlisted_symbol():
     provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(lambda _: httpx.Response(200, json=[])))
-    with pytest.raises(ProviderError, match="only enables HYPE"):
-        await provider.fetch("BTC", Timeframe.HOUR_4)
+    with pytest.raises(ProviderError, match="does not enable SOL"):
+        await provider.fetch("SOL", Timeframe.HOUR_4)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("symbol", ["BTC", "ETH", "HYPE"])
+async def test_hyperliquid_unified_source_accepts_all_weekly_crypto_symbols(symbol: str):
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["req"]["coin"] == symbol
+        return httpx.Response(200, json=[_row(1786838400000)])
+
+    provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(handler))
+    candles = await provider.fetch(symbol, Timeframe.HOUR_4, limit=1)
+
+    assert len(candles) == 1
+    assert provider.source_identity["provider_symbol"] == symbol
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
Extends the explicit Hyperliquid perpetual source to BTC, ETH, and HYPE.

## Why
Weekly Macro needs one provider/venue/contract semantics for the three crypto assets.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_hyperliquid.py tests/test_phase1_matrix.py tests/test_provenance.py` → 22 passed
- Live smoke: BTC/ETH/HYPE each return real 1d, 1w, and native 4h candles with Hyperliquid/USDC perpetual provenance.
- No fallback or cache path added.

Closes #37