### PR TITLE
feat: add resumable MVP ingestion orchestrator

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -8,9 +8,9 @@
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- `main@d6dbe96` 已合并 MVP #44–#48：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US adapter seam 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
-- 当前工作：#49 `codex/issue-49-cross-market`，固化 16 个非 Treasury cross-market instrument 的 provider/volume/session/roll/fallback contract；不购买 provider、不写 Treasury/30m。
+- `main@c496a80` 已合并 MVP #44–#49：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
+- 当前工作：#50 `codex/issue-50-ingestion-orchestrator`，实现单一 run_once orchestrator、watermark overlap、quality/transform promotion 与 atomic storage commit；不安装 launchd、不切换 live DB。
 
 ## 下一步
-- 完成 #49 cross-market mapping；随后按 #50→#54 依赖链推进 orchestrator/scheduler/SSD-NAS/30-day acceptance。
+- 完成 #50 ingestion orchestrator；随后按 #51→#54 依赖链推进 scheduler/SSD-NAS/30-day acceptance。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -1,0 +1,683 @@
+"""Single high-level, resumable ingestion seam for the MVP database."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+import hashlib
+import inspect
+import json
+from typing import Any, Callable, Mapping, Sequence
+
+from kline.market_calendar import QualityResult, assess_quality
+from kline.models import AssetClass, Candle, Timeframe
+from kline.mvp_manifest import MvpManifest, manifest_digest
+from kline.ports import FetchReceipt, MarketDataPort
+from kline.providers.base import EntitlementBlocked, ProviderError
+from kline.storage import (
+    CandleSeriesKey,
+    MvpCandle,
+    MvpRunReceipt,
+    MvpRunWrite,
+    QualityReceiptWrite,
+    SourceObservationWrite,
+    StorageError,
+    StoragePort,
+    TransformReceiptWrite,
+    WatermarkWrite,
+)
+
+
+class IngestionError(RuntimeError):
+    """The run could not produce a trustworthy storage receipt."""
+
+
+@dataclass(frozen=True)
+class IngestionPlan:
+    manifest: MvpManifest
+    run_id: str
+    now: datetime | None = None
+    history_start: str | None = None
+    overlap_bars: int = 2
+    fetch_limit: int = 500
+    max_retries: int = 2
+    retry_backoff_seconds: float = 0.0
+    rate_budget: int | None = None
+    policy: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CellResult:
+    instrument_id: str
+    display_symbol: str
+    source_id: str
+    provider_symbol: str
+    timeframe: str
+    status: str
+    requested_start: str | None
+    requested_end: str
+    candle_count: int
+    quality_flags: tuple[str, ...] = ()
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "instrument_id": self.instrument_id,
+            "display_symbol": self.display_symbol,
+            "source_id": self.source_id,
+            "provider_symbol": self.provider_symbol,
+            "timeframe": self.timeframe,
+            "status": self.status,
+            "requested_start": self.requested_start,
+            "requested_end": self.requested_end,
+            "candle_count": self.candle_count,
+            "quality_flags": list(self.quality_flags),
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class IngestionRunReceipt:
+    run_id: str
+    status: str
+    manifest_version: str
+    manifest_hash: str
+    started_at: str
+    completed_at: str
+    requested_cells: tuple[CellResult, ...]
+    source_attempts: tuple[dict[str, Any], ...]
+    row_counts: Mapping[str, int]
+    quality: Mapping[str, int]
+    blocked_cells: tuple[dict[str, Any], ...]
+    storage_receipt: MvpRunReceipt
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "status": self.status,
+            "manifest_version": self.manifest_version,
+            "manifest_hash": self.manifest_hash,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "requested_cells": [cell.to_dict() for cell in self.requested_cells],
+            "source_attempts": [dict(item) for item in self.source_attempts],
+            "row_counts": dict(self.row_counts),
+            "quality": dict(self.quality),
+            "blocked_cells": [dict(item) for item in self.blocked_cells],
+            "storage_receipt": {
+                "run_id": self.storage_receipt.run_id,
+                "status": self.storage_receipt.status,
+                "manifest_version": self.storage_receipt.manifest_version,
+                "manifest_hash": self.storage_receipt.manifest_hash,
+                "candle_count": self.storage_receipt.candle_count,
+                "observation_count": self.storage_receipt.observation_count,
+                "quality_count": self.storage_receipt.quality_count,
+                "transform_count": self.storage_receipt.transform_count,
+                "watermark_count": self.storage_receipt.watermark_count,
+                "committed_at": self.storage_receipt.committed_at,
+            },
+        }
+
+
+AdapterResolver = Callable[[Any], MarketDataPort | None]
+
+
+class IngestionOrchestrator:
+    """Execute one manifest plan and promote only validated closed candles."""
+
+    def __init__(
+        self,
+        storage: StoragePort,
+        *,
+        adapter_resolver: AdapterResolver | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._storage = storage
+        self._adapter_resolver = adapter_resolver or self._default_adapter_resolver
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+
+    @staticmethod
+    def _default_adapter_resolver(instrument: Any) -> MarketDataPort | None:
+        try:
+            from kline.registry import get_adapter_for_source
+
+            return get_adapter_for_source(instrument.source_id, AssetClass(instrument.asset_class))
+        except (KeyError, ValueError, ProviderError):
+            return None
+
+    @staticmethod
+    def _now_iso(value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+    @staticmethod
+    def _key(instrument: Any, timeframe: str, manifest: MvpManifest) -> CandleSeriesKey:
+        return CandleSeriesKey(
+            instrument_id=instrument.instrument_id,
+            display_symbol=instrument.display_symbol,
+            provider_symbol=instrument.provider_symbol,
+            source_id=instrument.source_id,
+            asset_class=instrument.asset_class,
+            timeframe=timeframe,
+            adjustment_basis=instrument.adjustment_basis,
+            manifest_version=manifest.version,
+        )
+
+    @staticmethod
+    def _hash(value: Any) -> str:
+        encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _interval(timeframe: str) -> timedelta:
+        return {
+            "15m": timedelta(minutes=15),
+            "4h": timedelta(hours=4),
+            "1d": timedelta(days=1),
+            "1w": timedelta(days=7),
+        }[timeframe]
+
+    def _overlap_start(
+        self, key: CandleSeriesKey, *, history_start: str | None, overlap_bars: int
+    ) -> str | None:
+        watermark = self._storage.get_mvp_watermark(key)
+        if watermark is None:
+            return history_start
+        try:
+            stamp = datetime.fromisoformat(watermark.last_closed_timestamp.replace("Z", "+00:00"))
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=timezone.utc)
+            start = stamp - self._interval(key.timeframe) * max(0, overlap_bars)
+            return start.astimezone(timezone.utc).isoformat()
+        except ValueError as exc:
+            raise IngestionError("persisted watermark is not an ISO timestamp") from exc
+
+    async def _fetch_with_retries(
+        self,
+        adapter: MarketDataPort,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str,
+        limit: int,
+        plan: IngestionPlan,
+    ) -> FetchReceipt:
+        last_error: Exception | None = None
+        for attempt in range(plan.max_retries + 1):
+            try:
+                fetch_with_receipt = getattr(adapter, "fetch_candles_with_receipt", None)
+                if callable(fetch_with_receipt):
+                    result = fetch_with_receipt(
+                        ticker,
+                        timeframe,
+                        start=start,
+                        end=end,
+                        limit=limit,
+                    )
+                    if inspect.isawaitable(result):
+                        result = await result
+                    if isinstance(result, FetchReceipt):
+                        return result
+                    if hasattr(result, "candles"):
+                        return FetchReceipt(
+                            candles=list(result.candles),
+                            timeframe_transform=getattr(result, "timeframe_transform", None),
+                            source_identity=getattr(result, "source_identity", {}) or {},
+                            raw_response=getattr(result, "raw_response", None),
+                        )
+                fetch = adapter.fetch_candles(
+                    ticker,
+                    timeframe,
+                    start=start,
+                    end=end,
+                    limit=limit,
+                )
+                candles = await fetch if inspect.isawaitable(fetch) else fetch
+                return FetchReceipt(
+                    candles=list(candles),
+                    timeframe_transform=getattr(adapter, "timeframe_transform", None),
+                    source_identity=getattr(adapter, "source_identity", {}) or {},
+                    raw_response=getattr(adapter, "last_raw_response", None),
+                )
+            except EntitlementBlocked:
+                raise
+            except ProviderError as exc:
+                last_error = exc
+                if (
+                    getattr(exc, "code", "provider_error")
+                    in {
+                        "blocked_for_entitlement",
+                        "market_closed",
+                        "malformed_row",
+                    }
+                    or attempt >= plan.max_retries
+                ):
+                    raise
+            except Exception as exc:
+                last_error = exc
+                if attempt >= plan.max_retries:
+                    raise ProviderError(f"provider fetch failed: {exc}") from exc
+            if plan.retry_backoff_seconds:
+                await asyncio.sleep(plan.retry_backoff_seconds * (attempt + 1))
+        assert last_error is not None
+        raise ProviderError(str(last_error)) from last_error
+
+    def _to_mvp_rows(
+        self, instrument: Any, timeframe: str, candles: Sequence[Candle], manifest: MvpManifest
+    ) -> list[MvpCandle]:
+        key = self._key(instrument, timeframe, manifest)
+        rows: list[MvpCandle] = []
+        for candle in candles:
+            volume = None if instrument.volume_semantics == "not_applicable" else candle.volume
+            rows.append(
+                MvpCandle(
+                    key=key,
+                    timestamp=candle.timestamp,
+                    open=candle.open,
+                    high=candle.high,
+                    low=candle.low,
+                    close=candle.close,
+                    volume=volume,
+                    amount=candle.amount,
+                    volume_semantics=instrument.volume_semantics,
+                    is_derived=timeframe in {"4h", "1w"},
+                )
+            )
+        return rows
+
+    @staticmethod
+    def _quality_receipt(
+        run_id: str, rows: Sequence[MvpCandle], quality: QualityResult
+    ) -> QualityReceiptWrite:
+        counts = {
+            status: sum(issue.status == status for issue in quality.issues)
+            for status in {
+                "gap",
+                "duplicate",
+                "malformed",
+                "forming",
+                "missing",
+                "stale",
+                "partial",
+            }
+        }
+        key = rows[0].key if rows else None
+        if key is None:
+            raise IngestionError("quality receipt requires a series key")
+        details = {"issues": [issue.__dict__ for issue in quality.issues]}
+        return QualityReceiptWrite(
+            run_id=run_id,
+            key=key,
+            status=quality.status,
+            gaps=counts["gap"],
+            duplicates=counts["duplicate"],
+            invalid_rows=counts["malformed"],
+            blocked_cells=counts["forming"] + counts["missing"],
+            details=details,
+            receipt_hash=IngestionOrchestrator._hash(details),
+        )
+
+    async def run_once(self, plan: IngestionPlan) -> IngestionRunReceipt:
+        """Run every manifest cell once; blocked cells remain explicit in the receipt."""
+
+        started = plan.now or self._clock()
+        started_at = self._now_iso(started)
+        now = started if plan.now is not None else self._clock()
+        end = self._now_iso(now)
+        manifest = plan.manifest
+        manifest_hash = manifest_digest(manifest)
+        cells: list[CellResult] = []
+        blocked_cells: list[dict[str, Any]] = []
+        source_attempts: list[dict[str, Any]] = []
+        candles: list[MvpCandle] = []
+        observations: list[SourceObservationWrite] = []
+        qualities: list[QualityReceiptWrite] = []
+        transforms: list[TransformReceiptWrite] = []
+        watermarks: list[WatermarkWrite] = []
+        request_count = 0
+        quality_counts = {"pass": 0, "partial": 0, "fail": 0}
+
+        for instrument in manifest.instruments:
+            for timeframe in ("15m", "4h", "1d", "1w"):
+                if timeframe in instrument.not_applicable_timeframes:
+                    cells.append(
+                        CellResult(
+                            instrument.instrument_id,
+                            instrument.display_symbol,
+                            instrument.source_id,
+                            instrument.provider_symbol,
+                            timeframe,
+                            "not_applicable",
+                            None,
+                            end,
+                            0,
+                        )
+                    )
+                    continue
+                if (
+                    timeframe in instrument.blocked_timeframes
+                    or instrument.source_status == "blocked_for_entitlement"
+                ):
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        "blocked_for_entitlement",
+                        None,
+                        end,
+                        0,
+                        error="manifest entitlement gate",
+                    )
+                    cells.append(result)
+                    blocked_cells.append(result.to_dict())
+                    continue
+                if timeframe not in instrument.required_timeframes:
+                    continue
+                if plan.rate_budget is not None and request_count >= plan.rate_budget:
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        "blocked_rate_budget",
+                        None,
+                        end,
+                        0,
+                        error="rate budget exhausted",
+                    )
+                    cells.append(result)
+                    blocked_cells.append(result.to_dict())
+                    quality_counts["fail"] += 1
+                    continue
+                key = self._key(instrument, timeframe, manifest)
+                request_start = self._overlap_start(
+                    key, history_start=plan.history_start, overlap_bars=plan.overlap_bars
+                )
+                adapter = self._adapter_resolver(instrument)
+                request_count += 1
+                if adapter is None:
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        "unavailable",
+                        request_start,
+                        end,
+                        0,
+                        error="source adapter is not configured",
+                    )
+                    cells.append(result)
+                    blocked_cells.append(result.to_dict())
+                    source_attempts.append(
+                        {
+                            "source_id": instrument.source_id,
+                            "provider_symbol": instrument.provider_symbol,
+                            "timeframe": timeframe,
+                            "status": "unavailable",
+                            "error": "source adapter is not configured",
+                        }
+                    )
+                    qualities.append(
+                        QualityReceiptWrite(
+                            run_id=plan.run_id, key=key, status="blocked", blocked_cells=1
+                        )
+                    )
+                    quality_counts["fail"] += 1
+                    continue
+                try:
+                    fetch_receipt = await self._fetch_with_retries(
+                        adapter,
+                        instrument.display_symbol,
+                        Timeframe(timeframe),
+                        start=request_start,
+                        end=end,
+                        limit=plan.fetch_limit,
+                        plan=plan,
+                    )
+                    raw_rows = fetch_receipt.candles
+                    mvp_rows = self._to_mvp_rows(instrument, timeframe, raw_rows, manifest)
+                    quality = assess_quality(
+                        mvp_rows,
+                        timeframe=timeframe,
+                        calendar_id=instrument.calendar_id,
+                        cutoff=now,
+                    )
+                    quality_counts[quality.status] = quality_counts.get(quality.status, 0) + 1
+                    quality_receipt = self._quality_receipt(plan.run_id, mvp_rows, quality)
+                    qualities.append(quality_receipt)
+                    response_hash = None
+                    if fetch_receipt.raw_response is not None:
+                        response_hash = self._hash(fetch_receipt.raw_response)
+                    latest = max((row.timestamp for row in mvp_rows), default=None)
+                    observations.append(
+                        SourceObservationWrite(
+                            run_id=plan.run_id,
+                            key=key,
+                            success=quality.status != "fail",
+                            request_start=request_start,
+                            request_end=end,
+                            response_hash=response_hash,
+                            policy={"fallback": "none", "overlap_bars": plan.overlap_bars},
+                            candle_count=len(mvp_rows),
+                            latest_timestamp=latest,
+                            served_from="upstream",
+                        )
+                    )
+                    source_attempts.append(
+                        {
+                            "source_id": instrument.source_id,
+                            "provider_symbol": instrument.provider_symbol,
+                            "timeframe": timeframe,
+                            "status": quality.status,
+                            "candle_count": len(mvp_rows),
+                            "response_hash": response_hash,
+                        }
+                    )
+                    if quality.status == "pass" and mvp_rows:
+                        candles.extend(mvp_rows)
+                        watermarks.append(
+                            WatermarkWrite(
+                                key=key,
+                                last_closed_timestamp=latest or end,
+                                cursor=None,
+                                run_id=plan.run_id,
+                            )
+                        )
+                    if fetch_receipt.timeframe_transform is not None and mvp_rows:
+                        transform = fetch_receipt.timeframe_transform
+                        if transform.timeframe_origin == "aggregated":
+                            transforms.append(
+                                TransformReceiptWrite(
+                                    run_id=plan.run_id,
+                                    manifest_version=manifest.version,
+                                    instrument_id=instrument.instrument_id,
+                                    source_id=instrument.source_id,
+                                    output_timeframe=timeframe,
+                                    input_timeframe=transform.raw_timeframe.value,
+                                    aggregation_rule_version=str(
+                                        transform.aggregation.get("rule", "provider_derived")
+                                    ),
+                                    input_start=request_start or mvp_rows[0].timestamp,
+                                    input_end=end,
+                                    input_hash=response_hash or self._hash(raw_rows),
+                                    output_hash=self._hash([row.timestamp for row in mvp_rows]),
+                                    bucket_anchor=transform.aggregation.get("bucket_anchor"),
+                                    partial_bucket_policy=transform.aggregation.get(
+                                        "partial_bucket_policy"
+                                    ),
+                                    partial_bucket_count=int(
+                                        transform.aggregation.get("partial_bucket_count", 0)
+                                    ),
+                                )
+                            )
+                    status = "ready" if quality.status == "pass" else quality.status
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        status,
+                        request_start,
+                        end,
+                        len(mvp_rows) if quality.status != "fail" else 0,
+                        tuple(issue.status for issue in quality.issues),
+                        None if quality.status != "fail" else "quality gate failed",
+                    )
+                    cells.append(result)
+                    if quality.status == "fail":
+                        blocked_cells.append(result.to_dict())
+                except EntitlementBlocked as exc:
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        "blocked_for_entitlement",
+                        request_start,
+                        end,
+                        0,
+                        error=str(exc),
+                    )
+                    cells.append(result)
+                    blocked_cells.append(result.to_dict())
+                    quality_counts["fail"] += 1
+                    source_attempts.append(
+                        {
+                            "source_id": instrument.source_id,
+                            "provider_symbol": instrument.provider_symbol,
+                            "timeframe": timeframe,
+                            "status": "blocked_for_entitlement",
+                            "error": str(exc),
+                        }
+                    )
+                    qualities.append(
+                        QualityReceiptWrite(
+                            run_id=plan.run_id,
+                            key=key,
+                            status="blocked",
+                            blocked_cells=1,
+                            details={"error": str(exc)},
+                        )
+                    )
+                except ProviderError as exc:
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        getattr(exc, "code", "unavailable"),
+                        request_start,
+                        end,
+                        0,
+                        error=str(exc),
+                    )
+                    cells.append(result)
+                    blocked_cells.append(result.to_dict())
+                    quality_counts["fail"] += 1
+                    source_attempts.append(
+                        {
+                            "source_id": instrument.source_id,
+                            "provider_symbol": instrument.provider_symbol,
+                            "timeframe": timeframe,
+                            "status": getattr(exc, "code", "unavailable"),
+                            "error": str(exc),
+                        }
+                    )
+                    qualities.append(
+                        QualityReceiptWrite(
+                            run_id=plan.run_id,
+                            key=key,
+                            status="fail",
+                            blocked_cells=1,
+                            details={"error": str(exc)},
+                        )
+                    )
+                except (StorageError, ValueError) as exc:
+                    result = CellResult(
+                        instrument.instrument_id,
+                        instrument.display_symbol,
+                        instrument.source_id,
+                        instrument.provider_symbol,
+                        timeframe,
+                        "malformed",
+                        request_start,
+                        end,
+                        0,
+                        error=str(exc),
+                    )
+                    cells.append(result)
+                    blocked_cells.append(result.to_dict())
+                    quality_counts["fail"] += 1
+                    source_attempts.append(
+                        {
+                            "source_id": instrument.source_id,
+                            "provider_symbol": instrument.provider_symbol,
+                            "timeframe": timeframe,
+                            "status": "malformed",
+                            "error": str(exc),
+                        }
+                    )
+                    qualities.append(
+                        QualityReceiptWrite(
+                            run_id=plan.run_id,
+                            key=key,
+                            status="fail",
+                            invalid_rows=1,
+                            details={"error": str(exc)},
+                        )
+                    )
+
+        failures = [cell for cell in cells if cell.status not in {"ready", "not_applicable"}]
+        overall_status = "success" if not failures else "partial"
+        try:
+            storage_receipt = self._storage.commit_mvp_run(
+                MvpRunWrite(
+                    run_id=plan.run_id,
+                    manifest_version=manifest.version,
+                    manifest_hash=manifest_hash,
+                    started_at=started_at,
+                    window_start=plan.history_start,
+                    window_end=end,
+                    policy={**dict(plan.policy), "overlap_bars": plan.overlap_bars},
+                    candles=tuple(candles),
+                    source_observations=tuple(observations),
+                    quality_receipts=tuple(qualities),
+                    transform_receipts=tuple(transforms),
+                    watermarks=tuple(watermarks),
+                    status=overall_status,
+                    completed_at=end,
+                )
+            )
+        except StorageError as exc:
+            raise IngestionError(f"atomic storage promotion failed: {exc}") from exc
+        return IngestionRunReceipt(
+            run_id=plan.run_id,
+            status=overall_status,
+            manifest_version=manifest.version,
+            manifest_hash=manifest_hash,
+            started_at=started_at,
+            completed_at=end,
+            requested_cells=tuple(cells),
+            source_attempts=tuple(source_attempts),
+            row_counts={
+                "promoted_candles": len(candles),
+                "observations": len(observations),
+                "quality_receipts": len(qualities),
+                "transform_receipts": len(transforms),
+                "watermarks": len(watermarks),
+            },
+            quality=quality_counts,
+            blocked_cells=tuple(blocked_cells),
+            storage_receipt=storage_receipt,
+        )

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -469,8 +469,8 @@ class KlineStore:
         if write.window_end is not None:
             self._mvp_text(write.window_end, field_name="window_end")
         self._mvp_json(write.policy, field_name="policy")
-        if write.status not in {"success", "failed"}:
-            raise StorageError("run status must be success or failed")
+        if write.status not in {"success", "partial", "failed"}:
+            raise StorageError("run status must be success, partial, or failed")
         if write.status == "failed":
             if not write.error:
                 raise StorageError("failed run requires error")
@@ -707,7 +707,7 @@ class KlineStore:
                     or existing.manifest_hash != write.manifest_hash
                 ):
                     raise StorageError("run_id already belongs to a different manifest")
-                if existing.status != "success":
+                if existing.status not in {"success", "partial"}:
                     raise StorageError("run_id already has a failed attempt")
                 return self._mvp_run_receipt(existing)
             session.rollback()

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kline.ingestion import IngestionError, IngestionOrchestrator, IngestionPlan
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.mvp_manifest import load_manifest
+from kline.ports import FetchReceipt
+from kline.storage import CandleSeriesKey
+from kline.store import KlineStore
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+class FakeCryptoAdapter:
+    async def fetch_candles_with_receipt(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> FetchReceipt:
+        timestamps = {
+            Timeframe.MIN_15: "2026-08-31T00:00:00+00:00",
+            Timeframe.HOUR_4: "2026-08-31T00:00:00+00:00",
+            Timeframe.DAY: "2026-08-31T00:00:00+00:00",
+            Timeframe.WEEK: "2026-08-28T00:00:00+00:00",
+        }
+        candle = Candle(
+            timestamp=timestamps[timeframe],
+            open=100.0,
+            high=102.0,
+            low=99.0,
+            close=101.0,
+            volume=10.0,
+        )
+        transform = None
+        if timeframe == Timeframe.HOUR_4:
+            transform = TimeframeTransform(
+                raw_timeframe=Timeframe.MIN_15,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": "utc_fixed_4h_v1",
+                    "bucket_anchor": "00:00",
+                    "partial_bucket_policy": "drop_and_record",
+                    "partial_bucket_count": 0,
+                },
+            )
+        elif timeframe == Timeframe.WEEK:
+            transform = TimeframeTransform(
+                raw_timeframe=Timeframe.DAY,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": "completed_local_calendar_week_v1",
+                    "bucket_anchor": "local_week",
+                    "partial_bucket_policy": "defer_until_closed",
+                    "partial_bucket_count": 0,
+                },
+            )
+        return FetchReceipt(
+            candles=[candle],
+            timeframe_transform=transform,
+            source_identity={"provider_symbol": ticker},
+            raw_response={"row_count": 1, "request": {"start": start, "end": end}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_once_promotes_ready_crypto_cells_and_keeps_blocked_cells_explicit(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "ingestion.db"))
+    adapter = FakeCryptoAdapter()
+
+    def resolve(instrument):
+        return adapter if instrument.instrument_id.startswith("CRYPTO.") else None
+
+    plan = IngestionPlan(
+        manifest=manifest,
+        run_id="run-ingestion-1",
+        now=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+        history_start="2026-08-01T00:00:00+00:00",
+        fetch_limit=10,
+    )
+    receipt = await IngestionOrchestrator(store, adapter_resolver=resolve).run_once(plan)
+
+    assert receipt.status == "partial"
+    assert receipt.manifest_hash
+    assert receipt.row_counts["promoted_candles"] == 12
+    assert receipt.row_counts["watermarks"] == 12
+    assert any(cell["status"] == "blocked_for_entitlement" for cell in receipt.blocked_cells)
+    assert any(cell.status == "not_applicable" for cell in receipt.requested_cells)
+    key = CandleSeriesKey(
+        instrument_id="CRYPTO.PERP.BTC",
+        display_symbol="BTC",
+        provider_symbol="BTC",
+        source_id="hyperliquid_perpetual_public",
+        asset_class="crypto",
+        timeframe="4h",
+        adjustment_basis="raw_unadjusted",
+        manifest_version=manifest.version,
+    )
+    assert len(store.query_mvp_candles(key)) == 1
+    assert store.get_mvp_watermark(key) is not None
+    assert store.mvp_storage_health()["transform_receipts"] == 6
+
+
+@pytest.mark.asyncio
+async def test_run_once_uses_watermark_overlap_and_is_idempotent(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "idempotent.db"))
+    adapter = FakeCryptoAdapter()
+
+    def resolve(instrument):
+        return adapter if instrument.instrument_id == "CRYPTO.PERP.BTC" else None
+
+    orchestrator = IngestionOrchestrator(store, adapter_resolver=resolve)
+    first = await orchestrator.run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-overlap-1",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            history_start="2026-08-01T00:00:00+00:00",
+            fetch_limit=10,
+        )
+    )
+    second = await orchestrator.run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-overlap-2",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            history_start="2026-08-01T00:00:00+00:00",
+            overlap_bars=2,
+            fetch_limit=10,
+        )
+    )
+    assert first.storage_receipt.candle_count == second.storage_receipt.candle_count == 4
+    assert second.row_counts["promoted_candles"] == 4
+    assert store.mvp_storage_health()["candles"] == 4
+
+
+@pytest.mark.asyncio
+async def test_run_once_atomic_failure_leaves_rerun_point(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "failure.db"))
+    adapter = FakeCryptoAdapter()
+
+    def resolve(instrument):
+        return adapter if instrument.instrument_id == "CRYPTO.PERP.BTC" else None
+
+    store._mvp_commit_failpoint = lambda stage: (
+        (_ for _ in ()).throw(RuntimeError("forced storage interruption"))
+        if stage == "after_candles"
+        else None
+    )
+    with pytest.raises(IngestionError, match="atomic storage promotion failed"):
+        await IngestionOrchestrator(store, adapter_resolver=resolve).run_once(
+            IngestionPlan(
+                manifest=manifest,
+                run_id="run-failure",
+                now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+                fetch_limit=10,
+            )
+        )
+    assert store.mvp_storage_health()["runs"] == 0
+    assert store.mvp_storage_health()["candles"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_once_rate_budget_blocks_remaining_required_cells(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "budget.db"))
+    adapter = FakeCryptoAdapter()
+
+    def resolve(instrument):
+        return adapter if instrument.instrument_id == "CRYPTO.PERP.BTC" else None
+
+    receipt = await IngestionOrchestrator(store, adapter_resolver=resolve).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-budget",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            rate_budget=1,
+            fetch_limit=10,
+        )
+    )
+    assert receipt.status == "partial"
+    assert any(cell.status == "blocked_rate_budget" for cell in receipt.requested_cells)


### PR DESCRIPTION
## What
- Add `IngestionPlan`, cell/run receipts, and one high-level `run_once` orchestration seam.
- Load source-aware watermarks with bounded overlap, invoke explicit adapters with bounded retries, and keep not-applicable, entitlement-blocked, unavailable, rate-budget, provider, and quality failures explicit.
- Convert validated closed candles to the #45 MVP storage types; promote only quality-pass rows, persist source/quality/transform receipts, and advance watermarks in one atomic storage commit.
- Include manifest hash, requested cells, source attempts, row counts, quality outcomes, blocked cells, and storage receipt in the run result.

## Why
The MVP now needs one resumable execution seam before adding the four-hour worker. This keeps scheduling separate from source adapters and SQLite details while preserving fail-closed behavior.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (203 passed)
- `python3 -m ruff check src/kline/ingestion.py src/kline/store.py tests/test_ingestion.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No launchd install, active-DB cutover, provider implementation, automatic fallback, trading path, or public API.

Closes #50