### PR TITLE
feat: add atomic MVP storage receipts

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -3,11 +3,14 @@
 ## 要去哪里
 多资产 K 线数据服务:ticker+timeframe → 标准化 OHLCV + provenance(provider/fresh/synthetic 标记),A股/美股/加密/商品全覆盖;近期喂养 trading-system 与 tokenpulse,远期可作为独立 API 产品外卖。
 
-## 现在在哪里(2026-07-28)
+## 现在在哪里(2026-08-31)
 - V1 运行中:tushare/yahoo/binance 多源,ports-and-adapters,realtime strict 失败即显式报错、永不隐藏降级。
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
+- `main@5c1a5dd` 已合并 MVP #44：机器可读的 100 A 股 + 100 美股 + 16 跨市场 manifest、reserve/quarantine、source/timeframe/identity 校验与激活闸门已就绪；当前仍是 `candidate`，TuShare/美国源 entitlement 未提供前不会宣称 verified。
+- 当前工作：#45 `codex/issue-45-storage-receipts`，实现独立 `mvp_*` storage schema 与原子 run/receipt/watermark 写入；resident DB、NAS、provider、scheduler 尚未改动。
 
 ## 下一步
+- 完成 #45 StoragePort 与 SQLite receipt/rollback contract；随后按 #46→#54 依赖链推进 calendar/adapter/orchestrator/scheduler/SSD-NAS/30-day acceptance。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/src/kline/models.py
+++ b/src/kline/models.py
@@ -231,7 +231,9 @@ class KlineRow(Base):
     __tablename__ = "klines"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    source_id = Column(String, nullable=False, default="legacy_unknown", server_default="legacy_unknown")
+    source_id = Column(
+        String, nullable=False, default="legacy_unknown", server_default="legacy_unknown"
+    )
     ticker = Column(String, nullable=False)
     asset_class = Column(String, nullable=False)
     timeframe = Column(String, nullable=False)
@@ -324,3 +326,219 @@ class SourceObservation(Base):
             "observed_at",
         ),
     )
+
+
+class MvpCandleRow(Base):
+    """Source-aware MVP candle; isolated from the legacy ``klines`` table."""
+
+    __tablename__ = "mvp_candles"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    instrument_id = Column(String, nullable=False)
+    display_symbol = Column(String, nullable=False)
+    provider_symbol = Column(String, nullable=False)
+    source_id = Column(String, nullable=False)
+    asset_class = Column(String, nullable=False)
+    timeframe = Column(String, nullable=False)
+    adjustment_basis = Column(String, nullable=False)
+    manifest_version = Column(String, nullable=False)
+    timestamp = Column(String, nullable=False)
+    open = Column(Float, nullable=False)
+    high = Column(Float, nullable=False)
+    low = Column(Float, nullable=False)
+    close = Column(Float, nullable=False)
+    volume = Column(Float, nullable=True)
+    amount = Column(Float, nullable=True)
+    volume_semantics = Column(String, nullable=False)
+    is_derived = Column(Boolean, nullable=False, default=False)
+    transform_receipt_id = Column(Integer, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        Index(
+            "uq_mvp_candle_identity",
+            "source_id",
+            "instrument_id",
+            "timeframe",
+            "adjustment_basis",
+            "manifest_version",
+            "timestamp",
+            unique=True,
+        ),
+        Index(
+            "ix_mvp_candle_series",
+            "source_id",
+            "instrument_id",
+            "timeframe",
+            "manifest_version",
+        ),
+    )
+
+
+class MvpRunRow(Base):
+    """One ingestion attempt, including the manifest identity it ran."""
+
+    __tablename__ = "mvp_runs"
+
+    run_id = Column(String, primary_key=True)
+    manifest_version = Column(String, nullable=False)
+    manifest_hash = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    started_at = Column(String, nullable=False)
+    completed_at = Column(String, nullable=True)
+    window_start = Column(String, nullable=True)
+    window_end = Column(String, nullable=True)
+    policy_json = Column(Text, nullable=False, default="{}")
+    receipt_hash = Column(String, nullable=True)
+    error = Column(Text, nullable=True)
+    candle_count = Column(Integer, nullable=False, default=0)
+    observation_count = Column(Integer, nullable=False, default=0)
+    quality_count = Column(Integer, nullable=False, default=0)
+    transform_count = Column(Integer, nullable=False, default=0)
+    watermark_count = Column(Integer, nullable=False, default=0)
+    committed_at = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+
+class MvpWatermarkRow(Base):
+    """Last closed candle promoted for one exact source-aware series."""
+
+    __tablename__ = "mvp_watermarks"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    instrument_id = Column(String, nullable=False)
+    display_symbol = Column(String, nullable=False)
+    provider_symbol = Column(String, nullable=False)
+    source_id = Column(String, nullable=False)
+    asset_class = Column(String, nullable=False)
+    timeframe = Column(String, nullable=False)
+    adjustment_basis = Column(String, nullable=False)
+    manifest_version = Column(String, nullable=False)
+    last_closed_timestamp = Column(String, nullable=False)
+    cursor = Column(String, nullable=True)
+    run_id = Column(String, nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    __table_args__ = (
+        Index(
+            "uq_mvp_watermark_identity",
+            "source_id",
+            "instrument_id",
+            "timeframe",
+            "adjustment_basis",
+            "manifest_version",
+            unique=True,
+        ),
+    )
+
+
+class MvpSourceObservationRow(Base):
+    """Request-level observation with identity, window, policy and response hash."""
+
+    __tablename__ = "mvp_source_observations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    run_id = Column(String, nullable=False)
+    manifest_version = Column(String, nullable=False)
+    instrument_id = Column(String, nullable=False)
+    display_symbol = Column(String, nullable=False)
+    provider_symbol = Column(String, nullable=False)
+    source_id = Column(String, nullable=False)
+    asset_class = Column(String, nullable=False)
+    timeframe = Column(String, nullable=False)
+    success = Column(Boolean, nullable=False)
+    served_from = Column(String, nullable=False)
+    request_start = Column(String, nullable=True)
+    request_end = Column(String, nullable=True)
+    response_hash = Column(String, nullable=True)
+    policy_json = Column(Text, nullable=False, default="{}")
+    candle_count = Column(Integer, nullable=False, default=0)
+    latest_timestamp = Column(String, nullable=True)
+    latency_ms = Column(Float, nullable=True)
+    error = Column(Text, nullable=True)
+    observed_at = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        Index("ix_mvp_source_observation_run", "run_id", "source_id", "instrument_id", "timeframe"),
+    )
+
+
+class MvpQualityReceiptRow(Base):
+    """Quality gate receipt attached to one run/series."""
+
+    __tablename__ = "mvp_quality_receipts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    run_id = Column(String, nullable=False)
+    manifest_version = Column(String, nullable=False)
+    instrument_id = Column(String, nullable=False)
+    source_id = Column(String, nullable=False)
+    timeframe = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    gaps = Column(Integer, nullable=False, default=0)
+    duplicates = Column(Integer, nullable=False, default=0)
+    invalid_rows = Column(Integer, nullable=False, default=0)
+    blocked_cells = Column(Integer, nullable=False, default=0)
+    details_json = Column(Text, nullable=False, default="{}")
+    receipt_hash = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+
+class MvpTransformReceiptRow(Base):
+    """Auditable input/output identity for a derived timeframe."""
+
+    __tablename__ = "mvp_transform_receipts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    run_id = Column(String, nullable=False)
+    manifest_version = Column(String, nullable=False)
+    instrument_id = Column(String, nullable=False)
+    source_id = Column(String, nullable=False)
+    output_timeframe = Column(String, nullable=False)
+    input_timeframe = Column(String, nullable=False)
+    aggregation_rule_version = Column(String, nullable=False)
+    input_start = Column(String, nullable=False)
+    input_end = Column(String, nullable=False)
+    input_hash = Column(String, nullable=False)
+    output_hash = Column(String, nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+
+class MvpEntitlementReceiptRow(Base):
+    """Source licence/permission receipt; absence must remain a blocked state."""
+
+    __tablename__ = "mvp_entitlement_receipts"
+
+    receipt_id = Column(String, primary_key=True)
+    source_id = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    allowed_history_json = Column(Text, nullable=False)
+    timeframe_permissions_json = Column(Text, nullable=False)
+    persistence_allowed = Column(Boolean, nullable=False)
+    derived_allowed = Column(Boolean, nullable=False)
+    non_display_allowed = Column(Boolean, nullable=False)
+    valid_from = Column(String, nullable=True)
+    valid_to = Column(String, nullable=True)
+    evidence_ref = Column(String, nullable=False)
+    receipt_hash = Column(String, nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    __table_args__ = (Index("ix_mvp_entitlement_source", "source_id", "valid_from", "valid_to"),)
+
+
+class MvpBackupReceiptRow(Base):
+    """Completed consistent-backup receipt, including restore verification."""
+
+    __tablename__ = "mvp_backup_receipts"
+
+    backup_id = Column(String, primary_key=True)
+    run_id = Column(String, nullable=False)
+    destination = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    checksum = Column(String, nullable=False)
+    size_bytes = Column(Integer, nullable=False)
+    restore_verified = Column(Boolean, nullable=False)
+    policy_json = Column(Text, nullable=False, default="{}")
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)

--- a/src/kline/ports.py
+++ b/src/kline/ports.py
@@ -13,6 +13,16 @@ from typing import Any, AsyncIterator, Mapping, Protocol
 
 from kline.models import AssetClass, Candle, InstrumentDefinition, Timeframe, TimeframeTransform
 from kline.providers.base import Provider, ProviderError
+from kline.storage import StoragePort
+
+__all__ = [
+    "FetchReceipt",
+    "MarketDataPort",
+    "ProviderBackedMarketDataAdapter",
+    "ProviderMeta",
+    "SourceManifest",
+    "StoragePort",
+]
 
 
 @dataclass(frozen=True)
@@ -83,26 +93,20 @@ class MarketDataPort(Protocol):
     """Port every market-data adapter must implement."""
 
     @property
-    def manifest(self) -> SourceManifest:
-        ...
+    def manifest(self) -> SourceManifest: ...
 
     @property
-    def last_raw_response(self) -> dict[str, Any] | None:
-        ...
+    def last_raw_response(self) -> dict[str, Any] | None: ...
 
     @property
-    def timeframe_transform(self) -> TimeframeTransform | None:
-        ...
+    def timeframe_transform(self) -> TimeframeTransform | None: ...
 
     @property
-    def source_identity(self) -> Mapping[str, Any] | None:
-        ...
+    def source_identity(self) -> Mapping[str, Any] | None: ...
 
-    def canonical_ticker(self, ticker: str) -> str:
-        ...
+    def canonical_ticker(self, ticker: str) -> str: ...
 
-    def supported_timeframes(self) -> list[Timeframe]:
-        ...
+    def supported_timeframes(self) -> list[Timeframe]: ...
 
     async def fetch_candles(
         self,
@@ -112,8 +116,7 @@ class MarketDataPort(Protocol):
         start: str | None = None,
         end: str | None = None,
         limit: int = 500,
-    ) -> list[Candle]:
-        ...
+    ) -> list[Candle]: ...
 
     async def fetch_candles_with_receipt(
         self,
@@ -123,18 +126,15 @@ class MarketDataPort(Protocol):
         start: str | None = None,
         end: str | None = None,
         limit: int = 500,
-    ) -> FetchReceipt:
-        ...
+    ) -> FetchReceipt: ...
 
     async def stream_candles(
         self,
         ticker: str,
         timeframe: Timeframe,
-    ) -> AsyncIterator[Candle]:
-        ...
+    ) -> AsyncIterator[Candle]: ...
 
