### PR TITLE
feat: add entitlement-gated TuShare MVP adapter

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -8,9 +8,9 @@
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- `main@5a832f3` 已合并 MVP #44/#45：216 instrument manifest 与独立 `mvp_*` storage/receipt/watermark schema 已就绪；当前 manifest 仍是 `candidate`，TuShare/美国源 entitlement 未提供前不会宣称 verified，resident DB/NAS 尚未切换。
-- 当前工作：#46 `codex/issue-46-calendar-aggregation`，实现 calendar-aware closed-bar、4H/weekly transform 与 quality classification；不动 provider credentials、scheduler 或 live DB。
+- `main@1dd1c0a` 已合并 MVP #44/#45/#46：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar-aware closed-bar/4H/weekly quality seam 已就绪；当前 manifest 仍是 `candidate`，TuShare/美国源 entitlement 未提供前不会宣称 verified，resident DB/NAS 尚未切换。
+- 当前工作：#47 `codex/issue-47-tushare-adapter`，接入 TuShare A-share 100 adapter 与 entitlement fail-closed gate；无 token 时只返回 blocked，不写库。
 
 ## 下一步
-- 完成 #46 calendar/aggregation/quality contract；随后按 #47→#54 依赖链推进 adapter/orchestrator/scheduler/SSD-NAS/30-day acceptance。
+- 完成 #47 TuShare adapter/entitlement contract；随后按 #48→#54 依赖链推进 US source/orchestrator/scheduler/SSD-NAS/30-day acceptance。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/src/kline/config.py
+++ b/src/kline/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
 
     # TuShare Pro (required for A-shares)
     tushare_token: str = ""
+    # Optional JSON receipt proving minute/history/persistence rights. A token
+    # without this operator-controlled receipt remains blocked_for_entitlement.
+    tushare_entitlement_path: str = ""
 
     # Provider timeouts (seconds)
     request_timeout: int = 30

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -437,7 +437,6 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.A_SHARE,
         meta=_PROVIDER_META[AssetClass.A_SHARE],
         default_for_asset_class=True,
