### PR TITLE
Fix Yahoo latest-session OHLC gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ $ curl "localhost:8100/api/candles/us_stock/AAPL?timeframe=1d&limit=3"
 | `latest_timestamp` / `age_seconds` | 最新一根 bar 的时间与年龄（永远是诚实事实） |
 | `fresh` / `max_age_seconds` | **仅对 7×24 连续市场（crypto）给出**新鲜度判定；行情有休市的源（美股/商品/A股）恒为 `null`，由消费方按自己的交易日历判断 |
 | `execution_venue` | 是否来自可作为交易页实时真源的执行场所。research 源为 `false`，Binance USD-M Futures live 为 `true` |
+
+### Yahoo 最新交易日修复
+
+Yahoo 偶尔会返回一个有成交量、但 OHLC 为 `NaN` 的最新交易日行。严格请求不会把
+这类坏行静默变成上一根 K 线：provider 先保留原始响应，只有在 OHLC 校验失败时才
+调用 yfinance 的 upstream repair 路径，并在 `source_identity` 中记录
+`repair_attempted`、`repaired_row_count` 和 `repaired_timestamps`。请求会多取少量上下文，
+但公开 candles 仍严格裁剪到请求的 `end`，不会泄漏未来数据、读取旧 cache 或生成合成价格。
 | `reject_reason` / `access_issues` | strict quality blocked 时的直接原因，如 `upstream_error`、`empty_data`、`stale`、`gap`、`out_of_order` |
 
 > `cache_policy=allow` 命中 cache 时不会自动回源刷新，但 `served_from` + `age_seconds` + `fresh` 让陈旧数据可见。实时路径应使用 `cache_policy=bypass` 或 `profile=realtime`。

--- a/decision-log.md
+++ b/decision-log.md
@@ -286,3 +286,13 @@ consumers can use without direct exchange or private SQLite access.
   the final legacy migration reports zero skipped rows.
 - Visual proof:
   `/Users/wendy/park-io/008_codex session insights and decision logs/交易系统/evidence/2026-07-15-datafeed-source-health-final.png`.
+# 2026-08-31 - Repair Yahoo latest-session OHLC gaps without stale fallback
+
+- Yahoo occasionally returned a latest-session row with valid volume but
+  `NaN` OHLC, causing strict ETF/index requests to fail with `502 upstream_error`.
+- The provider now requests a small upstream context window and retries with
+  yfinance `repair=True` only after the raw response fails OHLC validation.
+- Repaired rows are explicitly recorded in `source_identity`; output remains
+  upstream, non-synthetic, and clipped to the caller's requested cutoff.
+- No cache fallback, previous-close substitution, or implicit source change was
+  introduced. Focused and full test suites pass (147 tests).

--- a/src/kline/providers/us.py
+++ b/src/kline/providers/us.py
@@ -8,6 +8,7 @@ import math
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import pandas as pd
 import yfinance as yf
 
 from kline.models import Candle, Timeframe, TimeframeTransform
@@ -39,6 +40,46 @@ _DEFAULT_PERIOD = {
     Timeframe.DAY: "5y",
     Timeframe.WEEK: "5y",
 }
+
+
+def _index_date(index: Any) -> date:
+    """Return a calendar date from a pandas timestamp-like index value."""
+
+    value = getattr(index, "date", None)
+    if callable(value):
+        return value()
+    return date.fromisoformat(str(index)[:10])
+
+
+def _index_text(index: Any, timeframe: Timeframe) -> str:
+    if timeframe == Timeframe.DAY:
+        return _index_date(index).isoformat()
+    if hasattr(index, "isoformat"):
+        return index.isoformat()
+    return str(index)
+
+
+def _invalid_indices(frame: Any) -> list[Any]:
+    """Return rows that cannot be represented as a finite OHLCV candle."""
+
+    if frame is None or getattr(frame, "empty", True):
+        return []
+    invalid: list[Any] = []
+    for idx, row in frame.iterrows():
+        try:
+            values = [
+                float(row[column])
+                for column in ("Open", "High", "Low", "Close")
+            ]
+            volume = float(row.get("Volume", 0))
+            if not all(math.isfinite(value) for value in (*values, volume)):
+                invalid.append(idx)
+                continue
+            if values[1] < max(values[0], values[3]) or values[2] > min(values[0], values[3]):
+                invalid.append(idx)
+        except (TypeError, ValueError, KeyError):
+            invalid.append(idx)
+    return invalid
 
 
 class USStockProvider:
@@ -82,8 +123,9 @@ class USStockProvider:
                 self.source_identity = {"provider_symbol": ticker.upper()}
                 raise
             raw_audit = self.last_raw_response
