### PR TITLE
feat: expose Hyperliquid native 30m candles

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ python -m kline
 | `binance_spot_public` | `crypto` | Binance Spot API | spot | true | false | BTC/BTCUSDT: 1m, 5m, 15m, 30m, 1h, 4h, 1d, 1w; other symbols: no Phase 1 4h guarantee |
 | `binance_usdm_futures` | `commodity` | Binance USD-M Futures | USD-M futures | true | true | XAUUSDT: 1m, 5m, 15m, 30m, 1h, 4h |
 | `binance_usdm_futures_research` | `crypto` | Binance USD-M Futures | USD-M perpetuals | true | false | BTCUSDT/ETHUSDT: 4h, 1d, 1w |
-| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | BTC/ETH/HYPE: 4h, 1d, 1w |
+| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | BTC/ETH/HYPE: 30m, 4h, 1d, 1w |
 
 ## 技术栈
 

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -306,9 +306,9 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         ticker_aliases={"BTC": "BTC", "ETH": "ETH", "HYPE": "HYPE"},
         canonical_instrument_ids={"BTC": "BTC.HYPERLIQUID", "ETH": "ETH.HYPERLIQUID", "HYPE": "HYPE.HYPERLIQUID"},
         symbol_timeframes={
-            "BTC": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
-            "ETH": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
-            "HYPE": (Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+            "BTC": (Timeframe.MIN_30, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+            "ETH": (Timeframe.MIN_30, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
+            "HYPE": (Timeframe.MIN_30, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK),
         },
         enforce_symbol_allowlist=True,
     ),

--- a/src/kline/providers/hyperliquid.py
+++ b/src/kline/providers/hyperliquid.py
@@ -15,6 +15,7 @@ from kline.providers.base import ProviderError
 HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info"
 
 _TF_MAP = {
+    Timeframe.MIN_30: ("30m", 30 * 60 * 1000),
     Timeframe.HOUR_4: ("4h", 4 * 60 * 60 * 1000),
     Timeframe.DAY: ("1d", 24 * 60 * 60 * 1000),
 }
@@ -70,7 +71,7 @@ class HyperliquidPerpetualProvider:
         self.source_identity: dict[str, Any] = {}
 
     def supported_timeframes(self) -> list[Timeframe]:
-        return [Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK]
+        return [Timeframe.MIN_30, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK]
 
     async def fetch(
         self,
@@ -115,7 +116,7 @@ class HyperliquidPerpetualProvider:
 
         interval, interval_ms = _TF_MAP.get(timeframe, (None, None))
         if interval is None or interval_ms is None:
-            raise ProviderError("Hyperliquid perpetual source supports only 4h, 1d, and 1w")
+            raise ProviderError("Hyperliquid perpetual source supports only 30m, 4h, 1d, and 1w")
         now = datetime.now(timezone.utc)
         start_ms = _parse_bound(start)
         end_ms = _parse_bound(end)

--- a/tests/test_hyperliquid.py
+++ b/tests/test_hyperliquid.py
@@ -26,6 +26,15 @@ def _row(open_ms: int, close: str = "60.0") -> dict[str, object]:
     }
 
 
+def _row_for_interval(open_ms: int, interval: str, close: str = "60.0") -> dict[str, object]:
+    minutes = {"30m": 30, "4h": 240}[interval]
+    return {
+        **_row(open_ms, close),
+        "T": open_ms + minutes * 60 * 1000 - 1,
+        "i": interval,
+    }
+
+
 @pytest.mark.asyncio
 async def test_hyperliquid_native_4h_preserves_perpetual_identity():
     def handler(request: httpx.Request) -> httpx.Response:
@@ -47,6 +56,24 @@ async def test_hyperliquid_native_4h_preserves_perpetual_identity():
         "contract_type": "perpetual",
         "settlement": "USDC",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("symbol", ["BTC", "ETH", "HYPE"])
+async def test_hyperliquid_native_30m_is_available_for_unified_crypto_source(symbol: str):
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["req"]["coin"] == symbol
+        assert payload["req"]["interval"] == "30m"
+        return httpx.Response(200, json=[_row_for_interval(1786838400000, "30m")])
+
+    provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(handler))
+    candles = await provider.fetch(symbol, Timeframe.MIN_30, limit=1)
+
+    assert len(candles) == 1
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.MIN_30
+    assert provider.timeframe_transform.timeframe_origin == "native"
 
 
 @pytest.mark.asyncio

--- a/tests/test_timeframe_contract.py
+++ b/tests/test_timeframe_contract.py
@@ -177,6 +177,7 @@ def test_yahoo_symbol_timeframe_allowlist_is_explicit():
     futures = source_manifest("yahoo_finance_futures", AssetClass.COMMODITY)
     us_stock = source_manifest("yahoo_finance", AssetClass.US_STOCK)
     crypto = source_manifest("binance_spot_public", AssetClass.CRYPTO)
+    hyperliquid = source_manifest("hyperliquid_perpetual_public", AssetClass.CRYPTO)
 
     assert index.meta.supported_symbols == ("DX-Y.NYB", "^GSPC", "^IXIC", "^VIX", "^N225", "^KS11")
     assert index.supports_timeframe("DX-Y.NYB", Timeframe.HOUR_4)
@@ -190,6 +191,9 @@ def test_yahoo_symbol_timeframe_allowlist_is_explicit():
     assert not us_stock.supports_timeframe("AAPL", Timeframe.HOUR_4)
     assert crypto.supports_timeframe("BTC", Timeframe.HOUR_4)
     assert not crypto.supports_timeframe("ETH", Timeframe.HOUR_4)
+    assert hyperliquid.supports_timeframe("BTC", Timeframe.MIN_30)
+    assert hyperliquid.supports_timeframe("ETH", Timeframe.MIN_30)
+    assert hyperliquid.supports_timeframe("HYPE", Timeframe.MIN_30)
 
 
 def test_health_exposes_effective_symbol_matrix(tmp_path):


### PR DESCRIPTION
## What
- expose native 30m candles for BTC, ETH, and HYPE on the unified Hyperliquid perpetual source
- declare the capability in the source manifest and README
- add provider and manifest coverage tests

## Why
The Daily K-line newsletter needs a same-venue 30m context for the three crypto perpetuals. Previously the provider itself had an upstream-capable interval map but the source contract blocked it as unsupported.

## Validation
- `env -u PYTHONPATH PYTHONPATH=/Users/wendy/datafeed-runtime/src python3 -m pytest -q tests/test_hyperliquid.py tests/test_provenance.py` (19 passed)
- `tests/test_timeframe_contract.py` has two pre-existing date/timezone-sensitive failures unrelated to this change.

Closes #39