-        blocked_timeframes=(Timeframe.MIN_15, Timeframe.HOUR_4),
     ),
     "tencent_kline": SourceManifest(
         source_id="tencent_kline",

--- a/src/kline/providers/__init__.py
+++ b/src/kline/providers/__init__.py
@@ -1,7 +1,8 @@
 """Data providers — one per asset class, all return list[Candle]."""
 
-from kline.providers.base import Provider
+from kline.providers.base import EntitlementBlocked, Provider
 from kline.providers.ashare import AShareProvider
+from kline.providers.tushare_mvp import TuShareEntitlement, TuShareMvpProvider
 from kline.providers.us import USStockProvider
 from kline.providers.crypto import CryptoProvider
 from kline.providers.commodity import CommodityProvider
@@ -9,7 +10,10 @@ from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 
 __all__ = [
     "Provider",
+    "EntitlementBlocked",
     "AShareProvider",
+    "TuShareEntitlement",
+    "TuShareMvpProvider",
     "USStockProvider",
     "CryptoProvider",
     "CommodityProvider",

--- a/src/kline/providers/base.py
+++ b/src/kline/providers/base.py
@@ -33,3 +33,12 @@ class ProviderError(Exception):
     def __init__(self, message: str, *, suggestions: list[str] | None = None) -> None:
         super().__init__(message)
         self.suggestions = suggestions or []
+        self.code = "provider_error"
+
+
+class EntitlementBlocked(ProviderError):
+    """The source is unavailable because the operator has no valid entitlement."""
+
+    def __init__(self, message: str = "data source is blocked_for_entitlement") -> None:
+        super().__init__(message)
+        self.code = "blocked_for_entitlement"

--- a/src/kline/providers/tushare_mvp.py
+++ b/src/kline/providers/tushare_mvp.py
@@ -1,0 +1,501 @@
+"""Entitlement-gated TuShare Pro adapter for the A-share MVP universe.
+
+The adapter is deliberately inert without an operator-supplied entitlement.
+It never falls back to Tencent/Sina/Yahoo and never includes the token in a
+receipt or error message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from hashlib import sha256
+import json
+import math
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import tushare as ts
+
+from kline.market_calendar import aggregate_15m_to_4h, aggregate_daily_to_weekly
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.mvp_manifest import MvpManifest, load_manifest
+from kline.providers.ashare import _to_tushare_code
+from kline.providers.base import EntitlementBlocked, ProviderError
+from kline.storage import CandleSeriesKey, EntitlementReceiptWrite, MvpCandle
+
+
+MVP_TUSHARE_TIMEFRAMES = (Timeframe.MIN_15, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK)
+_A_SHARE_CALENDAR = "cn_a"
+_A_SHARE_ZONE = timezone(timedelta(hours=8))
+
+
+@dataclass(frozen=True)
+class TuShareEntitlement:
+    """Operator-provided permission receipt; no token is stored here."""
+
+    source_id: str = "tushare_pro"
+    status: str = "active"
+    allowed_timeframes: tuple[str, ...] = ("15m", "4h", "1d", "1w")
+    persistence_allowed: bool = False
+    derived_allowed: bool = False
+    non_display_allowed: bool = False
+    valid_from: str | None = None
+    valid_to: str | None = None
+    evidence_ref: str = ""
+    receipt_hash: str = ""
+    allowed_history: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allowed_timeframes", tuple(self.allowed_timeframes))
+
+    @classmethod
+    def from_json_file(cls, path: str | Path) -> "TuShareEntitlement":
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise ProviderError("TuShare entitlement receipt file was not found") from exc
+        except json.JSONDecodeError as exc:
+            raise ProviderError("TuShare entitlement receipt file is invalid JSON") from exc
+        if not isinstance(payload, Mapping):
+            raise ProviderError("TuShare entitlement receipt must be an object")
+        try:
+            return cls(**dict(payload))
+        except TypeError as exc:
+            raise ProviderError("TuShare entitlement receipt has invalid fields") from exc
+
+    def permits(self, timeframe: Timeframe, *, now: datetime) -> bool:
+        if self.status != "active" or timeframe.value not in set(self.allowed_timeframes):
+            return False
+        try:
+            if self.valid_from and now.date() < date.fromisoformat(self.valid_from[:10]):
+                return False
+            if self.valid_to and now.date() > date.fromisoformat(self.valid_to[:10]):
+                return False
+        except ValueError:
+            return False
+        return True
+
+    def as_receipt(self) -> EntitlementReceiptWrite:
+        if not self.receipt_hash or len(self.receipt_hash) != 64:
+            raise ProviderError("TuShare entitlement receipt hash is required")
+        if not self.evidence_ref:
+            raise ProviderError("TuShare entitlement evidence reference is required")
+        return EntitlementReceiptWrite(
+            receipt_id=f"{self.source_id}:{self.receipt_hash[:16]}",
+            source_id=self.source_id,
+            status=self.status,
+            allowed_history=dict(self.allowed_history),
+            timeframe_permissions=self.allowed_timeframes,
+            persistence_allowed=self.persistence_allowed,
+            derived_allowed=self.derived_allowed,
+            non_display_allowed=self.non_display_allowed,
+            valid_from=self.valid_from,
+            valid_to=self.valid_to,
+            evidence_ref=self.evidence_ref,
+            receipt_hash=self.receipt_hash,
+        )
+
+
+class TuShareMvpProvider:
+    """Fetch the exact 100 A-share members through authorized TuShare APIs."""
+
+    def __init__(
+        self,
+        token: str = "",
+        *,
+        entitlement: TuShareEntitlement | None = None,
+        client: Any | None = None,
+        manifest: MvpManifest | str | Path | None = None,
+        clock: Callable[[], datetime] | None = None,
+        max_retries: int = 2,
+        retry_delay: float = 0.0,
+    ) -> None:
+        self._token = token
+        self._entitlement = entitlement
+        self._client = client
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._max_retries = max(0, max_retries)
+        self._retry_delay = max(0.0, retry_delay)
+        if isinstance(manifest, (str, Path)):
+            self._manifest = load_manifest(manifest)
+        else:
+            self._manifest = manifest
+        self._members = {
+            item.display_symbol: item
+            for item in (self._manifest.instruments if self._manifest else ())
+            if item.universe == "a_share"
+        }
+        self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform: TimeframeTransform | None = None
+        self.source_identity: dict[str, Any] = {}
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        if (
+            self._entitlement is None
+            or not self._token
+            or not self._entitlement.persistence_allowed
+            or not self._entitlement.non_display_allowed
+        ):
+            return []
+        now = self._clock()
+        return [
+            timeframe
+            for timeframe in MVP_TUSHARE_TIMEFRAMES
+            if self._entitlement.permits(timeframe, now=now)
+            and (
+                timeframe not in {Timeframe.HOUR_4, Timeframe.WEEK}
+                or self._entitlement.derived_allowed
+            )
+        ]
+
+    def membership_report(self) -> dict[str, Any]:
+        expected = 100
+        return {
+            "manifest_version": self._manifest.version if self._manifest else None,
+            "expected_members": expected,
+            "mapped_members": len(self._members),
+            "complete": len(self._members) == expected,
+            "source_id": "tushare_pro",
+        }
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        instrument = self._resolve_member(ticker)
+        self._require_entitlement(timeframe)
+        if timeframe in {Timeframe.HOUR_4, Timeframe.WEEK}:
+            if self._entitlement is None or not self._entitlement.derived_allowed:
+                raise EntitlementBlocked(
+                    "TuShare derived timeframe persistence is blocked_for_entitlement"
+                )
+        if timeframe == Timeframe.HOUR_4:
+            raw = await self.fetch(
+                ticker, Timeframe.MIN_15, start=start, end=end, limit=max(limit * 16, 200)
+            )
+            key = self._key(instrument, Timeframe.MIN_15)
+            mvp_rows = [self._to_mvp(key, candle) for candle in raw]
+            result = aggregate_15m_to_4h(
+                mvp_rows,
+                calendar_id=_A_SHARE_CALENDAR,
+                cutoff=self._clock(),
+                run_id=f"tushare-preview:{instrument.instrument_id}",
+            )
+            self.timeframe_transform = TimeframeTransform(
+                raw_timeframe=Timeframe.MIN_15,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": result.transform_receipt.aggregation_rule_version
+                    if result.transform_receipt
+                    else "cn_a_session_4h_v1",
+                    "partial_bucket_policy": "drop_and_record",
+                    "partial_bucket_count": len(result.partial_buckets),
+                },
+            )
+            self.last_raw_response = dict(self.last_raw_response or {})
+            self.last_raw_response["requested_timeframe"] = timeframe.value
+            return [self._from_mvp(row) for row in result.candles[-limit:]]
+        if timeframe == Timeframe.WEEK:
+            raw = await self.fetch(
+                ticker, Timeframe.DAY, start=start, end=end, limit=max(limit * 7 + 10, 200)
+            )
+            key = self._key(instrument, Timeframe.DAY)
+            mvp_rows = [self._to_mvp(key, candle) for candle in raw]
+            result = aggregate_daily_to_weekly(
+                mvp_rows,
+                calendar_id=_A_SHARE_CALENDAR,
+                cutoff=self._clock(),
+                run_id=f"tushare-preview:{instrument.instrument_id}",
+            )
+            self.timeframe_transform = TimeframeTransform(
+                raw_timeframe=Timeframe.DAY,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": result.transform_receipt.aggregation_rule_version
+                    if result.transform_receipt
+                    else "completed_local_calendar_week_v1",
+                    "partial_bucket_policy": "defer_until_closed",
+                    "partial_bucket_count": len(result.partial_buckets),
+                },
+            )
+            self.last_raw_response = dict(self.last_raw_response or {})
+            self.last_raw_response["requested_timeframe"] = timeframe.value
+            return [self._from_mvp(row) for row in result.candles[-limit:]]
+        return await self._fetch_native(instrument, timeframe, start=start, end=end, limit=limit)
+
+    async def _fetch_native(
+        self,
+        instrument: Any,
+        timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        client = self._get_client()
+        ts_code = instrument.provider_symbol or _to_tushare_code(instrument.display_symbol)
+        request_params: dict[str, Any] = {
+            "ts_code": ts_code,
+            "start_date": start,
+            "end_date": end,
+            "limit": limit,
+            "freq": "15min" if timeframe == Timeframe.MIN_15 else None,
+        }
+        self.last_raw_response = {
+            "request_params": request_params,
+            "response_body": None,
+            "status_code": None,
+            "error": None,
+        }
+        try:
+            if timeframe == Timeframe.MIN_15:
+                frame = await self._call(
+                    lambda: client.stk_mins(
+                        ts_code=ts_code,
+                        start_date=start,
+                        end_date=end,
+                        freq="15min",
+                    )
+                )
+            elif timeframe == Timeframe.DAY:
+                method = (
+                    client.index_daily
+                    if ts_code in {"000001.SH", "000688.SH", "000015.SH"}
+                    else client.daily
+                )
+                frame = await self._call(
+                    lambda: method(ts_code=ts_code, start_date=start, end_date=end)
+                )
+            else:
+                raise ProviderError(f"TuShare native timeframe {timeframe.value} is unsupported")
+        except ProviderError:
+            raise
+        except Exception as exc:
+            self._set_error(exc)
+            failure = ProviderError(f"TuShare request failed for {instrument.display_symbol}")
+            failure.code = str((self.last_raw_response or {}).get("error") or "provider_error")
+            raise failure from exc
+        rows = self._parse_rows(frame, instrument=instrument, timeframe=timeframe, limit=limit)
+        if not rows:
+            error = "market_closed_or_no_closed_rows"
+            self.last_raw_response["error"] = error
+            failure = ProviderError(
+                f"TuShare returned no closed rows for {instrument.display_symbol}"
+            )
+            failure.code = "market_closed"
+            raise failure
+        self.last_raw_response["response_body"] = {
+            "row_count": len(rows),
+            "sha256": self._frame_hash(frame),
+        }
+        self.timeframe_transform = TimeframeTransform(
+            raw_timeframe=timeframe,
+            timeframe_origin="native",
+            aggregation={"kind": "none", "rule": "native_passthrough"},
+        )
+        history_status = (
+            "new_listing_exception"
+            if instrument.display_symbol in {"688825", "688836"}
+            else "standard"
+        )
+        self.source_identity = {
+            "source_id": "tushare_pro",
+            "provider_symbol": ts_code,
+            "instrument_id": instrument.instrument_id,
+            "manifest_version": self._manifest.version if self._manifest else None,
+            "entitlement_status": self._entitlement.status if self._entitlement else "blocked",
+            "history_status": history_status,
+        }
+        return rows
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        if not self._token:
+            raise EntitlementBlocked("TuShare token/entitlement is required")
+        ts.set_token(self._token)
+        self._client = ts.pro_api()
+        return self._client
+
+    async def _call(self, operation: Callable[[], Any]) -> Any:
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                return operation()
+            except Exception as exc:  # provider SDK raises several exception types
+                last_error = exc
+                if attempt >= self._max_retries:
+                    self._set_error(exc)
+                    raise
+                if self._retry_delay:
+                    await asyncio.sleep(self._retry_delay * (attempt + 1))
+        assert last_error is not None
+        raise last_error
+
+    def _set_error(self, error: Exception) -> None:
+        text = str(error).lower()
+        code = "rate_limited" if "429" in text or "rate limit" in text else "provider_error"
+        self.last_raw_response = dict(self.last_raw_response or {})
+        self.last_raw_response["error"] = code
+
+    def _require_entitlement(self, timeframe: Timeframe) -> None:
+        now = self._clock()
+        if not self._token or self._entitlement is None:
+            raise EntitlementBlocked("TuShare source is blocked_for_entitlement")
+        if not self._entitlement.permits(timeframe, now=now):
+            raise EntitlementBlocked(f"TuShare {timeframe.value} is blocked_for_entitlement")
+        if not self._entitlement.persistence_allowed or not self._entitlement.non_display_allowed:
+            raise EntitlementBlocked(
+                "TuShare persistence/non-display use is blocked_for_entitlement"
+            )
+
+    def _resolve_member(self, ticker: str) -> Any:
+        symbol = ticker.strip()
+        if symbol in self._members:
+            return self._members[symbol]
+        ts_code = _to_tushare_code(symbol)
+        for item in self._members.values():
+            if item.provider_symbol.upper() == ts_code.upper():
+                return item
+        if self._manifest is not None:
+            raise ProviderError(f"A-share ticker {ticker} is not in the MVP manifest")
+        return type(
+            "FallbackInstrument",
+            (),
+            {
+                "display_symbol": symbol,
+                "provider_symbol": ts_code,
+                "instrument_id": f"CN.A.{symbol}",
+            },
+        )()
+
+    def _key(self, instrument: Any, timeframe: Timeframe) -> CandleSeriesKey:
+        return CandleSeriesKey(
+            instrument_id=instrument.instrument_id,
+            display_symbol=instrument.display_symbol,
+            provider_symbol=instrument.provider_symbol,
+            source_id="tushare_pro",
+            asset_class="a_share",
+            timeframe=timeframe,
+            adjustment_basis=getattr(instrument, "adjustment_basis", "raw_unadjusted"),
+            manifest_version=self._manifest.version if self._manifest else "mvp_universe_v1",
+        )
+
+    def _to_mvp(self, key: CandleSeriesKey, candle: Candle) -> MvpCandle:
+        return MvpCandle(
+            key=key,
+            timestamp=candle.timestamp,
+            open=candle.open,
+            high=candle.high,
+            low=candle.low,
+            close=candle.close,
+            volume=candle.volume,
+            amount=candle.amount,
+            volume_semantics="traded",
+        )
+
+    @staticmethod
+    def _from_mvp(candle: MvpCandle) -> Candle:
+        return Candle(
+            timestamp=candle.timestamp,
+            open=candle.open,
+            high=candle.high,
+            low=candle.low,
+            close=candle.close,
+            volume=candle.volume or 0,
+            amount=candle.amount,
+        )
+
+    def _parse_rows(
+        self, frame: Any, *, instrument: Any, timeframe: Timeframe, limit: int
+    ) -> list[Candle]:
+        if frame is None or getattr(frame, "empty", False):
+            return []
+        rows: list[Candle] = []
+        now = self._clock().astimezone(timezone.utc)
+        for _, row in frame.iterrows():
+            try:
+                stamp_value = self._row_value(row, "trade_time", "trade_date", "datetime")
+                stamp = self._parse_row_timestamp(stamp_value, timeframe)
+                close_boundary = (
+                    stamp + timedelta(minutes=15)
+                    if timeframe == Timeframe.MIN_15
+                    else self._daily_close(stamp)
+                )
+                if close_boundary > now:
+                    continue
+                values = [
+                    float(self._row_value(row, name)) for name in ("open", "high", "low", "close")
+                ]
+                volume = float(self._row_value(row, "vol", "volume"))
+                amount_value = self._row_value(row, "amount", "成交额", default=None)
+                amount = float(amount_value) if amount_value not in (None, "", "nan") else None
+                if not all(math.isfinite(value) for value in (*values, volume)) or volume < 0:
+                    raise ValueError("non-finite OHLCV")
+                if values[1] < max(values[0], values[3]) or values[2] > min(values[0], values[3]):
+                    raise ValueError("OHLC invariant")
+                rows.append(
+                    Candle(
+                        timestamp=stamp.isoformat(),
+                        open=values[0],
+                        high=values[1],
+                        low=values[2],
+                        close=values[3],
+                        volume=volume,
+                        amount=amount,
+                    )
+                )
+            except (KeyError, TypeError, ValueError, OverflowError) as exc:
+                self.last_raw_response["error"] = "malformed_row"
+                failure = ProviderError(f"TuShare returned malformed {timeframe.value} row")
+                failure.code = "malformed_row"
+                raise failure from exc
+        rows.sort(key=lambda candle: candle.timestamp)
+        return rows[-limit:] if limit else rows
+
+    @staticmethod
+    def _row_value(row: Any, *names: str, default: Any = ...) -> Any:
+        for name in names:
+            if hasattr(row, "get"):
+                value = row.get(name, None)
+            else:
+                value = getattr(row, name, None)
+            if value is not None:
+                return value
+        if default is not ...:
+            return default
+        raise KeyError(names[0])
+
+    @staticmethod
+    def _parse_row_timestamp(value: Any, timeframe: Timeframe) -> datetime:
+        text = str(value).strip()
+        if timeframe == Timeframe.DAY and len(text) == 8 and text.isdigit():
+            text = f"{text[:4]}-{text[4:6]}-{text[6:8]}"
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(
+                tzinfo=_A_SHARE_ZONE if timeframe == Timeframe.MIN_15 else timezone.utc
+            )
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _daily_close(stamp: datetime) -> datetime:
+        local = stamp.astimezone(_A_SHARE_ZONE)
+        return datetime.combine(local.date(), time(15, 0), tzinfo=_A_SHARE_ZONE).astimezone(
+            timezone.utc
+        )
+
+    @staticmethod
+    def _frame_hash(frame: Any) -> str:
+        try:
+            payload = frame.to_json(orient="records", date_format="iso")
+        except Exception:
+            payload = repr(frame)
+        return sha256(payload.encode("utf-8")).hexdigest()

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -9,7 +9,8 @@ from kline.config import Settings, ensure_data_dir, get_settings
 from kline.models import AssetClass, Timeframe
 from kline.plugin_loader import load_configured_adapters, load_entrypoint_adapters
 from kline.ports import MarketDataPort, ProviderBackedMarketDataAdapter
-from kline.providers.ashare import AShareProvider, TencentIndexProvider
+from kline.providers.ashare import TencentIndexProvider
+from kline.providers.tushare_mvp import TuShareEntitlement, TuShareMvpProvider
 from kline.providers.base import Provider, ProviderError
 from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 from kline.providers.commodity import CommodityProvider
@@ -126,7 +127,9 @@ def init(settings: Settings | None = None) -> None:
     register_adapter(
         ProviderBackedMarketDataAdapter(
             source_manifest("binance_usdm_futures_research", AssetClass.CRYPTO),
-            BinanceUsdmFuturesProvider(timeout=s.request_timeout, allowed_symbols={"BTCUSDT", "ETHUSDT"}),
+            BinanceUsdmFuturesProvider(
+                timeout=s.request_timeout, allowed_symbols={"BTCUSDT", "ETHUSDT"}
+            ),
         )
     )
     register_adapter(
@@ -136,15 +139,23 @@ def init(settings: Settings | None = None) -> None:
         )
     )
 
-    # A-share requires TuShare token
-    if s.tushare_token:
-        _providers[AssetClass.A_SHARE] = AShareProvider(s.tushare_token)
-        register_adapter(
-            ProviderBackedMarketDataAdapter(
-                source_manifest("tushare_pro", AssetClass.A_SHARE),
-                _providers[AssetClass.A_SHARE],
-            )
+    # A-share is always represented by the MVP adapter. Without both an
+    # operator token and an entitlement receipt, fetches remain typed
+    # blocked_for_entitlement and cannot write/promote candles.
+    entitlement = None
+    if s.tushare_entitlement_path:
+        entitlement = TuShareEntitlement.from_json_file(s.tushare_entitlement_path)
+    _providers[AssetClass.A_SHARE] = TuShareMvpProvider(
+        s.tushare_token,
+        entitlement=entitlement,
+        manifest=Path(__file__).resolve().parents[2] / "configs" / "mvp_manifest.json",
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("tushare_pro", AssetClass.A_SHARE),
+            _providers[AssetClass.A_SHARE],
         )
+    )
 
     external_adapters = load_configured_adapters(s.adapter_config_path)
     if s.load_entrypoint_adapters:
@@ -247,9 +258,7 @@ def provider_status() -> dict:
             ]
         else:
             supported_timeframes = (
-                [timeframe.value for timeframe in adapter.supported_timeframes()]
-                if adapter
-                else []
+                [timeframe.value for timeframe in adapter.supported_timeframes()] if adapter else []
             )
         sources[source_id] = {
             "available": False,

--- a/tests/test_mvp_manifest.py
+++ b/tests/test_mvp_manifest.py
@@ -443,10 +443,12 @@ def test_manifest_rejects_malformed_open_ended_dates_and_source_mismatch() -> No
         validate_manifest(payload)
 
     payload = manifest.to_dict()
-    payload["instruments"][0]["source_status"] = "configured"
-    payload["instruments"][0]["required_timeframes"] = ["15m"]
-    payload["instruments"][0]["blocked_timeframes"] = []
-    payload["instruments"][0]["not_applicable_timeframes"] = ["4h", "1d", "1w"]
+    capability_target = next(
+        item for item in payload["instruments"] if item["source_id"] == "tencent_kline"
+    )
+    capability_target["required_timeframes"] = ["15m"]
+    capability_target["blocked_timeframes"] = []
+    capability_target["not_applicable_timeframes"] = ["4h", "1d", "1w"]
     with pytest.raises(ManifestError, match="does not support"):
         validate_manifest(payload)
 

--- a/tests/test_timeframe_contract.py
+++ b/tests/test_timeframe_contract.py
@@ -295,8 +295,8 @@ def test_yahoo_symbol_timeframe_allowlist_is_explicit():
     assert hyperliquid.supports_timeframe("BTC", Timeframe.MIN_15)
     assert hyperliquid.supports_timeframe("ETH", Timeframe.MIN_15)
     assert hyperliquid.supports_timeframe("HYPE", Timeframe.MIN_15)
-    assert not tushare.supports_timeframe("300308.SZ", Timeframe.MIN_15)
-    assert not tushare.supports_timeframe("300308.SZ", Timeframe.HOUR_4)
+    assert tushare.supports_timeframe("300308.SZ", Timeframe.MIN_15)
+    assert tushare.supports_timeframe("300308.SZ", Timeframe.HOUR_4)
     assert tushare.supports_timeframe("300308.SZ", Timeframe.DAY)
 
 

--- a/tests/test_tushare_mvp.py
+++ b/tests/test_tushare_mvp.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from kline.models import AssetClass, Timeframe
+from kline.mvp_manifest import load_manifest
+from kline.providers.base import EntitlementBlocked, ProviderError
+from kline.providers.tushare_mvp import TuShareEntitlement, TuShareMvpProvider
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def _entitlement(**overrides: object) -> TuShareEntitlement:
+    values: dict[str, object] = {
+        "allowed_timeframes": ("15m", "4h", "1d", "1w"),
+        "persistence_allowed": True,
+        "derived_allowed": True,
+        "non_display_allowed": True,
+        "evidence_ref": "operator://tushare/receipt-1",
+        "receipt_hash": "a" * 64,
+        "allowed_history": {"daily_years": 5, "minute_days": 60},
+    }
+    values.update(overrides)
+    return TuShareEntitlement(**values)
+
+
+class FakeTuShareClient:
+    def __init__(
+        self, *, daily: pd.DataFrame | None = None, mins: pd.DataFrame | None = None
+    ) -> None:
+        self.daily_frame = daily if daily is not None else pd.DataFrame()
+        self.mins_frame = mins if mins is not None else pd.DataFrame()
+        self.daily_calls: list[dict[str, object]] = []
+        self.minute_calls: list[dict[str, object]] = []
+
+    def daily(self, **kwargs: object) -> pd.DataFrame:
+        self.daily_calls.append(kwargs)
+        return self.daily_frame
+
+    def index_daily(self, **kwargs: object) -> pd.DataFrame:
+        self.daily_calls.append(kwargs)
+        return self.daily_frame
+
+    def stk_mins(self, **kwargs: object) -> pd.DataFrame:
+        self.minute_calls.append(kwargs)
+        return self.mins_frame
+
+
+def _daily_frame(*dates: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "trade_date": trading_date.replace("-", ""),
+                "open": 100 + index,
+                "high": 102 + index,
+                "low": 99 + index,
+                "close": 101 + index,
+                "vol": 1000 + index,
+                "amount": 100000 + index,
+            }
+            for index, trading_date in enumerate(dates)
+        ]
+    )
+
+
+def _minute_frame(*times: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "trade_time": stamp,
+                "open": 100 + index,
+                "high": 102 + index,
+                "low": 99 + index,
+                "close": 101 + index,
+                "vol": 1000 + index,
+                "amount": 100000 + index,
+            }
+            for index, stamp in enumerate(times)
+        ]
+    )
+
+
+def _provider(
+    client: FakeTuShareClient,
+    *,
+    clock: datetime = datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc),
+    entitlement: TuShareEntitlement | None = None,
+    max_retries: int = 2,
+) -> TuShareMvpProvider:
+    return TuShareMvpProvider(
+        "secret-token",
+        entitlement=entitlement or _entitlement(),
+        client=client,
+        manifest=MANIFEST_PATH,
+        clock=lambda: clock,
+        max_retries=max_retries,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mvp_provider_maps_exact_100_members_and_is_blocked_without_entitlement() -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    provider = TuShareMvpProvider(manifest=manifest)
+
+    assert provider.membership_report() == {
+        "manifest_version": "mvp_universe_v1",
+        "expected_members": 100,
+        "mapped_members": 100,
+        "complete": True,
+        "source_id": "tushare_pro",
+    }
+    assert provider.supported_timeframes() == []
+    with pytest.raises(EntitlementBlocked, match="blocked_for_entitlement") as error:
+        await provider.fetch("300308", Timeframe.DAY)
+    assert error.value.code == "blocked_for_entitlement"
+
+
+def test_expired_or_partial_entitlement_reports_no_persistable_timeframes() -> None:
+    expired = TuShareMvpProvider(
+        "secret-token",
+        entitlement=_entitlement(valid_to="2026-08-01"),
+        manifest=MANIFEST_PATH,
+        clock=lambda: datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    assert expired.supported_timeframes() == []
+    partial = TuShareEntitlement(
+        allowed_timeframes=("1d",),
+        persistence_allowed=True,
+        derived_allowed=False,
+        non_display_allowed=True,
+        evidence_ref="operator://tushare/receipt-2",
+        receipt_hash="b" * 64,
+    )
+    assert TuShareMvpProvider("secret-token", entitlement=partial).supported_timeframes() == [
+        Timeframe.DAY
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mvp_provider_fetches_daily_with_source_identity_and_no_token_leak() -> None:
+    client = FakeTuShareClient(daily=_daily_frame("2026-08-31"))
+    provider = _provider(client)
+
+    candles = await provider.fetch("300308", Timeframe.DAY, start="2026-08-01", end="2026-09-01")
+
+    assert len(candles) == 1
+    assert client.daily_calls == [
+        {"ts_code": "300308.SZ", "start_date": "2026-08-01", "end_date": "2026-09-01"}
+    ]
+    assert provider.source_identity["provider_symbol"] == "300308.SZ"
+    assert provider.source_identity["instrument_id"] == "CN.A.300308"
+    assert provider.last_raw_response is not None
+    assert provider.last_raw_response["response_body"]["row_count"] == 1
+    assert "secret-token" not in repr(provider.last_raw_response)
+
+
+@pytest.mark.asyncio
+async def test_mvp_provider_fetches_15m_and_aggregates_4h_without_30m() -> None:
+    local_day = datetime(2026, 8, 31, 9, 30)
+    local_times = [
+        *[
+            (local_day + timedelta(minutes=15 * index)).strftime("%Y-%m-%d %H:%M:%S")
+            for index in range(8)
+        ],
+        *[
+            (datetime(2026, 8, 31, 13, 0) + timedelta(minutes=15 * index)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            for index in range(8)
+        ],
+    ]
+    client = FakeTuShareClient(mins=_minute_frame(*local_times))
+    provider = _provider(client, clock=datetime(2026, 9, 1, tzinfo=timezone.utc))
+
+    native = await provider.fetch("300308", Timeframe.MIN_15, limit=100)
+    derived = await provider.fetch("300308", Timeframe.HOUR_4, limit=10)
+
+    assert len(native) == 16
+    assert len(derived) == 1
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
+    assert provider.timeframe_transform.aggregation["partial_bucket_count"] == 0
+    assert "30m" not in [timeframe.value for timeframe in provider.supported_timeframes()]
+
+
+@pytest.mark.asyncio
+async def test_mvp_provider_weekly_transform_and_new_listing_exception() -> None:
+    client = FakeTuShareClient(
+        daily=_daily_frame("2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28")
+    )
+    provider = _provider(client, clock=datetime(2026, 8, 29, 12, tzinfo=timezone.utc))
+
+    candles = await provider.fetch("688825", Timeframe.WEEK, limit=10)
+
+    assert len(candles) == 1
+    assert provider.source_identity["history_status"] == "new_listing_exception"
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.DAY
+
+
+@pytest.mark.asyncio
+async def test_mvp_provider_retries_rate_limit_and_rejects_malformed_or_empty_rows() -> None:
+    class FlakyClient(FakeTuShareClient):
+        def __init__(self) -> None:
+            super().__init__(daily=_daily_frame("2026-08-31"))
+            self.attempts = 0
+
+        def daily(self, **kwargs: object) -> pd.DataFrame:
+            self.attempts += 1
+            if self.attempts < 3:
+                raise RuntimeError("429 rate limit")
+            return super().daily(**kwargs)
+
+    flaky = FlakyClient()
+    provider = _provider(flaky)
+    assert len(await provider.fetch("300308", Timeframe.DAY)) == 1
+    assert flaky.attempts == 3
+    assert provider.last_raw_response is not None
+
+    malformed = FakeTuShareClient(daily=pd.DataFrame([{"trade_date": "20260831", "open": "bad"}]))
+    with pytest.raises(ProviderError, match="malformed") as malformed_error:
+        await _provider(malformed).fetch("300308", Timeframe.DAY)
+    assert malformed_error.value.code == "malformed_row"
+
+    empty = FakeTuShareClient(daily=pd.DataFrame())
+    with pytest.raises(ProviderError, match="no closed rows"):
+        await _provider(empty).fetch("300308", Timeframe.DAY)
+
+
+def test_entitlement_receipt_is_explicit_and_token_free() -> None:
+    receipt = _entitlement().as_receipt()
+    assert receipt.source_id == "tushare_pro"
+    assert receipt.persistence_allowed is True
+    assert receipt.non_display_allowed is True
+    assert "secret-token" not in repr(receipt)
+
+
+@pytest.mark.asyncio
+async def test_registry_exposes_typed_blocked_a_share_adapter_without_token(tmp_path: Path) -> None:
+    from kline.config import Settings
+    from kline.registry import get_adapter_for_source, init
+
+    init(
+        Settings(
+            db_path=str(tmp_path / "blocked.db"), tushare_token="", load_entrypoint_adapters=False
+        )
+    )
+    adapter = get_adapter_for_source("tushare_pro", AssetClass.A_SHARE)
+    with pytest.raises(EntitlementBlocked) as error:
+        await adapter.fetch_candles("300308", Timeframe.DAY, limit=1)
+    assert error.value.code == "blocked_for_entitlement"


### PR DESCRIPTION
## What
- Add an exact-100-member `TuShareMvpProvider` bound to the executable A-share manifest.
- Gate every request on an operator-supplied token plus explicit entitlement receipt; missing/expired/insufficient rights raise `blocked_for_entitlement` and do not promote data.
- Support authorized 15m and 1d requests, shared 15m→4h and 1d→1w transforms, closed-bar filtering, source identity, response hashes, bounded retries, and typed rate-limit/malformed/market-closed errors.
- Preserve explicit new-listing status for 688825/688836 without zero-fill or fallback.
- Register the adapter without logging or exposing tokens; add `KLINE_TUSHARE_ENTITLEMENT_PATH` configuration and update registry metadata.

## Why
The A-share half of the MVP must be ready for a future user-controlled TuShare renewal without treating an expired token or API access as permission to persist data.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (188 passed)
- `python3 -m ruff check src/kline/providers/tushare_mvp.py src/kline/providers/base.py src/kline/registry.py src/kline/config.py src/kline/providers/__init__.py tests/test_tushare_mvp.py tests/test_timeframe_contract.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No automatic purchase/renewal, token logging, Tencent/Sina/Yahoo fallback, full-market expansion, live trading, or live database cutover.

Closes #47