+            raw_identity = dict(self.source_identity)
             self.timeframe_transform = requested_transform
-            self.source_identity = {"provider_symbol": ticker.upper()}
+            self.source_identity = raw_identity
             try:
                 candles = _aggregate_completed_weeks(
                     daily,
@@ -128,8 +170,9 @@ class USStockProvider:
                 self.source_identity = {"provider_symbol": ticker.upper()}
                 raise
             raw_audit = self.last_raw_response
+            raw_identity = dict(self.source_identity)
             self.timeframe_transform = requested_transform
-            self.source_identity = {"provider_symbol": ticker.upper()}
+            self.source_identity = raw_identity
             candles, dropped = _aggregate_fixed_4h(
                 hourly,
                 anchor_hour=self._four_hour_anchor[0],
@@ -166,6 +209,10 @@ class USStockProvider:
             "start": start,
             "end": end,
             "limit": limit,
+            # Yahoo occasionally emits a live row with valid volume but NaN
+            # OHLC. We first ask for the raw response, then invoke yfinance's
+            # repair path only when the raw response cannot pass validation.
+            "repair_policy": "yfinance_repair_on_invalid_ohlc",
         }
         self.last_raw_response = {
             "request_params": request_params,
@@ -175,10 +222,15 @@ class USStockProvider:
         }
         try:
             stock = yf.Ticker(ticker.upper())
-            kwargs: dict = {"interval": interval}
+            kwargs: dict = {"interval": interval, "repair": False, "keepna": False}
             if start and end:
                 kwargs["start"] = start
-                kwargs["end"] = end
+                # Give Yahoo a little context beyond the requested cutoff.
+                # Its repair path needs the next session to reconstruct a
+                # live row; the public response is still clipped to `end`
+                # below, so no future candle can leak into the contract.
+                kwargs["end"] = _repair_context_end(end)
+                request_params["repair_context_end"] = kwargs["end"]
             else:
                 period = _DEFAULT_PERIOD.get(timeframe, "2y")
                 kwargs["period"] = period
@@ -200,6 +252,73 @@ class USStockProvider:
                     "Try common symbols: AAPL, MSFT, GOOGL, AMZN",
                 ],
             )
+
+        cutoff = (
+            _closed_daily_cutoff(end, timezone_name=_source_timezone(ticker))
+            if timeframe == Timeframe.DAY
+            else None
+        )
+        raw_bad_indices = _invalid_indices(df)
+        if timeframe == Timeframe.DAY and cutoff is not None:
+            raw_dates = [
+                _index_date(idx)
+                for idx in df.index
+                if _index_date(idx) <= cutoff
+            ]
+            # A missing latest session can be represented by a dropped row
+            # rather than a NaN row (notably for VIX). Only retry when the
+            # requested cutoff is a weekday and the raw data stops earlier.
+            if raw_dates and max(raw_dates) < cutoff and cutoff.weekday() < 5:
+                raw_bad_indices.append(None)
+
+        repaired_timestamps: list[str] = []
+        repair_attempted = False
+        if raw_bad_indices:
+            repair_attempted = True
+            repair_kwargs = dict(kwargs)
+            repair_kwargs["repair"] = True
+            try:
+                repaired_df = yf.Ticker(ticker.upper()).history(**repair_kwargs)
+            except Exception as e:
+                self.last_raw_response["error"] = str(e)
+                raise ProviderError(
+                    f"Yahoo Finance repair failed for {ticker}: {e}",
+                    suggestions=["Retry the same source after the upstream response stabilizes"],
+                ) from e
+            if repaired_df is None or repaired_df.empty:
+                self.last_raw_response["error"] = "repair_empty_data"
+                raise ProviderError(f"Yahoo Finance repair returned no data for {ticker}")
+
+            allowed_indices = set(df.index)
+            target_index = None
+            if timeframe == Timeframe.DAY and cutoff is not None:
+                candidates = [
+                    idx for idx in repaired_df.index if _index_date(idx) <= cutoff
+                ]
+                if candidates:
+                    target_index = max(candidates, key=_index_date)
+                    allowed_indices.add(target_index)
+
+            replace_indices = {idx for idx in raw_bad_indices if idx is not None}
+            repaired_indices = [
+                idx
+                for idx in repaired_df.index
+                if idx in allowed_indices
+                and (idx in replace_indices or idx == target_index)
+            ]
+            for idx in repaired_indices:
+                if idx in df.index:
+                    for column in ("Open", "High", "Low", "Close", "Volume"):
+                        if column in repaired_df.columns:
+                            df.loc[idx, column] = repaired_df.loc[idx, column]
+                else:
+                    df = pd.concat([df, repaired_df.loc[[idx]]], sort=False)
+                repaired_timestamps.append(_index_text(idx, timeframe))
+            df = df.sort_index()
+            request_params["repair_attempted"] = True
+            request_params["repair_selected_rows"] = repaired_timestamps
+        else:
+            request_params["repair_attempted"] = False
 
         candles = []
         for idx, row in df.iterrows():