-    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition:
-        ...
+    async def fetch_instrument_definition(self, ticker: str) -> InstrumentDefinition: ...
 
 
 class ProviderBackedMarketDataAdapter:

--- a/src/kline/storage.py
+++ b/src/kline/storage.py
@@ -1,0 +1,265 @@
+"""Storage seam for the Market Data Database MVP.
+
+The public interface deliberately models an ingestion run rather than exposing
+SQLAlchemy sessions.  SQLite is one adapter behind this seam today; a future
+server-backed adapter can preserve the same identity and atomicity contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import math
+from typing import Any, Mapping, Protocol, Sequence
+
+
+MVP_TIMEFRAMES = frozenset({"15m", "4h", "1d", "1w"})
+VOLUME_SEMANTICS = frozenset({"traded", "quote_derived", "not_applicable"})
+
+
+class StorageError(ValueError):
+    """The storage contract rejected a write before or during a transaction."""
+
+
+def _value(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    if not isinstance(raw, str) or not raw.strip():
+        raise StorageError("storage identity values must be non-empty strings")
+    return raw.strip()
+
+
+def _timestamp(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise StorageError(f"{field_name} must be a non-empty ISO timestamp")
+    text = value.strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise StorageError(f"{field_name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class CandleSeriesKey:
+    """Stable identity for one persisted candle series."""
+
+    instrument_id: str
+    display_symbol: str
+    provider_symbol: str
+    source_id: str
+    asset_class: str
+    timeframe: str
+    adjustment_basis: str
+    manifest_version: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "instrument_id",
+            "display_symbol",
+            "provider_symbol",
+            "source_id",
+            "asset_class",
+            "adjustment_basis",
+            "manifest_version",
+        ):
+            object.__setattr__(self, field_name, _value(getattr(self, field_name)))
+        timeframe = _value(self.timeframe)
+        if timeframe not in MVP_TIMEFRAMES:
+            raise StorageError(f"unsupported MVP timeframe: {timeframe}")
+        object.__setattr__(self, "timeframe", timeframe)
+
+
+@dataclass(frozen=True)
+class MvpCandle:
+    """One source-aware candle, including the nullable volume semantics."""
+
+    key: CandleSeriesKey
+    timestamp: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float | None
+    amount: float | None = None
+    volume_semantics: str = "traded"
+    is_derived: bool = False
+    transform_receipt_id: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "timestamp", _timestamp(self.timestamp, field_name="timestamp"))
+        numeric = (self.open, self.high, self.low, self.close)
+        if not all(
+            isinstance(value, (int, float)) and math.isfinite(float(value)) for value in numeric
+        ):
+            raise StorageError("OHLC values must be finite numbers")
+        if self.high < max(self.open, self.close) or self.low > min(self.open, self.close):
+            raise StorageError("OHLC invariant failed")
+        semantics = _value(self.volume_semantics)
+        if semantics not in VOLUME_SEMANTICS:
+            raise StorageError(f"unknown volume_semantics: {semantics}")
+        if semantics == "not_applicable" and self.volume is not None:
+            raise StorageError("not_applicable volume must be NULL")
+        if semantics != "not_applicable" and self.volume is None:
+            raise StorageError("traded/quote_derived volume must be present")
+        if self.volume is not None and (
+            not isinstance(self.volume, (int, float))
+            or not math.isfinite(float(self.volume))
+            or self.volume < 0
+        ):
+            raise StorageError("volume must be a finite non-negative number or NULL")
+        if not isinstance(self.is_derived, bool):
+            raise StorageError("is_derived must be boolean")
+        object.__setattr__(self, "volume_semantics", semantics)
+
+
+@dataclass(frozen=True)
+class SourceObservationWrite:
+    """One upstream observation receipt attached to a run."""
+
+    run_id: str
+    key: CandleSeriesKey
+    success: bool
+    request_start: str | None
+    request_end: str | None
+    response_hash: str | None
+    policy: Mapping[str, Any] = field(default_factory=dict)
+    candle_count: int = 0
+    latest_timestamp: str | None = None
+    latency_ms: float | None = None
+    served_from: str = "upstream"
+    error: str | None = None
+    observed_at: str | None = None
+
+
+@dataclass(frozen=True)
+class QualityReceiptWrite:
+    run_id: str
+    key: CandleSeriesKey
+    status: str
+    gaps: int = 0
+    duplicates: int = 0
+    invalid_rows: int = 0
+    blocked_cells: int = 0
+    details: Mapping[str, Any] = field(default_factory=dict)
+    receipt_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class TransformReceiptWrite:
+    run_id: str
+    manifest_version: str
+    instrument_id: str
+    source_id: str
+    output_timeframe: str
+    input_timeframe: str
+    aggregation_rule_version: str
+    input_start: str
+    input_end: str
+    input_hash: str
+    output_hash: str
+
+
+@dataclass(frozen=True)
+class WatermarkWrite:
+    key: CandleSeriesKey
+    last_closed_timestamp: str
+    cursor: str | None
+    run_id: str
+
+
+@dataclass(frozen=True)
+class EntitlementReceiptWrite:
+    receipt_id: str
+    source_id: str
+    status: str
+    allowed_history: Mapping[str, Any]
+    timeframe_permissions: Sequence[str]
+    persistence_allowed: bool
+    derived_allowed: bool
+    non_display_allowed: bool
+    valid_from: str | None
+    valid_to: str | None
+    evidence_ref: str
+    receipt_hash: str
+
+
+@dataclass(frozen=True)
+class BackupReceiptWrite:
+    backup_id: str
+    run_id: str
+    destination: str
+    status: str
+    checksum: str
+    size_bytes: int
+    restore_verified: bool
+    policy: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MvpRunWrite:
+    """Atomic unit submitted to the storage adapter."""
+
+    run_id: str
+    manifest_version: str
+    manifest_hash: str
+    started_at: str
+    window_start: str | None
+    window_end: str | None
+    policy: Mapping[str, Any]
+    candles: Sequence[MvpCandle] = ()
+    source_observations: Sequence[SourceObservationWrite] = ()
+    quality_receipts: Sequence[QualityReceiptWrite] = ()
+    transform_receipts: Sequence[TransformReceiptWrite] = ()
+    watermarks: Sequence[WatermarkWrite] = ()
+    entitlement_receipts: Sequence[EntitlementReceiptWrite] = ()
+    backup_receipts: Sequence[BackupReceiptWrite] = ()
+    status: str = "success"
+    completed_at: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class MvpRunReceipt:
+    run_id: str
+    status: str
+    manifest_version: str
+    manifest_hash: str
+    candle_count: int
+    observation_count: int
+    quality_count: int
+    transform_count: int
+    watermark_count: int
+    committed_at: str
+
+
+@dataclass(frozen=True)
+class WatermarkState:
+    key: CandleSeriesKey
+    last_closed_timestamp: str
+    cursor: str | None
+    run_id: str
+
+
+class StoragePort(Protocol):
+    """Deep storage seam used by the ingestion orchestrator."""
+
+    def commit_mvp_run(self, write: MvpRunWrite) -> MvpRunReceipt:
+        """Atomically persist a run, its observations/receipts, candles and watermarks."""
+        ...
+
+    def query_mvp_candles(
+        self,
+        key: CandleSeriesKey,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[MvpCandle]:
+        """Read only the exact source-aware series identified by ``key``."""
+        ...
+
+    def get_mvp_watermark(self, key: CandleSeriesKey) -> WatermarkState | None:
+        """Return the last atomically promoted closed-bar watermark."""
+        ...

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import hashlib
 import json
-from typing import Any
+from typing import Any, Sequence
 
-from sqlalchemy import create_engine, event, select
+from sqlalchemy import create_engine, event, func, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import sessionmaker
 
@@ -17,6 +19,28 @@ from kline.models import (
     RawUpstreamResponse,
     SourceObservation,
     Timeframe,
+    MvpBackupReceiptRow,
+    MvpCandleRow,
+    MvpEntitlementReceiptRow,
+    MvpQualityReceiptRow,
+    MvpRunRow,
+    MvpSourceObservationRow,
+    MvpTransformReceiptRow,
+    MvpWatermarkRow,
+)
+from kline.storage import (
+    BackupReceiptWrite,
+    CandleSeriesKey,
+    EntitlementReceiptWrite,
+    MvpCandle,
+    MvpRunReceipt,
+    MvpRunWrite,
+    QualityReceiptWrite,
+    SourceObservationWrite,
+    StorageError,
+    TransformReceiptWrite,
+    WatermarkState,
+    WatermarkWrite,
 )
 
 LEGACY_SOURCE_ID = "legacy_unknown"
@@ -27,6 +51,7 @@ class KlineStore:
 
     def __init__(self, db_path: str) -> None:
         self._engine = create_engine(f"sqlite:///{db_path}", echo=False)
+        self._mvp_commit_failpoint = None
         # Enable WAL mode for concurrent reads
         event.listen(self._engine, "connect", self._enable_wal)
         Base.metadata.create_all(self._engine)
@@ -69,8 +94,7 @@ class KlineStore:
                 unique_sql = "UNIQUE " if unique else ""
                 joined = ", ".join(expected_columns)
                 connection.exec_driver_sql(
-                    f"CREATE {unique_sql}INDEX IF NOT EXISTS {index_name} "
-                    f"ON klines ({joined})"
+                    f"CREATE {unique_sql}INDEX IF NOT EXISTS {index_name} ON klines ({joined})"
                 )
 
     def _normalize_stored_timestamps(self) -> None:
@@ -395,13 +419,630 @@ class KlineStore:
             stmt = select(func.count()).select_from(RawUpstreamResponse)
             return session.execute(stmt).scalar_one()
 
+    @staticmethod
+    def _mvp_key_identity(key: CandleSeriesKey) -> tuple[str, ...]:
+        return (
+            key.source_id,
+            key.instrument_id,
+            key.timeframe,
+            key.adjustment_basis,
+            key.manifest_version,
+        )
+
+    @staticmethod
+    def _mvp_json(value: Any, *, field_name: str) -> str:
+        if not isinstance(value, dict) and not hasattr(value, "items"):
+            raise StorageError(f"{field_name} must be JSON object-like")
+        try:
+            return json.dumps(
+                dict(value), ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+        except (TypeError, ValueError) as exc:
+            raise StorageError(f"{field_name} must be JSON serializable") from exc
+
+    @staticmethod
+    def _mvp_hash(value: str, *, field_name: str) -> str:
+        if not isinstance(value, str) or len(value) != 64:
+            raise StorageError(f"{field_name} must be a SHA-256 hex digest")
+        lowered = value.lower()
+        if any(char not in "0123456789abcdef" for char in lowered):
+            raise StorageError(f"{field_name} must be a SHA-256 hex digest")
+        return lowered
+
+    @staticmethod
+    def _mvp_text(value: Any, *, field_name: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise StorageError(f"{field_name} must be a non-empty string")
+        return value.strip()
+
+    def _validate_mvp_run(self, write: MvpRunWrite) -> None:
+        if not isinstance(write, MvpRunWrite):
+            raise StorageError("commit_mvp_run expects MvpRunWrite")
+        self._mvp_text(write.run_id, field_name="run_id")
+        self._mvp_text(write.manifest_version, field_name="manifest_version")
+        self._mvp_hash(write.manifest_hash, field_name="manifest_hash")
+        self._mvp_text(write.started_at, field_name="started_at")
+        if write.completed_at is not None:
+            self._mvp_text(write.completed_at, field_name="completed_at")
+        if write.window_start is not None:
+            self._mvp_text(write.window_start, field_name="window_start")
+        if write.window_end is not None:
+            self._mvp_text(write.window_end, field_name="window_end")
+        self._mvp_json(write.policy, field_name="policy")
+        if write.status not in {"success", "failed"}:
+            raise StorageError("run status must be success or failed")
+        if write.status == "failed":
+            if not write.error:
+                raise StorageError("failed run requires error")
+            if any(
+                (
+                    write.candles,
+                    write.source_observations,
+                    write.quality_receipts,
+                    write.transform_receipts,
+                    write.watermarks,
+                )
+            ):
+                raise StorageError("failed run cannot promote candles or watermarks")
+
+        candle_keys: set[tuple[Any, ...]] = set()
+        for candle in write.candles:
+            if not isinstance(candle, MvpCandle):
+                raise StorageError("candles must contain MvpCandle values")
+            if candle.key.manifest_version != write.manifest_version:
+                raise StorageError("candle manifest_version does not match run")
+            identity = (*self._mvp_key_identity(candle.key), candle.timestamp)
+            if identity in candle_keys:
+                raise StorageError("duplicate candle identity in one run")
+            candle_keys.add(identity)
+
+        for observation in write.source_observations:
+            if not isinstance(observation, SourceObservationWrite):
+                raise StorageError("source_observations must contain SourceObservationWrite values")
+            if observation.run_id != write.run_id:
+                raise StorageError("source observation run_id does not match run")
+            if not isinstance(observation.success, bool):
+                raise StorageError("source observation success must be boolean")
+            if observation.key.manifest_version != write.manifest_version:
+                raise StorageError("source observation manifest_version does not match run")
+            if observation.candle_count < 0:
+                raise StorageError("source observation candle_count cannot be negative")
+            self._mvp_json(observation.policy, field_name="source observation policy")
+            if observation.request_start is not None:
+                self._mvp_text(observation.request_start, field_name="request_start")
+            if observation.request_end is not None:
+                self._mvp_text(observation.request_end, field_name="request_end")
+            if observation.response_hash is not None:
+                self._mvp_hash(observation.response_hash, field_name="response_hash")
+            if observation.latest_timestamp is not None:
+                self._mvp_text(observation.latest_timestamp, field_name="latest_timestamp")
+            if observation.observed_at is not None:
+                self._mvp_text(observation.observed_at, field_name="observed_at")
+            self._mvp_text(observation.served_from, field_name="served_from")
+            if observation.latency_ms is not None and (
+                not isinstance(observation.latency_ms, (int, float)) or observation.latency_ms < 0
+            ):
+                raise StorageError("source observation latency_ms must be non-negative")
+
+        quality_keys: set[tuple[Any, ...]] = set()
+        for quality in write.quality_receipts:
+            if not isinstance(quality, QualityReceiptWrite):
+                raise StorageError("quality_receipts must contain QualityReceiptWrite values")
+            if (
+                quality.run_id != write.run_id
+                or quality.key.manifest_version != write.manifest_version
+            ):
+                raise StorageError("quality receipt identity does not match run")
+            identity = (*self._mvp_key_identity(quality.key),)
+            if identity in quality_keys:
+                raise StorageError("duplicate quality receipt identity in one run")
+            quality_keys.add(identity)
+            if quality.status not in {"pass", "partial", "blocked", "fail"}:
+                raise StorageError("quality receipt status is invalid")
+            for field_name in ("gaps", "duplicates", "invalid_rows", "blocked_cells"):
+                value = getattr(quality, field_name)
+                if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                    raise StorageError(f"quality receipt {field_name} must be non-negative integer")
+            self._mvp_json(quality.details, field_name="quality details")
+            if quality.receipt_hash is not None:
+                self._mvp_hash(quality.receipt_hash, field_name="quality receipt_hash")
+
+        transform_keys: set[tuple[Any, ...]] = set()
+        for transform in write.transform_receipts:
+            if not isinstance(transform, TransformReceiptWrite):
+                raise StorageError("transform_receipts must contain TransformReceiptWrite values")
+            if (
+                transform.run_id != write.run_id
+                or transform.manifest_version != write.manifest_version
+            ):
+                raise StorageError("transform receipt identity does not match run")
+            if transform.output_timeframe not in {
+                "15m",
+                "4h",
+                "1d",
+                "1w",
+            } or transform.input_timeframe not in {
+                "15m",
+                "4h",
+                "1d",
+                "1w",
+            }:
+                raise StorageError("transform receipt timeframe is invalid")
+            if transform.output_timeframe == transform.input_timeframe:
+                raise StorageError("transform receipt must change timeframe")
+            identity = (
+                transform.instrument_id,
+                transform.source_id,
+                transform.output_timeframe,
+                transform.input_timeframe,
+            )
+            if identity in transform_keys:
+                raise StorageError("duplicate transform receipt identity in one run")
+            transform_keys.add(identity)
+            for field_name in ("input_start", "input_end", "aggregation_rule_version"):
+                self._mvp_text(getattr(transform, field_name), field_name=field_name)
+            self._mvp_hash(transform.input_hash, field_name="input_hash")
+            self._mvp_hash(transform.output_hash, field_name="output_hash")
+
+        watermark_keys: set[tuple[Any, ...]] = set()
+        for watermark in write.watermarks:
+            if not isinstance(watermark, WatermarkWrite):
+                raise StorageError("watermarks must contain WatermarkWrite values")
+            if (
+                watermark.run_id != write.run_id
+                or watermark.key.manifest_version != write.manifest_version
+            ):
+                raise StorageError("watermark identity does not match run")
+            identity = self._mvp_key_identity(watermark.key)
+            if identity in watermark_keys:
+                raise StorageError("duplicate watermark identity in one run")
+            watermark_keys.add(identity)
+            self._mvp_text(watermark.last_closed_timestamp, field_name="last_closed_timestamp")
+            if watermark.cursor is not None:
+                self._mvp_text(watermark.cursor, field_name="cursor")
+
+        for entitlement in write.entitlement_receipts:
+            if not isinstance(entitlement, EntitlementReceiptWrite):
+                raise StorageError(
+                    "entitlement_receipts must contain EntitlementReceiptWrite values"
+                )
+            for field_name in ("receipt_id", "source_id", "status", "evidence_ref", "receipt_hash"):
+                self._mvp_text(getattr(entitlement, field_name), field_name=field_name)
+            self._mvp_hash(entitlement.receipt_hash, field_name="receipt_hash")
+            self._mvp_json(entitlement.allowed_history, field_name="allowed_history")
+            if not isinstance(entitlement.timeframe_permissions, Sequence) or isinstance(
+                entitlement.timeframe_permissions, (str, bytes)
+            ):
+                raise StorageError("timeframe_permissions must be a sequence")
+            if any(
+                item not in {"15m", "4h", "1d", "1w"} for item in entitlement.timeframe_permissions
+            ):
+                raise StorageError("timeframe_permissions contains unsupported timeframe")
+            if not all(
+                isinstance(value, bool)
+                for value in (
+                    entitlement.persistence_allowed,
+                    entitlement.derived_allowed,
+                    entitlement.non_display_allowed,
+                )
+            ):
+                raise StorageError("entitlement permissions must be boolean")
+
+        for backup in write.backup_receipts:
+            if not isinstance(backup, BackupReceiptWrite):
+                raise StorageError("backup_receipts must contain BackupReceiptWrite values")
+            for field_name in ("backup_id", "run_id", "destination", "status", "checksum"):
+                self._mvp_text(getattr(backup, field_name), field_name=field_name)
+            if backup.run_id != write.run_id:
+                raise StorageError("backup receipt run_id does not match run")
+            self._mvp_hash(backup.checksum, field_name="checksum")
+            if (
+                not isinstance(backup.size_bytes, int)
+                or isinstance(backup.size_bytes, bool)
+                or backup.size_bytes < 0
+            ):
+                raise StorageError("backup size_bytes must be a non-negative integer")
+            if not isinstance(backup.restore_verified, bool):
+                raise StorageError("backup restore_verified must be boolean")
+            self._mvp_json(backup.policy, field_name="backup policy")
+
+    @staticmethod
+    def _mvp_now() -> str:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    @staticmethod
+    def _mvp_run_receipt(row: MvpRunRow) -> MvpRunReceipt:
+        return MvpRunReceipt(
+            run_id=row.run_id,
+            status=row.status,
+            manifest_version=row.manifest_version,
+            manifest_hash=row.manifest_hash,
+            candle_count=row.candle_count,
+            observation_count=row.observation_count,
+            quality_count=row.quality_count,
+            transform_count=row.transform_count,
+            watermark_count=row.watermark_count,
+            committed_at=row.committed_at or "",
+        )
+
+    def commit_mvp_run(self, write: MvpRunWrite) -> MvpRunReceipt:
+        """Atomically persist a complete MVP run and all of its receipts."""
+
+        self._validate_mvp_run(write)
+        committed_at = self._mvp_now()
+        receipt_hash = hashlib.sha256(
+            json.dumps(
+                {
+                    "run_id": write.run_id,
+                    "manifest_version": write.manifest_version,
+                    "manifest_hash": write.manifest_hash,
+                    "status": write.status,
+                    "candle_count": len(write.candles),
+                    "observation_count": len(write.source_observations),
+                    "quality_count": len(write.quality_receipts),
+                    "transform_count": len(write.transform_receipts),
+                    "watermark_count": len(write.watermarks),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+
+        with self._session_factory() as session:
+            existing = session.get(MvpRunRow, write.run_id)
+            if existing is not None:
+                session.rollback()
+                if (
+                    existing.manifest_version != write.manifest_version
+                    or existing.manifest_hash != write.manifest_hash
+                ):
+                    raise StorageError("run_id already belongs to a different manifest")
+                if existing.status != "success":
+                    raise StorageError("run_id already has a failed attempt")
+                return self._mvp_run_receipt(existing)
+            session.rollback()
+
+            try:
+                with session.begin():
+                    run_row = MvpRunRow(
+                        run_id=write.run_id,
+                        manifest_version=write.manifest_version,
+                        manifest_hash=write.manifest_hash.lower(),
+                        status=write.status,
+                        started_at=write.started_at,
+                        completed_at=write.completed_at or committed_at,
+                        window_start=write.window_start,
+                        window_end=write.window_end,
+                        policy_json=self._mvp_json(write.policy, field_name="policy"),
+                        receipt_hash=receipt_hash,
+                        error=write.error,
+                        candle_count=len(write.candles),
+                        observation_count=len(write.source_observations),
+                        quality_count=len(write.quality_receipts),
+                        transform_count=len(write.transform_receipts),
+                        watermark_count=len(write.watermarks),
+                        committed_at=committed_at,
+                    )
+                    session.add(run_row)
+
+                    for entitlement in write.entitlement_receipts:
+                        session.add(
+                            MvpEntitlementReceiptRow(
+                                receipt_id=entitlement.receipt_id,
+                                source_id=entitlement.source_id,
+                                status=entitlement.status,
+                                allowed_history_json=self._mvp_json(
+                                    entitlement.allowed_history, field_name="allowed_history"
+                                ),
+                                timeframe_permissions_json=json.dumps(
+                                    list(entitlement.timeframe_permissions),
+                                    ensure_ascii=False,
+                                    sort_keys=True,
+                                ),
+                                persistence_allowed=entitlement.persistence_allowed,
+                                derived_allowed=entitlement.derived_allowed,
+                                non_display_allowed=entitlement.non_display_allowed,
+                                valid_from=entitlement.valid_from,
+                                valid_to=entitlement.valid_to,
+                                evidence_ref=entitlement.evidence_ref,
+                                receipt_hash=entitlement.receipt_hash.lower(),
+                            )
+                        )
+
+                    for transform in write.transform_receipts:
+                        row = MvpTransformReceiptRow(
+                            run_id=transform.run_id,
+                            manifest_version=transform.manifest_version,
+                            instrument_id=transform.instrument_id,
+                            source_id=transform.source_id,
+                            output_timeframe=transform.output_timeframe,
+                            input_timeframe=transform.input_timeframe,
+                            aggregation_rule_version=transform.aggregation_rule_version,
+                            input_start=transform.input_start,
+                            input_end=transform.input_end,
+                            input_hash=transform.input_hash.lower(),
+                            output_hash=transform.output_hash.lower(),
+                        )
+                        session.add(row)
+                    session.flush()
+
+                    for candle in write.candles:
+                        values = {
+                            "instrument_id": candle.key.instrument_id,
+                            "display_symbol": candle.key.display_symbol,
+                            "provider_symbol": candle.key.provider_symbol,
+                            "source_id": candle.key.source_id,
+                            "asset_class": candle.key.asset_class,
+                            "timeframe": candle.key.timeframe,
+                            "adjustment_basis": candle.key.adjustment_basis,
+                            "manifest_version": candle.key.manifest_version,
+                            "timestamp": candle.timestamp,
+                            "open": candle.open,
+                            "high": candle.high,
+                            "low": candle.low,
+                            "close": candle.close,
+                            "volume": candle.volume,
+                            "amount": candle.amount,
+                            "volume_semantics": candle.volume_semantics,
+                            "is_derived": candle.is_derived,
+                            "transform_receipt_id": candle.transform_receipt_id,
+                        }
+                        stmt = sqlite_insert(MvpCandleRow).values(values)
+                        stmt = stmt.on_conflict_do_update(
+                            index_elements=[
+                                "source_id",
+                                "instrument_id",
+                                "timeframe",
+                                "adjustment_basis",
+                                "manifest_version",
+                                "timestamp",
+                            ],
+                            set_={
+                                "display_symbol": stmt.excluded.display_symbol,
+                                "provider_symbol": stmt.excluded.provider_symbol,
+                                "asset_class": stmt.excluded.asset_class,
+                                "open": stmt.excluded.open,
+                                "high": stmt.excluded.high,
+                                "low": stmt.excluded.low,
+                                "close": stmt.excluded.close,
+                                "volume": stmt.excluded.volume,
+                                "amount": stmt.excluded.amount,
+                                "volume_semantics": stmt.excluded.volume_semantics,
+                                "is_derived": stmt.excluded.is_derived,
+                                "transform_receipt_id": stmt.excluded.transform_receipt_id,
+                            },
+                        )
+                        session.execute(stmt)
+
+                    if callable(self._mvp_commit_failpoint):
+                        self._mvp_commit_failpoint("after_candles")
+
+                    for observation in write.source_observations:
+                        session.add(
+                            MvpSourceObservationRow(
+                                run_id=observation.run_id,
+                                manifest_version=observation.key.manifest_version,
+                                instrument_id=observation.key.instrument_id,
+                                display_symbol=observation.key.display_symbol,
+                                provider_symbol=observation.key.provider_symbol,
+                                source_id=observation.key.source_id,
+                                asset_class=observation.key.asset_class,
+                                timeframe=observation.key.timeframe,
+                                success=observation.success,
+                                served_from=observation.served_from,
+                                request_start=observation.request_start,
+                                request_end=observation.request_end,
+                                response_hash=observation.response_hash.lower()
+                                if observation.response_hash
+                                else None,
+                                policy_json=self._mvp_json(
+                                    observation.policy, field_name="source observation policy"
+                                ),
+                                candle_count=observation.candle_count,
+                                latest_timestamp=observation.latest_timestamp,
+                                latency_ms=observation.latency_ms,
+                                error=observation.error,
+                                observed_at=observation.observed_at,
+                            )
+                        )
+                    for quality in write.quality_receipts:
+                        session.add(
+                            MvpQualityReceiptRow(
+                                run_id=quality.run_id,
+                                manifest_version=quality.key.manifest_version,
+                                instrument_id=quality.key.instrument_id,
+                                source_id=quality.key.source_id,
+                                timeframe=quality.key.timeframe,
+                                status=quality.status,
+                                gaps=quality.gaps,
+                                duplicates=quality.duplicates,
+                                invalid_rows=quality.invalid_rows,
+                                blocked_cells=quality.blocked_cells,
+                                details_json=self._mvp_json(
+                                    quality.details, field_name="quality details"
+                                ),
+                                receipt_hash=quality.receipt_hash.lower()
+                                if quality.receipt_hash
+                                else None,
+                            )
+                        )
+                    for watermark in write.watermarks:
+                        existing_watermark = session.execute(
+                            select(MvpWatermarkRow).where(
+                                MvpWatermarkRow.source_id == watermark.key.source_id,
+                                MvpWatermarkRow.instrument_id == watermark.key.instrument_id,
+                                MvpWatermarkRow.timeframe == watermark.key.timeframe,
+                                MvpWatermarkRow.adjustment_basis == watermark.key.adjustment_basis,
+                                MvpWatermarkRow.manifest_version == watermark.key.manifest_version,
+                            )
+                        ).scalar_one_or_none()
+                        if (
+                            existing_watermark is not None
+                            and watermark.last_closed_timestamp
+                            < existing_watermark.last_closed_timestamp
+                        ):
+                            raise StorageError("watermark cannot move backwards")
+                        if existing_watermark is None:
+                            session.add(
+                                MvpWatermarkRow(
+                                    instrument_id=watermark.key.instrument_id,
+                                    display_symbol=watermark.key.display_symbol,
+                                    provider_symbol=watermark.key.provider_symbol,
+                                    source_id=watermark.key.source_id,
+                                    asset_class=watermark.key.asset_class,
+                                    timeframe=watermark.key.timeframe,
+                                    adjustment_basis=watermark.key.adjustment_basis,
+                                    manifest_version=watermark.key.manifest_version,
+                                    last_closed_timestamp=watermark.last_closed_timestamp,
+                                    cursor=watermark.cursor,
+                                    run_id=watermark.run_id,
+                                )
+                            )
+                        else:
+                            existing_watermark.display_symbol = watermark.key.display_symbol
+                            existing_watermark.provider_symbol = watermark.key.provider_symbol
+                            existing_watermark.asset_class = watermark.key.asset_class
+                            existing_watermark.last_closed_timestamp = (
+                                watermark.last_closed_timestamp
+                            )
+                            existing_watermark.cursor = watermark.cursor
+                            existing_watermark.run_id = watermark.run_id
+
+                    for backup in write.backup_receipts:
+                        session.add(
+                            MvpBackupReceiptRow(
+                                backup_id=backup.backup_id,
+                                run_id=backup.run_id,
+                                destination=backup.destination,
+                                status=backup.status,
+                                checksum=backup.checksum.lower(),
+                                size_bytes=backup.size_bytes,
+                                restore_verified=backup.restore_verified,
+                                policy_json=self._mvp_json(
+                                    backup.policy, field_name="backup policy"
+                                ),
+                            )
+                        )
+                    if callable(self._mvp_commit_failpoint):
+                        self._mvp_commit_failpoint("before_commit")
+            except StorageError:
+                raise
+            except Exception as exc:
+                raise StorageError(f"MVP run transaction rolled back: {exc}") from exc
+
+            return MvpRunReceipt(
+                run_id=write.run_id,
+                status=write.status,
+                manifest_version=write.manifest_version,
+                manifest_hash=write.manifest_hash.lower(),
+                candle_count=len(write.candles),
+                observation_count=len(write.source_observations),
+                quality_count=len(write.quality_receipts),
+                transform_count=len(write.transform_receipts),
+                watermark_count=len(write.watermarks),
+                committed_at=committed_at,
+            )
+
+    def query_mvp_candles(
+        self,
+        key: CandleSeriesKey,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[MvpCandle]:
+        """Read a source-aware MVP series without consulting the legacy table."""
+
+        if limit < 1:
+            return []
+        with self._session_factory() as session:
+            stmt = (
+                select(MvpCandleRow)
+                .where(
+                    MvpCandleRow.source_id == key.source_id,
+                    MvpCandleRow.instrument_id == key.instrument_id,
+                    MvpCandleRow.timeframe == key.timeframe,
+                    MvpCandleRow.adjustment_basis == key.adjustment_basis,
+                    MvpCandleRow.manifest_version == key.manifest_version,
+                )
+                .order_by(MvpCandleRow.timestamp.desc())
+                .limit(limit)
+            )
+            if start is not None:
+                stmt = stmt.where(MvpCandleRow.timestamp >= start)
+            if end is not None:
+                stmt = stmt.where(MvpCandleRow.timestamp <= end)
+            rows = list(session.execute(stmt).scalars())
+        return [
+            MvpCandle(
+                key=key,
+                timestamp=row.timestamp,
+                open=row.open,
+                high=row.high,
+                low=row.low,
+                close=row.close,
+                volume=row.volume,
+                amount=row.amount,
+                volume_semantics=row.volume_semantics,
+                is_derived=row.is_derived,
+                transform_receipt_id=row.transform_receipt_id,
+            )
+            for row in reversed(rows)
+        ]
+
+    def get_mvp_watermark(self, key: CandleSeriesKey) -> WatermarkState | None:
+        """Return the last closed-bar watermark for an exact series key."""
+
+        with self._session_factory() as session:
+            row = session.execute(
+                select(MvpWatermarkRow).where(
+                    MvpWatermarkRow.source_id == key.source_id,
+                    MvpWatermarkRow.instrument_id == key.instrument_id,
+                    MvpWatermarkRow.timeframe == key.timeframe,
+                    MvpWatermarkRow.adjustment_basis == key.adjustment_basis,
+                    MvpWatermarkRow.manifest_version == key.manifest_version,
+                )
+            ).scalar_one_or_none()
+        if row is None:
+            return None
+        return WatermarkState(
+            key=key,
+            last_closed_timestamp=row.last_closed_timestamp,
+            cursor=row.cursor,
+            run_id=row.run_id,
+        )
+
+    def mvp_storage_health(self) -> dict[str, Any]:
+        """Return counts for the MVP serving and receipt tables."""
+
+        tables = {
+            "candles": MvpCandleRow,
+            "runs": MvpRunRow,
+            "watermarks": MvpWatermarkRow,
+            "source_observations": MvpSourceObservationRow,
+            "quality_receipts": MvpQualityReceiptRow,
+            "transform_receipts": MvpTransformReceiptRow,
+            "entitlement_receipts": MvpEntitlementReceiptRow,
+            "backup_receipts": MvpBackupReceiptRow,
+        }
+        with self._session_factory() as session:
+            counts = {
+                name: int(session.execute(select(func.count()).select_from(model)).scalar_one())
+                for name, model in tables.items()
+            }
+        return {"status": "ok", **counts}
+
     def storage_health(self) -> dict[str, Any]:
         """Return an owner-side integrity receipt without exposing the database path."""
         with self._engine.connect() as connection:
             integrity = str(connection.exec_driver_sql("PRAGMA integrity_check").scalar_one())
-            candle_rows = int(connection.exec_driver_sql("SELECT COUNT(*) FROM klines").scalar_one())
+            candle_rows = int(
+                connection.exec_driver_sql("SELECT COUNT(*) FROM klines").scalar_one()
+            )
             source_rows = int(
-                connection.exec_driver_sql("SELECT COUNT(DISTINCT source_id) FROM klines").scalar_one()
+                connection.exec_driver_sql(
+                    "SELECT COUNT(DISTINCT source_id) FROM klines"
+                ).scalar_one()
             )
         return {
             "status": "ok" if integrity == "ok" else "error",

--- a/tests/test_mvp_storage.py
+++ b/tests/test_mvp_storage.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from kline.storage import (
+    BackupReceiptWrite,
+    CandleSeriesKey,
+    EntitlementReceiptWrite,
+    MvpCandle,
+    MvpRunWrite,
+    QualityReceiptWrite,
+    SourceObservationWrite,
+    StorageError,
+    TransformReceiptWrite,
+    WatermarkWrite,
+)
+from kline.store import KlineStore
+
+
+def _key(
+    *,
+    instrument_id: str = "US.AAPL",
+    display_symbol: str = "AAPL",
+    provider_symbol: str = "AAPL",
+    source_id: str = "source-a",
+    asset_class: str = "us_stock",
+    timeframe: str = "1d",
+    adjustment_basis: str = "raw_unadjusted",
+    manifest_version: str = "mvp_universe_v1",
+) -> CandleSeriesKey:
+    return CandleSeriesKey(
+        instrument_id=instrument_id,
+        display_symbol=display_symbol,
+        provider_symbol=provider_symbol,
+        source_id=source_id,
+        asset_class=asset_class,
+        timeframe=timeframe,
+        adjustment_basis=adjustment_basis,
+        manifest_version=manifest_version,
+    )
+
+
+def _candle(
+    key: CandleSeriesKey,
+    *,
+    close: float = 101.0,
+    volume: float | None = 10.0,
+    semantics: str = "traded",
+) -> MvpCandle:
+    return MvpCandle(
+        key=key,
+        timestamp="2026-08-31T20:00:00+00:00",
+        open=100.0,
+        high=max(102.0, close),
+        low=99.0,
+        close=close,
+        volume=volume,
+        volume_semantics=semantics,
+    )
+
+
+def _run(*, run_id: str, key: CandleSeriesKey, candles: tuple[MvpCandle, ...] = ()) -> MvpRunWrite:
+    return MvpRunWrite(
+        run_id=run_id,
+        manifest_version=key.manifest_version,
+        manifest_hash="a" * 64,
+        started_at="2026-08-31T20:00:00+00:00",
+        window_start="2026-08-30T00:00:00+00:00",
+        window_end="2026-08-31T20:00:00+00:00",
+        policy={"overlap_bars": 2},
+        candles=candles,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> KlineStore:
+    return KlineStore(str(tmp_path / "mvp.db"))
+
+
+def test_mvp_series_key_is_source_and_instrument_aware(store: KlineStore) -> None:
+    first = _key(source_id="source-a", instrument_id="US.AAPL")
+    second = _key(source_id="source-b", instrument_id="US.AAPL")
+
+    store.commit_mvp_run(_run(run_id="run-a", key=first, candles=(_candle(first, close=101),)))
+    store.commit_mvp_run(_run(run_id="run-b", key=second, candles=(_candle(second, close=202),)))
+
+    assert store.query_mvp_candles(first)[0].close == 101
+    assert store.query_mvp_candles(second)[0].close == 202
+    assert store.mvp_storage_health()["candles"] == 2
+
+
+def test_mvp_volume_null_is_allowed_only_for_not_applicable(store: KlineStore) -> None:
+    key = _key(instrument_id="US.INDEX.SPX", display_symbol="SPX", asset_class="index")
+    store.commit_mvp_run(
+        _run(
+            run_id="run-index",
+            key=key,
+            candles=(_candle(key, volume=None, semantics="not_applicable"),),
+        )
+    )
+
+    assert store.query_mvp_candles(key)[0].volume is None
+
+    with pytest.raises(StorageError, match="must be NULL"):
+        _candle(key, volume=1.0, semantics="not_applicable")
+
+
+def test_mvp_upsert_is_idempotent_and_replaces_same_identity(store: KlineStore) -> None:
+    key = _key()
+    first = store.commit_mvp_run(
+        _run(run_id="run-one", key=key, candles=(_candle(key, close=101),))
+    )
+    second = store.commit_mvp_run(
+        _run(run_id="run-two", key=key, candles=(_candle(key, close=202),))
+    )
+
+    assert first.candle_count == second.candle_count == 1
+    assert len(store.query_mvp_candles(key)) == 1
+    assert store.query_mvp_candles(key)[0].close == 202
+    assert (
+        store.commit_mvp_run(_run(run_id="run-two", key=key, candles=(_candle(key, close=999),)))
+        == second
+    )
+    assert store.query_mvp_candles(key)[0].close == 202
+
+
+def test_mvp_duplicate_input_is_rejected_before_transaction(store: KlineStore) -> None:
+    key = _key()
+    candle = _candle(key)
+    with pytest.raises(StorageError, match="duplicate candle identity"):
+        store.commit_mvp_run(_run(run_id="run-duplicate", key=key, candles=(candle, candle)))
+
+    assert store.query_mvp_candles(key) == []
+    assert store.mvp_storage_health()["runs"] == 0
+
+
+def test_mvp_transaction_rolls_back_candles_receipts_and_watermarks(store: KlineStore) -> None:
+    key = _key()
+    write = replace(
+        _run(run_id="run-rollback", key=key, candles=(_candle(key),)),
+        quality_receipts=(
+            QualityReceiptWrite(
+                run_id="run-rollback",
+                key=key,
+                status="pass",
+            ),
+        ),
+        watermarks=(
+            WatermarkWrite(
+                key=key,
+                last_closed_timestamp="2026-08-31T20:00:00+00:00",
+                cursor="cursor-1",
+                run_id="run-rollback",
+            ),
+        ),
+    )
+
+    def fail(stage: str) -> None:
+        if stage == "after_candles":
+            raise RuntimeError("forced interruption")
+
+    store._mvp_commit_failpoint = fail
+    with pytest.raises(StorageError, match="forced interruption"):
+        store.commit_mvp_run(write)
+
+    assert store.query_mvp_candles(key) == []
+    assert store.get_mvp_watermark(key) is None
+    assert store.mvp_storage_health()["runs"] == 0
+
+
+def test_mvp_persists_source_quality_transform_entitlement_and_backup_receipts(
+    store: KlineStore,
+) -> None:
+    key = _key()
+    run_id = "run-receipts"
+    write = replace(
+        _run(run_id=run_id, key=key, candles=(_candle(key),)),
+        source_observations=(
+            SourceObservationWrite(
+                run_id=run_id,
+                key=key,
+                success=True,
+                request_start="2026-08-30T00:00:00+00:00",
+                request_end="2026-08-31T20:00:00+00:00",
+                response_hash="b" * 64,
+                policy={"retention": "receipt-only"},
+                candle_count=1,
+                latest_timestamp="2026-08-31T20:00:00+00:00",
+            ),
+        ),
+        quality_receipts=(QualityReceiptWrite(run_id=run_id, key=key, status="pass"),),
+        transform_receipts=(
+            TransformReceiptWrite(
+                run_id=run_id,
+                manifest_version=key.manifest_version,
+                instrument_id=key.instrument_id,
+                source_id=key.source_id,
+                output_timeframe="1w",
+                input_timeframe="1d",
+                aggregation_rule_version="mvp-aggregation-v1",
+                input_start="2026-08-24",
+                input_end="2026-08-28",
+                input_hash="c" * 64,
+                output_hash="d" * 64,
+            ),
+        ),
+        entitlement_receipts=(
+            EntitlementReceiptWrite(
+                receipt_id="entitlement-source-a-v1",
+                source_id=key.source_id,
+                status="active",
+                allowed_history={"days": 365},
+                timeframe_permissions=("1d", "1w"),
+                persistence_allowed=True,
+                derived_allowed=True,
+                non_display_allowed=True,
+                valid_from="2026-08-01",
+                valid_to=None,
+                evidence_ref="operator://receipt/1",
+                receipt_hash="e" * 64,
+            ),
+        ),
+        backup_receipts=(
+            BackupReceiptWrite(
+                backup_id="backup-run-receipts",
+                run_id=run_id,
+                destination="nas://market-data/mvp.db",
+                status="verified",
+                checksum="f" * 64,
+                size_bytes=1024,
+                restore_verified=True,
+                policy={"generations": 3},
+            ),
+        ),
+    )
+
+    receipt = store.commit_mvp_run(write)
+    assert receipt.observation_count == 1
+    assert receipt.quality_count == 1
+    assert receipt.transform_count == 1
+    health = store.mvp_storage_health()
+    assert health == {
+        "status": "ok",
+        "candles": 1,
+        "runs": 1,
+        "watermarks": 0,
+        "source_observations": 1,
+        "quality_receipts": 1,
+        "transform_receipts": 1,
+        "entitlement_receipts": 1,
+        "backup_receipts": 1,
+    }


### PR DESCRIPTION
## What
- Add the `StoragePort` seam and typed MVP run/candle/receipt inputs.
- Add isolated `mvp_candles`, `mvp_runs`, `mvp_watermarks`, source-observation, quality, transform, entitlement, and backup receipt tables while preserving legacy `klines` reads.
- Persist source-aware identity (instrument, display/provider symbol, source, timeframe, adjustment basis, manifest version) and nullable volume semantics.
- Add one transaction operation for candles, observations, quality/transform receipts, entitlements/backups, and watermark advancement with idempotent upserts and fail-closed rollback.
- Update `REGISTRY.md` after #44 merge.

## Why
The orchestrator needs a small deep storage seam instead of coupling to SQLite sessions. This establishes the durable receipt and watermark contract for resumable ingestion without moving the resident database or touching NAS/provider/scheduler paths.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (172 passed)
- `python3 -m ruff check src/kline/storage.py src/kline/store.py src/kline/models.py src/kline/ports.py tests/test_mvp_storage.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No live database path change, NAS mount, provider adapter, scheduler, resident DB deletion/VACUUM, or silent legacy schema rewrite.

Closes #45