### PR TITLE
feat: add authorized US MVP adapter gate

### DIFF
--- a/src/kline/config.py
+++ b/src/kline/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     # without this operator-controlled receipt remains blocked_for_entitlement.
     tushare_entitlement_path: str = ""
 
+    # Authorized US market-data adapter (provider choice remains explicit).
+    us_data_token: str = ""
+    us_data_source: str = "us_authorized_pending"
+    us_data_entitlement_path: str = ""
+
     # Provider timeouts (seconds)
     request_timeout: int = 30
 

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -137,6 +137,7 @@ _SOURCE_ALIASES = {
     "tushare_pro": "tushare_pro",
     "tencent": "tencent_kline",
     "tencent_kline": "tencent_kline",
+    "us_authorized_pending": "us_authorized_pending",
     "sina": "sina_index",
     "sina_index": "sina_index",
     "treasury": "treasury_official_csv",
@@ -161,6 +162,7 @@ _SOURCE_ASSET_CLASSES = {
     "treasury_official_csv_derived": AssetClass.MACRO,
     "yahoo_finance_index": AssetClass.INDEX,
     "yahoo_finance_etf": AssetClass.ETF,
+    "us_authorized_pending": AssetClass.US_STOCK,
     "fred_public_csv_macro": AssetClass.MACRO,
     "fred_public_csv_flow": AssetClass.FLOW,
     "fred_public_csv_event": AssetClass.EVENT,
@@ -206,6 +208,15 @@ _TENCENT_INDEX_META = ProviderMeta(
     realtime_supported=False,
     market_type="index",
     supported_symbols=("sh000001", "sh000688", "sh000015"),
+)
+_US_AUTHORIZED_META = ProviderMeta(
+    name="authorized_us_pending",
+    source_mode="us_authorized_pending",
+    quality_flags=("entitlement_required", "raw_unadjusted", "research_only"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="equity",
 )
 _SINA_INDEX_META = ProviderMeta(
     name="sina_finance",
@@ -340,6 +351,12 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         meta=_PROVIDER_META[AssetClass.US_STOCK],
         default_for_asset_class=True,
         blocked_timeframes=(Timeframe.HOUR_4,),
+    ),
+    "us_authorized_pending": SourceManifest(
+        source_id="us_authorized_pending",
+        asset_class=AssetClass.US_STOCK,
+        meta=_US_AUTHORIZED_META,
+        default_for_asset_class=False,
     ),
     "yahoo_finance_futures": SourceManifest(
         source_id="yahoo_finance_futures",

--- a/src/kline/providers/__init__.py
+++ b/src/kline/providers/__init__.py
@@ -3,6 +3,7 @@
 from kline.providers.base import EntitlementBlocked, Provider
 from kline.providers.ashare import AShareProvider
 from kline.providers.tushare_mvp import TuShareEntitlement, TuShareMvpProvider
+from kline.providers.us_authorized import AuthorizedUSProvider, USDataEntitlement
 from kline.providers.us import USStockProvider
 from kline.providers.crypto import CryptoProvider
 from kline.providers.commodity import CommodityProvider
@@ -14,6 +15,8 @@ __all__ = [
     "AShareProvider",
     "TuShareEntitlement",
     "TuShareMvpProvider",
+    "AuthorizedUSProvider",
+    "USDataEntitlement",
     "USStockProvider",
     "CryptoProvider",
     "CommodityProvider",

--- a/src/kline/providers/us_authorized.py
+++ b/src/kline/providers/us_authorized.py
@@ -1,0 +1,581 @@
+"""Source-agnostic authorized US equities adapter for the MVP.
+
+The concrete client is injected so the MVP can use a licensed Alpaca/Massive
+client later without coupling the manifest to an unverified public endpoint.
+Yahoo/yfinance is intentionally not used by this adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from hashlib import sha256
+import inspect
+import json
+import math
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol
+from zoneinfo import ZoneInfo
+
+from kline.market_calendar import aggregate_15m_to_4h, aggregate_daily_to_weekly
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.mvp_manifest import MvpManifest, load_manifest
+from kline.providers.base import EntitlementBlocked, ProviderError
+from kline.storage import CandleSeriesKey, EntitlementReceiptWrite, MvpCandle
+
+
+MVP_US_TIMEFRAMES = (Timeframe.MIN_15, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK)
+_US_ZONE = ZoneInfo("America/New_York")
+
+
+class AuthorizedUSClient(Protocol):
+    """Client seam implemented by a provider with written data rights."""
+
+    def fetch_bars(
+        self,
+        provider_symbol: str,
+        timeframe: str,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> Any: ...
+
+    def fetch_corporate_actions(
+        self,
+        provider_symbol: str,
+        *,
+        start: str | None,
+        end: str | None,
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class USDataEntitlement:
+    """Operator-provided permission receipt; credentials never live here."""
+
+    source_id: str = "us_authorized_pending"
+    status: str = "active"
+    allowed_timeframes: tuple[str, ...] = ("15m", "4h", "1d", "1w")
+    persistence_allowed: bool = False
+    derived_allowed: bool = False
+    non_display_allowed: bool = False
+    corporate_actions_allowed: bool = False
+    valid_from: str | None = None
+    valid_to: str | None = None
+    evidence_ref: str = ""
+    receipt_hash: str = ""
+    allowed_history: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allowed_timeframes", tuple(self.allowed_timeframes))
+
+    @classmethod
+    def from_json_file(cls, path: str | Path) -> "USDataEntitlement":
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise ProviderError("US entitlement receipt file was not found") from exc
+        except json.JSONDecodeError as exc:
+            raise ProviderError("US entitlement receipt file is invalid JSON") from exc
+        if not isinstance(payload, Mapping):
+            raise ProviderError("US entitlement receipt must be an object")
+        try:
+            return cls(**dict(payload))
+        except TypeError as exc:
+            raise ProviderError("US entitlement receipt has invalid fields") from exc
+
+    def permits(self, timeframe: Timeframe, *, now: datetime) -> bool:
+        if self.status != "active" or timeframe.value not in set(self.allowed_timeframes):
+            return False
+        try:
+            if self.valid_from and now.date() < date.fromisoformat(self.valid_from[:10]):
+                return False
+            if self.valid_to and now.date() > date.fromisoformat(self.valid_to[:10]):
+                return False
+        except ValueError:
+            return False
+        return True
+
+    def as_receipt(self) -> EntitlementReceiptWrite:
+        if not self.evidence_ref:
+            raise ProviderError("US entitlement evidence reference is required")
+        if len(self.receipt_hash) != 64 or any(
+            char not in "0123456789abcdefABCDEF" for char in self.receipt_hash
+        ):
+            raise ProviderError("US entitlement receipt hash is required")
+        return EntitlementReceiptWrite(
+            receipt_id=f"{self.source_id}:{self.receipt_hash[:16]}",
+            source_id=self.source_id,
+            status=self.status,
+            allowed_history=dict(self.allowed_history),
+            timeframe_permissions=self.allowed_timeframes,
+            persistence_allowed=self.persistence_allowed,
+            derived_allowed=self.derived_allowed,
+            non_display_allowed=self.non_display_allowed,
+            valid_from=self.valid_from,
+            valid_to=self.valid_to,
+            evidence_ref=self.evidence_ref,
+            receipt_hash=self.receipt_hash,
+        )
+
+
+class AuthorizedUSProvider:
+    """Fetch exact manifest members through an explicitly authorized client."""
+
+    def __init__(
+        self,
+        token: str = "",
+        *,
+        entitlement: USDataEntitlement | None = None,
+        client: AuthorizedUSClient | None = None,
+        manifest: MvpManifest | str | Path | None = None,
+        source_id: str = "us_authorized_pending",
+        clock: Callable[[], datetime] | None = None,
+        max_retries: int = 2,
+        retry_delay: float = 0.0,
+    ) -> None:
+        self._token = token
+        self._entitlement = entitlement
+        self._client = client
+        self._source_id = source_id
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._max_retries = max(0, max_retries)
+        self._retry_delay = max(0.0, retry_delay)
+        if isinstance(manifest, (str, Path)):
+            self._manifest = load_manifest(manifest)
+        else:
+            self._manifest = manifest
+        self._members = {
+            item.display_symbol: item
+            for item in (self._manifest.instruments if self._manifest else ())
+            if item.universe == "us_stock"
+        }
+        self._aliases = {
+            alias.casefold(): item
+            for item in self._members.values()
+            for alias in item.ticker_aliases
+        }
+        self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform: TimeframeTransform | None = None
+        self.source_identity: dict[str, Any] = {}
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        if (
+            not self._token
+            or self._entitlement is None
+            or not self._entitlement.persistence_allowed
+            or not self._entitlement.non_display_allowed
+        ):
+            return []
+        now = self._clock()
+        return [
+            timeframe
+            for timeframe in MVP_US_TIMEFRAMES
+            if self._entitlement.permits(timeframe, now=now)
+            and (
+                timeframe not in {Timeframe.HOUR_4, Timeframe.WEEK}
+                or self._entitlement.derived_allowed
+            )
+        ]
+
+    def membership_report(self) -> dict[str, Any]:
+        return {
+            "manifest_version": self._manifest.version if self._manifest else None,
+            "expected_members": 100,
+            "mapped_members": len(self._members),
+            "complete": len(self._members) == 100,
+            "source_id": self._source_id,
+        }
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        instrument, alias_used = self._resolve_member(ticker, start=start, end=end)
+        self._require_entitlement(timeframe)
+        if timeframe in {Timeframe.HOUR_4, Timeframe.WEEK}:
+            if self._entitlement is None or not self._entitlement.derived_allowed:
+                raise EntitlementBlocked(
+                    "US derived timeframe persistence is blocked_for_entitlement"
+                )
+        if timeframe == Timeframe.HOUR_4:
+            raw = await self.fetch(
+                instrument.display_symbol,
+                Timeframe.MIN_15,
+                start=start,
+                end=end,
+                limit=max(limit * 26, 300),
+            )
+            key = self._key(instrument, Timeframe.MIN_15)
+            result = aggregate_15m_to_4h(
+                [self._to_mvp(key, candle) for candle in raw],
+                calendar_id="us_equities",
+                cutoff=self._clock(),
+                run_id=f"us-preview:{instrument.instrument_id}",
+            )
+            self._set_transform(
+                Timeframe.MIN_15,
+                result.transform_receipt.aggregation_rule_version
+                if result.transform_receipt
+                else "us_regular_fixed_4h_v1",
+                len(result.partial_buckets),
+            )
+            self.source_identity["alias_used"] = alias_used
+            return [self._from_mvp(row) for row in result.candles[-limit:]]
+        if timeframe == Timeframe.WEEK:
+            raw = await self.fetch(
+                instrument.display_symbol,
+                Timeframe.DAY,
+                start=start,
+                end=end,
+                limit=max(limit * 7 + 10, 200),
+            )
+            key = self._key(instrument, Timeframe.DAY)
+            result = aggregate_daily_to_weekly(
+                [self._to_mvp(key, candle) for candle in raw],
+                calendar_id="us_equities",
+                cutoff=self._clock(),
+                run_id=f"us-preview:{instrument.instrument_id}",
+            )
+            self._set_transform(
+                Timeframe.DAY,
+                result.transform_receipt.aggregation_rule_version
+                if result.transform_receipt
+                else "completed_local_calendar_week_v1",
+                len(result.partial_buckets),
+            )
+            self.source_identity["alias_used"] = alias_used
+            return [self._from_mvp(row) for row in result.candles[-limit:]]
+        rows = await self._fetch_native(instrument, timeframe, start=start, end=end, limit=limit)
+        self.source_identity["alias_used"] = alias_used
+        return rows
+
+    async def fetch_corporate_actions(
+        self,
+        ticker: str,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> Any:
+        instrument, _ = self._resolve_member(ticker, start=start, end=end)
+        if (
+            not self._token
+            or self._entitlement is None
+            or not self._entitlement.corporate_actions_allowed
+            or not self._entitlement.persistence_allowed
+        ):
+            raise EntitlementBlocked("US corporate actions are blocked_for_entitlement")
+        client = self._get_client()
+        return await self._call(
+            lambda: client.fetch_corporate_actions(
+                instrument.provider_symbol,
+                start=start,
+                end=end,
+            )
+        )
+
+    async def _fetch_native(
+        self,
+        instrument: Any,
+        timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        if timeframe not in {Timeframe.MIN_15, Timeframe.DAY}:
+            raise ProviderError(f"US native timeframe {timeframe.value} is unsupported")
+        client = self._get_client()
+        request_params = {
+            "provider_symbol": instrument.provider_symbol,
+            "timeframe": timeframe.value,
+            "start": start,
+            "end": end,
+            "limit": limit,
+            "adjustment": "raw_unadjusted",
+        }
+        self.last_raw_response = {
+            "request_params": request_params,
+            "response_body": None,
+            "status_code": None,
+            "error": None,
+        }
+        try:
+            payload = await self._call(
+                lambda: client.fetch_bars(
+                    instrument.provider_symbol,
+                    timeframe.value,
+                    start=start,
+                    end=end,
+                    limit=limit,
+                )
+            )
+        except ProviderError:
+            raise
+        except Exception as exc:
+            failure = ProviderError(f"authorized US request failed for {instrument.display_symbol}")
+            failure.code = str((self.last_raw_response or {}).get("error") or "provider_error")
+            raise failure from exc
+        rows = self._parse_rows(payload, instrument=instrument, timeframe=timeframe, limit=limit)
+        if not rows:
+            self.last_raw_response["error"] = "empty_window"
+            failure = ProviderError(
+                f"authorized US returned no closed rows for {instrument.display_symbol}"
+            )
+            failure.code = "market_closed"
+            raise failure
+        self.last_raw_response["response_body"] = {
+            "row_count": len(rows),
+            "sha256": self._payload_hash(payload),
+        }
+        self.timeframe_transform = TimeframeTransform(
+            raw_timeframe=timeframe,
+            timeframe_origin="native",
+            aggregation={"kind": "none", "rule": "native_passthrough"},
+        )
+        self.source_identity = {
+            "source_id": self._source_id,
+            "provider_symbol": instrument.provider_symbol,
+            "instrument_id": instrument.instrument_id,
+            "manifest_version": self._manifest.version if self._manifest else None,
+            "exchange": instrument.venue,
+            "session_policy": instrument.session_policy,
+            "adjustment_basis": "raw_unadjusted",
+            "share_class": instrument.share_class,
+            "security_type": instrument.security_type,
+            "adr_ratio": instrument.adr_ratio,
+            "venue_valid_from": instrument.venue_valid_from,
+            "venue_valid_to": instrument.venue_valid_to,
+            "entitlement_status": self._entitlement.status if self._entitlement else "blocked",
+        }
+        return rows
+
+    def _get_client(self) -> AuthorizedUSClient:
+        if self._client is None:
+            raise EntitlementBlocked("authorized US client is not configured")
+        return self._client
+
+    async def _call(self, operation: Callable[[], Any]) -> Any:
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                result = operation()
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+            except Exception as exc:
+                last_error = exc
+                if attempt >= self._max_retries:
+                    text = str(exc).lower()
+                    self.last_raw_response = dict(self.last_raw_response or {})
+                    self.last_raw_response["error"] = (
+                        "rate_limited"
+                        if "429" in text or "rate limit" in text
+                        else "provider_error"
+                    )
+                    raise
+                if self._retry_delay:
+                    await asyncio.sleep(self._retry_delay * (attempt + 1))
+        assert last_error is not None
+        raise last_error
+
+    def _require_entitlement(self, timeframe: Timeframe) -> None:
+        if not self._token or self._entitlement is None:
+            raise EntitlementBlocked("authorized US source is blocked_for_entitlement")
+        if not self._entitlement.permits(timeframe, now=self._clock()):
+            raise EntitlementBlocked(f"authorized US {timeframe.value} is blocked_for_entitlement")
+        if not self._entitlement.persistence_allowed or not self._entitlement.non_display_allowed:
+            raise EntitlementBlocked(
+                "authorized US persistence/non-display use is blocked_for_entitlement"
+            )
+
+    def _resolve_member(
+        self, ticker: str, *, start: str | None, end: str | None
+    ) -> tuple[Any, str | None]:
+        symbol = ticker.strip()
+        member = self._members.get(symbol) or next(
+            (
+                item
+                for display, item in self._members.items()
+                if display.casefold() == symbol.casefold()
+            ),
+            None,
+        )
+        if member is not None:
+            return member, None
+        if symbol.casefold() in self._aliases:
+            item = self._aliases[symbol.casefold()]
+            validity = next(
+                (
+                    value
+                    for alias, value in item.ticker_alias_validity.items()
+                    if alias.casefold() == symbol.casefold()
+                ),
+                {},
+            )
+            valid_to = validity.get("valid_to") if isinstance(validity, Mapping) else None
+            valid_from = validity.get("valid_from") if isinstance(validity, Mapping) else None
+            window_start = start[:10] if start else None
+            window_end = end[:10] if end else self._clock().date().isoformat()
+            if (valid_to and window_end > valid_to[:10]) or (
+                valid_from and window_start and window_start < valid_from[:10]
+            ):
+                raise ProviderError(f"ticker alias {ticker} is not valid for requested window")
+            return item, symbol
+        for item in self._members.values():
+            if item.provider_symbol.upper() == symbol.upper():
+                return item, None
+        if self._manifest is not None:
+            raise ProviderError(f"US ticker {ticker} is not in the MVP manifest")
+        raise ProviderError("authorized US provider requires a manifest")
+
+    def _key(self, instrument: Any, timeframe: Timeframe) -> CandleSeriesKey:
+        return CandleSeriesKey(
+            instrument_id=instrument.instrument_id,
+            display_symbol=instrument.display_symbol,
+            provider_symbol=instrument.provider_symbol,
+            source_id=self._source_id,
+            asset_class="us_stock",
+            timeframe=timeframe,
+            adjustment_basis="raw_unadjusted",
+            manifest_version=self._manifest.version if self._manifest else "mvp_universe_v1",
+        )
+
+    @staticmethod
+    def _to_mvp(key: CandleSeriesKey, candle: Candle) -> MvpCandle:
+        return MvpCandle(
+            key=key,
+            timestamp=candle.timestamp,
+            open=candle.open,
+            high=candle.high,
+            low=candle.low,
+            close=candle.close,
+            volume=candle.volume,
+            amount=candle.amount,
+            volume_semantics="traded",
+        )
+
+    @staticmethod
+    def _from_mvp(candle: MvpCandle) -> Candle:
+        return Candle(
+            timestamp=candle.timestamp,
+            open=candle.open,
+            high=candle.high,
+            low=candle.low,
+            close=candle.close,
+            volume=candle.volume or 0,
+            amount=candle.amount,
+        )
+
+    def _set_transform(self, raw_timeframe: Timeframe, rule: str, partial_count: int) -> None:
+        self.timeframe_transform = TimeframeTransform(
+            raw_timeframe=raw_timeframe,
+            timeframe_origin="aggregated",
+            aggregation={
+                "rule": rule,
+                "partial_bucket_policy": "drop_and_record",
+                "partial_bucket_count": partial_count,
+            },
+        )
+
+    def _parse_rows(
+        self, payload: Any, *, instrument: Any, timeframe: Timeframe, limit: int
+    ) -> list[Candle]:
+        if payload is None:
+            return []
+        if isinstance(payload, Mapping):
+            rows = payload.get("bars", payload.get("data", []))
+        else:
+            rows = payload
+        if not isinstance(rows, list):
+            raise ProviderError("authorized US returned malformed bar payload")
+        output: list[Candle] = []
+        now = self._clock().astimezone(timezone.utc)
+        for raw in rows:
+            if not isinstance(raw, Mapping):
+                raise ProviderError("authorized US returned malformed bar row")
+            try:
+                timestamp = raw.get("timestamp", raw.get("t", raw.get("time")))
+                stamp = self._parse_timestamp(timestamp, timeframe)
+                local = stamp.astimezone(_US_ZONE)
+                if timeframe == Timeframe.MIN_15:
+                    if stamp + timedelta(minutes=15) > now:
+                        continue
+                else:
+                    close = datetime.combine(local.date(), time(16, 0), tzinfo=_US_ZONE).astimezone(
+                        timezone.utc
+                    )
+                    if close > now:
+                        continue
+                adjustment = raw.get("adjustment_basis", raw.get("adjustment"))
+                if raw.get("adjusted") is True or (
+                    adjustment is not None and str(adjustment) != "raw_unadjusted"
+                ):
+                    raise ValueError("adjusted row is not allowed")
+                values = [
+                    float(self._raw_value(raw, name, short))
+                    for name, short in (("open", "o"), ("high", "h"), ("low", "l"), ("close", "c"))
+                ]
+                volume = float(self._raw_value(raw, "volume", "v"))
+                amount = self._raw_value(raw, "amount", "nvalue", default=None)
+                amount_value = float(amount) if amount is not None else None
+                if not all(math.isfinite(value) for value in (*values, volume)) or volume < 0:
+                    raise ValueError("non-finite OHLCV")
+                if values[1] < max(values[0], values[3]) or values[2] > min(values[0], values[3]):
+                    raise ValueError("OHLC invariant")
+                output.append(
+                    Candle(
+                        timestamp=stamp.isoformat(),
+                        open=values[0],
+                        high=values[1],
+                        low=values[2],
+                        close=values[3],
+                        volume=volume,
+                        amount=amount_value,
+                    )
+                )
+            except (KeyError, TypeError, ValueError, OverflowError) as exc:
+                self.last_raw_response["error"] = "malformed_row"
+                failure = ProviderError(f"authorized US returned malformed {timeframe.value} row")
+                failure.code = "malformed_row"
+                raise failure from exc
+        return sorted(output, key=lambda candle: candle.timestamp)[-limit:] if limit else output
+
+    @staticmethod
+    def _parse_timestamp(value: Any, timeframe: Timeframe) -> datetime:
+        if value is None:
+            raise ValueError("missing timestamp")
+        if isinstance(value, (int, float)):
+            seconds = float(value) / (1000 if float(value) > 10_000_000_000 else 1)
+            return datetime.fromtimestamp(seconds, tz=timezone.utc)
+        text = str(value).strip().replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(
+                tzinfo=_US_ZONE if timeframe == Timeframe.MIN_15 else timezone.utc
+            )
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _raw_value(raw: Mapping[str, Any], *names: str, default: Any = ...) -> Any:
+        for name in names:
+            if name in raw and raw[name] is not None:
+                return raw[name]
+        if default is not ...:
+            return default
+        raise KeyError(names[0])
+
+    @staticmethod
+    def _payload_hash(payload: Any) -> str:
+        try:
+            encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            encoded = repr(payload)
+        return sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -20,6 +20,7 @@ from kline.providers.hyperliquid import HyperliquidPerpetualProvider
 from kline.providers.sina import SinaIndexProvider
 from kline.providers.treasury import TreasuryCsvProvider
 from kline.providers.us import USStockProvider
+from kline.providers.us_authorized import AuthorizedUSProvider, USDataEntitlement
 from kline.provenance import (
     all_source_manifests,
     normalize_source,
@@ -85,6 +86,24 @@ def init(settings: Settings | None = None) -> None:
         ProviderBackedMarketDataAdapter(
             source_manifest("yahoo_finance_etf", AssetClass.ETF),
             _providers[AssetClass.ETF],
+        )
+    )
+    us_entitlement = None
+    if s.us_data_entitlement_path:
+        us_entitlement = USDataEntitlement.from_json_file(s.us_data_entitlement_path)
+    if s.us_data_source != "us_authorized_pending":
+        raise ProviderError(
+            "US MVP source must be registered explicitly before changing us_data_source"
+        )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("us_authorized_pending", AssetClass.US_STOCK),
+            AuthorizedUSProvider(
+                s.us_data_token,
+                entitlement=us_entitlement,
+                manifest=Path(__file__).resolve().parents[2] / "configs" / "mvp_manifest.json",
+                source_id="us_authorized_pending",
+            ),
         )
     )
     for factor_asset_class in (AssetClass.MACRO, AssetClass.FLOW, AssetClass.EVENT):

--- a/tests/test_us_authorized.py
+++ b/tests/test_us_authorized.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from kline.models import AssetClass, Timeframe
+from kline.mvp_manifest import load_manifest
+from kline.providers.base import EntitlementBlocked, ProviderError
+from kline.providers.us_authorized import AuthorizedUSProvider, USDataEntitlement
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def _entitlement(**overrides: object) -> USDataEntitlement:
+    values: dict[str, object] = {
+        "allowed_timeframes": ("15m", "4h", "1d", "1w"),
+        "persistence_allowed": True,
+        "derived_allowed": True,
+        "non_display_allowed": True,
+        "corporate_actions_allowed": True,
+        "evidence_ref": "operator://us/receipt-1",
+        "receipt_hash": "a" * 64,
+        "allowed_history": {"daily_years": 5, "minute_days": 60},
+    }
+    values.update(overrides)
+    return USDataEntitlement(**values)
+
+
+class FakeUSClient:
+    def __init__(self, bars: list[dict[str, object]] | None = None) -> None:
+        self.bars = bars or []
+        self.calls: list[dict[str, object]] = []
+        self.actions_calls: list[dict[str, object]] = []
+
+    def fetch_bars(
+        self,
+        provider_symbol: str,
+        timeframe: str,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        self.calls.append(
+            {
+                "provider_symbol": provider_symbol,
+                "timeframe": timeframe,
+                "start": start,
+                "end": end,
+                "limit": limit,
+            }
+        )
+        return self.bars
+
+    def fetch_corporate_actions(
+        self,
+        provider_symbol: str,
+        *,
+        start: str | None,
+        end: str | None,
+    ) -> list[dict[str, object]]:
+        self.actions_calls.append({"provider_symbol": provider_symbol, "start": start, "end": end})
+        return [{"type": "split", "ratio": "2:1"}]
+
+
+def _bar(timestamp: str, *, close: float = 101.0, adjusted: bool = False) -> dict[str, object]:
+    return {
+        "timestamp": timestamp,
+        "open": 100.0,
+        "high": max(close, 102.0),
+        "low": 99.0,
+        "close": close,
+        "volume": 1000.0,
+        "adjusted": adjusted,
+    }
+
+
+def _provider(
+    client: FakeUSClient,
+    *,
+    clock: datetime = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    entitlement: USDataEntitlement | None = None,
+    max_retries: int = 2,
+) -> AuthorizedUSProvider:
+    return AuthorizedUSProvider(
+        "secret-us-token",
+        entitlement=entitlement or _entitlement(),
+        client=client,
+        manifest=MANIFEST_PATH,
+        clock=lambda: clock,
+        max_retries=max_retries,
+    )
+
+
+@pytest.mark.asyncio
+async def test_us_provider_maps_exact_100_and_blocks_without_entitlement() -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    provider = AuthorizedUSProvider(manifest=manifest)
+
+    assert provider.membership_report() == {
+        "manifest_version": "mvp_universe_v1",
+        "expected_members": 100,
+        "mapped_members": 100,
+        "complete": True,
+        "source_id": "us_authorized_pending",
+    }
+    assert provider.supported_timeframes() == []
+    with pytest.raises(EntitlementBlocked, match="blocked_for_entitlement"):
+        await provider.fetch("AAPL", Timeframe.DAY)
+
+
+@pytest.mark.asyncio
+async def test_us_provider_keeps_raw_identity_share_class_and_venue_metadata() -> None:
+    client = FakeUSClient([_bar("2026-08-31T13:30:00Z")])
+    provider = _provider(client)
+
+    candles = await provider.fetch("BRK.B", Timeframe.MIN_15, start="2026-08-31", end="2026-09-01")
+
+    assert len(candles) == 1
+    assert client.calls[0]["provider_symbol"] == "BRK.B"
+    assert provider.source_identity["provider_symbol"] == "BRK.B"
+    assert provider.source_identity["security_type"] == "common_stock"
+    assert provider.source_identity["adjustment_basis"] == "raw_unadjusted"
+    assert "secret-us-token" not in repr(provider.last_raw_response)
+
+    tsm_client = FakeUSClient([_bar("2026-08-31")])
+    tsm = _provider(tsm_client)
+    await tsm.fetch("TSM", Timeframe.DAY)
+    assert tsm.source_identity["adr_ratio"] == "1:5"
+
+
+@pytest.mark.asyncio
+async def test_us_provider_resolves_historical_alias_and_rejects_invalid_current_alias() -> None:
+    client = FakeUSClient([_bar("2021-06-01")])
+    provider = _provider(client)
+    await provider.fetch("FB", Timeframe.DAY, start="2021-01-01", end="2021-12-31")
+    assert provider.source_identity["instrument_id"] == "US.EQ.META"
+    assert provider.source_identity["alias_used"] == "FB"
+    await provider.fetch("fb", Timeframe.DAY, start="2021-01-01", end="2021-12-31")
+    assert provider.source_identity["alias_used"] == "fb"
+
+    with pytest.raises(ProviderError, match="not valid"):
+        await provider.fetch("FB", Timeframe.DAY, start="2023-01-01", end="2023-12-31")
+
+
+@pytest.mark.asyncio
+async def test_us_provider_aggregates_15m_to_4h_and_daily_to_weekly() -> None:
+    zone = timezone(timedelta(hours=-4))
+    start = datetime(2026, 8, 31, 9, 30, tzinfo=zone)
+    bars = [
+        _bar((start + timedelta(minutes=15 * index)).isoformat(), close=100 + index)
+        for index in range(16)
+    ]
+    client = FakeUSClient(bars)
+    provider = _provider(client, clock=datetime(2026, 9, 1, tzinfo=timezone.utc))
+    derived = await provider.fetch("AAPL", Timeframe.HOUR_4)
+    assert len(derived) == 1
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
+
+    daily_client = FakeUSClient([_bar(f"2026-08-{24 + index:02d}") for index in range(5)])
+    weekly = _provider(daily_client, clock=datetime(2026, 8, 29, 12, tzinfo=timezone.utc))
+    weekly_rows = await weekly.fetch("AAPL", Timeframe.WEEK)
+    assert len(weekly_rows) == 1
+    assert weekly.timeframe_transform is not None
+    assert weekly.timeframe_transform.raw_timeframe == Timeframe.DAY
+
+
+@pytest.mark.asyncio
+async def test_us_provider_keeps_corporate_actions_separate_and_rejects_adjusted_rows() -> None:
+    client = FakeUSClient([_bar("2026-08-31", adjusted=True)])
+    provider = _provider(client)
+    with pytest.raises(ProviderError, match="malformed"):
+        await provider.fetch("AAPL", Timeframe.DAY)
+
+    actions = await _provider(FakeUSClient()).fetch_corporate_actions("AAPL")
+    assert actions == [{"type": "split", "ratio": "2:1"}]
+
+    blocked = _provider(FakeUSClient(), entitlement=_entitlement(corporate_actions_allowed=False))
+    with pytest.raises(EntitlementBlocked):
+        await blocked.fetch_corporate_actions("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_us_provider_retries_rate_limit_and_reports_empty_windows() -> None:
+    class FlakyClient(FakeUSClient):
+        def __init__(self) -> None:
+            super().__init__([_bar("2026-08-31")])
+            self.attempts = 0
+
+        def fetch_bars(self, *args: object, **kwargs: object) -> list[dict[str, object]]:
+            self.attempts += 1
+            if self.attempts < 3:
+                raise RuntimeError("429 rate limit")
+            return super().fetch_bars(*args, **kwargs)  # type: ignore[arg-type]
+
+    flaky = FlakyClient()
+    assert len(await _provider(flaky).fetch("AAPL", Timeframe.DAY)) == 1
+    assert flaky.attempts == 3
+
+    with pytest.raises(ProviderError, match="no closed rows"):
+        await _provider(FakeUSClient()).fetch("AAPL", Timeframe.DAY)
+
+
+def test_us_entitlement_receipt_is_explicit() -> None:
+    receipt = _entitlement().as_receipt()
+    assert receipt.source_id == "us_authorized_pending"
+    assert receipt.persistence_allowed is True
+    assert receipt.derived_allowed is True
+    assert "secret-us-token" not in repr(receipt)
+
+
+@pytest.mark.asyncio
+async def test_registry_exposes_pending_us_source_without_marking_it_ready(tmp_path: Path) -> None:
+    from kline.config import Settings
+    from kline.registry import get_adapter_for_source, init
+
+    init(Settings(db_path=str(tmp_path / "pending-us.db"), load_entrypoint_adapters=False))
+    adapter = get_adapter_for_source("us_authorized_pending", AssetClass.US_STOCK)
+    with pytest.raises(EntitlementBlocked) as error:
+        await adapter.fetch_candles("AAPL", Timeframe.DAY, limit=1)
+    assert error.value.code == "blocked_for_entitlement"


### PR DESCRIPTION
## What
- Add a source-agnostic `AuthorizedUSProvider` seam for the exact 100-member US manifest; the concrete licensed client is injected rather than silently using Yahoo/yfinance.
- Require explicit token plus entitlement evidence covering history, 15m/1d, derived 4H/weekly, persistence, non-display, and corporate actions. Missing/expired rights remain `blocked_for_entitlement`.
- Preserve raw/unadjusted candles, ADR/ADS/share-class/venue metadata, BRK.B provider identity, case-insensitive META/FB historical aliases, and separate corporate-action retrieval.
- Add shared 4H/weekly transforms, source/response hashes, retries, rate-limit/empty/malformed/adjusted-row classification, and pending-source registry wiring.

## Why
The US half of the MVP needs an auditable adapter contract while provider licensing is still a user-controlled decision. No public endpoint is promoted to persistent production authority by assumption.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (196 passed)
- `python3 -m ruff check src/kline/providers/us_authorized.py src/kline/provenance.py src/kline/registry.py src/kline/config.py src/kline/providers/__init__.py tests/test_us_authorized.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No automatic provider purchase, public redistribution, Yahoo/yfinance production promotion, options/fundamentals/news, trading, credentials logging, or live database cutover.

Closes #48