@@ -239,11 +358,17 @@ class USStockProvider:
             )
 
         if timeframe == Timeframe.DAY:
-            cutoff = _closed_daily_cutoff(end, timezone_name=_source_timezone(ticker))
+            assert cutoff is not None
             candles = [
                 candle
                 for candle in candles
                 if date.fromisoformat(candle.timestamp[:10]) <= cutoff
+            ]
+            returned_timestamps = {candle.timestamp[:10] for candle in candles}
+            repaired_timestamps = [
+                timestamp
+                for timestamp in repaired_timestamps
+                if timestamp[:10] in returned_timestamps
             ]
             if not candles:
                 raise ProviderError(f"No closed daily data returned for {ticker}")
@@ -256,10 +381,17 @@ class USStockProvider:
             timeframe_origin="native",
             aggregation={"kind": "none", "rule": "native_passthrough"},
         )
-        self.source_identity = {"provider_symbol": ticker.upper()}
+        self.source_identity = {
+            "provider_symbol": ticker.upper(),
+            "repair_policy": "yfinance_repair_on_invalid_ohlc",
+            "repair_attempted": repair_attempted,
+            "repaired_row_count": len(repaired_timestamps),
+            "repaired_timestamps": repaired_timestamps,
+        }
         self.last_raw_response["response_body"] = {
             "row_count": len(candles),
             "rows": [item.model_dump() for item in candles],
+            "repaired_timestamps": repaired_timestamps,
         }
         logger.info(f"Fetched {len(candles)} candles for {ticker} ({timeframe.value})")
         return candles
@@ -317,6 +449,12 @@ def _closed_daily_cutoff(end: str | None, *, timezone_name: str) -> date:
     yesterday = datetime.now(ZoneInfo(timezone_name)).date() - timedelta(days=1)
     requested = _exclusive_end_cutoff(end, timezone_name=timezone_name)
     return min(requested, yesterday)
+
+
+def _repair_context_end(end: str) -> str:
+    """Extend an upstream Yahoo request without extending the public cutoff."""
+
+    return (date.fromisoformat(end[:10]) + timedelta(days=7)).isoformat()
 
 
 def _derived_audit(

--- a/tests/test_timeframe_contract.py
+++ b/tests/test_timeframe_contract.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import pytest
@@ -23,6 +24,28 @@ def _daily_frame(rows: list[tuple[str, float, float, float, float]]) -> pd.DataF
         },
         index=index,
     )
+
+
+def _repaired_daily_frame() -> pd.DataFrame:
+    index = pd.DatetimeIndex(["2026-08-27", "2026-08-28"], tz="UTC")
+    return pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            "High": [102.0, 103.0],
+            "Low": [99.0, 100.0],
+            "Close": [101.0, 102.0],
+            "Volume": [100.0, 120.0],
+            "Repaired?": [False, True],
+        },
+        index=index,
+    )
+
+
+def _broken_daily_frame() -> pd.DataFrame:
+    frame = _repaired_daily_frame().copy()
+    frame.loc[frame.index[-1], ["Open", "High", "Low", "Close"]] = float("nan")
+    frame["Repaired?"] = [False, False]
+    return frame
 
 
 @pytest.mark.asyncio
@@ -98,7 +121,7 @@ async def test_yahoo_weekly_excludes_current_partial_week(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_yahoo_daily_excludes_current_calendar_day(monkeypatch):
-    today = date.today()
+    today = datetime.now(ZoneInfo("America/New_York")).date()
     rows = [
         ((today - timedelta(days=1)).isoformat(), 100, 105, 99, 104),
         (today.isoformat(), 104, 110, 103, 109),
@@ -119,7 +142,7 @@ async def test_yahoo_daily_excludes_current_calendar_day(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_yahoo_default_daily_history_is_bounded_and_recorded(monkeypatch):
-    yesterday = date.today() - timedelta(days=1)
+    yesterday = datetime.now(ZoneInfo("America/New_York")).date() - timedelta(days=1)
     calls: dict = {}
 
     class FakeTicker:
@@ -139,6 +162,75 @@ async def test_yahoo_default_daily_history_is_bounded_and_recorded(monkeypatch):
     assert calls["period"] == "5y"
     assert provider.last_raw_response is not None
     assert provider.last_raw_response["request_params"]["period"] == "5y"
+
+
+@pytest.mark.asyncio
+async def test_yahoo_enables_upstream_repair_and_records_repaired_rows(monkeypatch):
+    calls: dict = {}
+
+    class FakeTicker:
+        def history(self, **kwargs):
+            calls.update(kwargs)
+            return _repaired_daily_frame() if kwargs["repair"] else _broken_daily_frame()
+
+    monkeypatch.setattr("kline.providers.us.yf.Ticker", lambda ticker: FakeTicker())
+    provider = USStockProvider()
+
+    candles = await provider.fetch(
+        "SPY",
+        Timeframe.DAY,
+        start="2026-08-27",
+        end="2026-08-29",
+        limit=10,
+    )
+
+    assert len(candles) == 2
+    assert calls["repair"] is True
+    assert provider.last_raw_response is not None
+    assert provider.last_raw_response["request_params"]["repair_policy"] == "yfinance_repair_on_invalid_ohlc"
+    assert provider.last_raw_response["request_params"]["repair_attempted"] is True
+    assert provider.source_identity["repair_policy"] == "yfinance_repair_on_invalid_ohlc"
+    assert provider.source_identity["repair_attempted"] is True
+    assert provider.source_identity["repaired_row_count"] == 1
+    assert provider.source_identity["repaired_timestamps"] == ["2026-08-28"]
+    assert provider.last_raw_response["response_body"]["repaired_timestamps"] == ["2026-08-28"]
+
+
+@pytest.mark.asyncio
+async def test_yahoo_repair_context_is_clipped_to_requested_end(monkeypatch):
+    calls: dict = {}
+    index = pd.DatetimeIndex(["2026-08-28", "2026-08-31"], tz="UTC")
+    frame = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            "High": [102.0, 103.0],
+            "Low": [99.0, 100.0],
+            "Close": [101.0, 102.0],
+            "Volume": [100.0, 120.0],
+            "Repaired?": [True, True],
+        },
+        index=index,
+    )
+
+    class FakeTicker:
+        def history(self, **kwargs):
+            calls.update(kwargs)
+            return frame if kwargs["repair"] else frame.assign(Close=[101.0, float("nan")])
+
+    monkeypatch.setattr("kline.providers.us.yf.Ticker", lambda ticker: FakeTicker())
+    provider = USStockProvider()
+
+    candles = await provider.fetch(
+        "^KS11",
+        Timeframe.DAY,
+        start="2026-08-28",
+        end="2026-08-29",
+        limit=10,
+    )
+
+    assert calls["end"] == "2026-09-05"
+    assert [candle.timestamp for candle in candles] == ["2026-08-28"]
+    assert provider.source_identity["repaired_timestamps"] == ["2026-08-28"]
 
 
 @pytest.mark.asyncio
@@ -165,10 +257,12 @@ async def test_yahoo_explicit_range_does_not_add_default_period(monkeypatch):
 
     assert calls["interval"] == "1d"
     assert calls["start"] == "2026-08-18"
-    assert calls["end"] == "2026-08-19"
+    assert calls["end"] == "2026-08-26"
     assert "period" not in calls
     assert provider.last_raw_response is not None
     assert "period" not in provider.last_raw_response["request_params"]
+    assert provider.last_raw_response["request_params"]["end"] == "2026-08-19"
+    assert provider.last_raw_response["request_params"]["repair_context_end"] == "2026-08-26"
 
 
 def test_yahoo_symbol_timeframe_allowlist_is_explicit():


### PR DESCRIPTION
## What
- Request Yahoo data with a small cutoff context window.
- Retry with yfinance upstream repair only when raw OHLC validation fails.
- Keep the public candles clipped to the requested cutoff and record repaired rows in provenance.

## Why
Yahoo was returning a latest-session row with volume but NaN OHLC, causing strict UUP/SPY/QQQ/SCHD/KOSPI/Nikkei requests to be rejected as 502. This restores real upstream candles without stale cache, previous-close substitution, or implicit source fallback.

## Validation
- `PYTHONPATH=/Users/wendy/datafeed-runtime/src /usr/local/bin/python3 -m pytest -q` (147 passed)
- Live isolated datafeed acceptance on port 8110: UUP, SPY, QQQ, SCHD, KOSPI, Nikkei and VIX daily + weekly requests returned HTTP 200 with latest 2026-08-28 and finite OHLC.
- Repaired rows are visible only in provenance (`repair_attempted`, `repaired_row_count`, `repaired_timestamps`).

Closes #41