### PR TITLE
feat: add controlled MVP worker and health surface

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -8,9 +8,9 @@
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- `main@c496a80` 已合并 MVP #44–#49：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
-- 当前工作：#50 `codex/issue-50-ingestion-orchestrator`，实现单一 run_once orchestrator、watermark overlap、quality/transform promotion 与 atomic storage commit；不安装 launchd、不切换 live DB。
+- `main@74e8810` 已合并 MVP #44–#50：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
+- 当前工作：#51 `codex/issue-51-mvp-worker`，实现独立 ≤4h worker、single-run lock、SSD guard callback 与 health/serving status；不改 resident launchd、不切 live DB。
 
 ## 下一步
-- 完成 #50 ingestion orchestrator；随后按 #51→#54 依赖链推进 scheduler/SSD-NAS/30-day acceptance。
+- 完成 #51 MVP worker/health surface；随后按 #52→#54 依赖链推进 SSD/NAS/30-day acceptance。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/src/kline/mvp_worker.py
+++ b/src/kline/mvp_worker.py
@@ -1,0 +1,447 @@
+"""Controlled four-hour MVP worker and local health/serving receipts.
+
+This module is intentionally separate from the resident launchd service.  A
+caller may run one pass or supervise the loop from its own process; installing
+launchd is a later cutover decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import fcntl
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+from kline.ingestion import (
+    IngestionError,
+    IngestionOrchestrator,
+    IngestionPlan,
+    IngestionRunReceipt,
+)
+from kline.mvp_manifest import MvpManifest
+from kline.storage import StoragePort
+
+
+MAX_INTERVAL_SECONDS = 4 * 60 * 60
+
+
+class WorkerError(RuntimeError):
+    """Worker configuration or supervision error."""
+
+
+@dataclass(frozen=True)
+class TargetGuardResult:
+    status: str
+    target: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class WorkerRunResult:
+    status: str
+    run_id: str | None
+    started_at: str
+    completed_at: str
+    receipt: IngestionRunReceipt | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkerState:
+    status: str
+    last_attempt_at: str | None
+    last_success_at: str | None
+    last_run_id: str | None
+    next_due_at: str | None
+    last_reason: str | None
+
+
+def next_due_at(*, last_started: datetime, now: datetime, interval_seconds: int) -> datetime:
+    """Schedule the next run without accumulating interval-overrun drift."""
+
+    due = last_started + timedelta(seconds=interval_seconds)
+    if due <= now:
+        return now
+    return due
+
+
+class _SingleRunLock:
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._fd: int | None = None
+
+    def __enter__(self) -> "_SingleRunLock":
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(self._fd)
+            self._fd = None
+            raise WorkerError("worker lock is already held") from exc
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._fd is not None:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+
+class MvpWorker:
+    """Run the orchestrator on a bounded heartbeat with local supervision gates."""
+
+    def __init__(
+        self,
+        manifest: MvpManifest,
+        storage: StoragePort,
+        *,
+        orchestrator: IngestionOrchestrator | None = None,
+        adapter_resolver: Callable[[Any], Any] | None = None,
+        interval_seconds: int = MAX_INTERVAL_SECONDS,
+        lock_path: str | Path = ".mvp-worker.lock",
+        history_start: str | None = None,
+        target_guard: Callable[[], TargetGuardResult | bool] | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        if interval_seconds <= 0 or interval_seconds > MAX_INTERVAL_SECONDS:
+            raise WorkerError("interval_seconds must be >0 and no greater than four hours")
+        self.manifest = manifest
+        self.storage = storage
+        self.interval_seconds = interval_seconds
+        self.lock_path = Path(lock_path)
+        self.history_start = history_start
+        self._target_guard = target_guard or (lambda: True)
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._orchestrator = orchestrator or IngestionOrchestrator(
+            storage,
+            adapter_resolver=adapter_resolver,
+            clock=self._clock,
+        )
+        self._state = WorkerState("idle", None, None, None, None, None)
+        self._restore_state()
+
+    def _restore_state(self) -> None:
+        latest = self.storage.latest_mvp_run() if hasattr(self.storage, "latest_mvp_run") else None
+        if not latest:
+            return
+        status = (
+            "success"
+            if latest["status"] == "success"
+            else "partial"
+            if latest["status"] == "partial"
+            else "failed"
+        )
+        last_attempt = latest.get("started_at")
+        last_success = latest.get("completed_at") if status == "success" else None
+        next_due = None
+        completed = latest.get("completed_at")
+        if isinstance(completed, str):
+            try:
+                parsed = datetime.fromisoformat(completed.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                next_due = self._iso(
+                    parsed.astimezone(timezone.utc) + timedelta(seconds=self.interval_seconds)
+                )
+            except ValueError:
+                next_due = None
+        self._state = WorkerState(
+            status,
+            last_attempt,
+            last_success,
+            latest.get("run_id"),
+            next_due,
+            latest.get("error"),
+        )
+
+    @staticmethod
+    def _iso(value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+    def _guard(self) -> TargetGuardResult:
+        value = self._target_guard()
+        if isinstance(value, TargetGuardResult):
+            return value
+        if value is True:
+            return TargetGuardResult("ready", "unspecified")
+        return TargetGuardResult("blocked", "unspecified", "target guard returned false")
+
+    async def run_once(self) -> WorkerRunResult:
+        started = self._clock()
+        started_at = self._iso(started)
+        due = next_due_at(last_started=started, now=started, interval_seconds=self.interval_seconds)
+        guard = self._guard()
+        if guard.status != "ready":
+            completed_at = self._iso(self._clock())
+            self._state = WorkerState(
+                "blocked_target",
+                started_at,
+                self._state.last_success_at,
+                None,
+                self._iso(due),
+                guard.detail or guard.status,
+            )
+            return WorkerRunResult(
+                "blocked_target",
+                None,
+                started_at,
+                completed_at,
+                reason=guard.detail or guard.status,
+            )
+        try:
+            lock = _SingleRunLock(self.lock_path)
+            lock.__enter__()
+        except WorkerError as exc:
+            completed_at = self._iso(self._clock())
+            self._state = WorkerState(
+                "lock_contended",
+                started_at,
+                self._state.last_success_at,
+                None,
+                self._iso(due),
+                str(exc),
+            )
+            return WorkerRunResult(
+                "lock_contended", None, started_at, completed_at, reason=str(exc)
+            )
+        try:
+            run_id = f"mvp-{started.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+            receipt = await self._orchestrator.run_once(
+                IngestionPlan(
+                    manifest=self.manifest,
+                    run_id=run_id,
+                    now=started,
+                    history_start=self.history_start,
+                )
+            )
+            completed_at = self._iso(self._clock())
+            next_due = next_due_at(
+                last_started=started,
+                now=self._clock(),
+                interval_seconds=self.interval_seconds,
+            )
+            status = "success" if receipt.status == "success" else "partial"
+            self._state = WorkerState(
+                status,
+                started_at,
+                completed_at if status == "success" else self._state.last_success_at,
+                run_id,
+                self._iso(next_due),
+                None,
+            )
+            return WorkerRunResult(status, run_id, started_at, completed_at, receipt=receipt)
+        except IngestionError as exc:
+            completed_at = self._iso(self._clock())
+            self._state = WorkerState(
+                "failed",
+                started_at,
+                self._state.last_success_at,
+                None,
+                self._iso(due),
+                str(exc),
+            )
+            return WorkerRunResult("failed", None, started_at, completed_at, reason=str(exc))
+        finally:
+            lock.__exit__(None, None, None)
+
+    def health(self, *, now: datetime | None = None) -> dict[str, Any]:
+        return build_mvp_health(
+            self.manifest,
+            self.storage,
+            state=self._state,
+            now=now or self._clock(),
+            interval_seconds=self.interval_seconds,
+        )
+
+    def serving(self) -> dict[str, Any]:
+        return build_mvp_serving_status(self.manifest, self.storage, now=self._clock())
+
+    async def run_forever(self, stop_event: Any) -> None:
+        """Supervise the worker until an asyncio-compatible stop event is set."""
+
+        while not stop_event.is_set():
+            result = await self.run_once()
+            wait_seconds = self.interval_seconds
+            if result.receipt is not None:
+                wait_seconds = self.interval_seconds
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=wait_seconds)
+            except TimeoutError:
+                continue
+
+
+def _source_states(manifest: MvpManifest) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for item in manifest.instruments:
+        state = grouped.setdefault(
+            item.source_id,
+            {
+                "source_id": item.source_id,
+                "status": "configured",
+                "instruments": 0,
+                "blocked_cells": 0,
+            },
+        )
+        state["instruments"] += 1
+        if item.source_status == "blocked_for_entitlement":
+            state["status"] = "blocked_for_entitlement"
+            state["blocked_cells"] += len(item.blocked_timeframes) or 4
+    return sorted(grouped.values(), key=lambda value: value["source_id"])
+
+
+def build_mvp_health(
+    manifest: MvpManifest,
+    storage: StoragePort,
+    *,
+    state: WorkerState | None = None,
+    now: datetime,
+    interval_seconds: int = MAX_INTERVAL_SECONDS,
+) -> dict[str, Any]:
+    latest_run = storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None
+    storage_health = storage.mvp_storage_health() if hasattr(storage, "mvp_storage_health") else {}
+    quality = storage.mvp_quality_summary() if hasattr(storage, "mvp_quality_summary") else {}
+    backup = storage.latest_mvp_backup() if hasattr(storage, "latest_mvp_backup") else None
+    worker_state = state or WorkerState("idle", None, None, None, None, None)
+    if latest_run is None:
+        overall = "blocked"
+    elif latest_run["status"] == "success":
+        overall = "ready"
+    elif latest_run["status"] == "partial":
+        overall = "partial"
+    else:
+        overall = "failed"
+    return {
+        "status": overall,
+        "manifest_version": manifest.version,
+        "manifest_hash": _manifest_hash(manifest),
+        "worker": {
+            "status": worker_state.status,
+            "last_attempt_at": worker_state.last_attempt_at,
+            "last_success_at": worker_state.last_success_at,
+            "last_run_id": worker_state.last_run_id,
+            "next_due_at": worker_state.next_due_at,
+            "last_reason": worker_state.last_reason,
+            "interval_seconds": interval_seconds,
+        },
+        "last_run": latest_run,
+        "sources": _source_states(manifest),
+        "latest_closed_bars": storage.mvp_latest_closed_bars()
+        if hasattr(storage, "mvp_latest_closed_bars")
+        else [],
+        "quality": quality,
+        "row_counts": storage_health,
+        "raw_retention": {
+            "status": "receipt_only",
+            "policy": "mvp_raw_payloads_are_not_persisted_by_worker",
+            "legacy_raw_table_is_outside_mvp": True,
+        },
+        "backup": backup,
+        "as_of": _iso(now),
+    }
+
+
+def build_mvp_serving_status(
+    manifest: MvpManifest, storage: StoragePort, *, now: datetime | None = None
+) -> dict[str, Any]:
+    latest = {
+        (
+            row["source_id"],
+            row["instrument_id"],
+            row["timeframe"],
+            row["adjustment_basis"],
+            row["manifest_version"],
+        ): row
+        for row in storage.mvp_latest_closed_bars()
+    }
+    cells: list[dict[str, Any]] = []
+    for instrument in manifest.instruments:
+        for timeframe in ("15m", "4h", "1d", "1w"):
+            status = "ready"
+            if timeframe in instrument.not_applicable_timeframes:
+                status = "not_applicable"
+            elif (
+                timeframe in instrument.blocked_timeframes
+                or instrument.source_status == "blocked_for_entitlement"
+            ):
+                status = "blocked"
+            elif timeframe not in instrument.required_timeframes:
+                status = "not_applicable"
+            else:
+                row = latest.get(
+                    (
+                        instrument.source_id,
+                        instrument.instrument_id,
+                        timeframe,
+                        instrument.adjustment_basis,
+                        manifest.version,
+                    )
+                )
+                if row is None:
+                    status = "unavailable"
+                elif now is not None and instrument.calendar_id in {"crypto_24x7", "us_futures"}:
+                    try:
+                        latest_stamp = datetime.fromisoformat(
+                            row["latest_timestamp"].replace("Z", "+00:00")
+                        )
+                        if latest_stamp.tzinfo is None:
+                            latest_stamp = latest_stamp.replace(tzinfo=timezone.utc)
+                        age = (
+                            now.astimezone(timezone.utc) - latest_stamp.astimezone(timezone.utc)
+                        ).total_seconds()
+                        max_age = {
+                            "15m": 45 * 60,
+                            "4h": 12 * 60 * 60,
+                            "1d": 3 * 24 * 60 * 60,
+                            "1w": 21 * 24 * 60 * 60,
+                        }[timeframe]
+                        if age > max_age:
+                            status = "stale"
+                    except (AttributeError, TypeError, ValueError):
+                        status = "unavailable"
+            row = latest.get(
+                (
+                    instrument.source_id,
+                    instrument.instrument_id,
+                    timeframe,
+                    instrument.adjustment_basis,
+                    manifest.version,
+                )
+            )
+            cells.append(
+                {
+                    "instrument_id": instrument.instrument_id,
+                    "display_symbol": instrument.display_symbol,
+                    "provider_symbol": instrument.provider_symbol,
+                    "source_id": instrument.source_id,
+                    "manifest_version": manifest.version,
+                    "timeframe": timeframe,
+                    "status": status,
+                    "adjustment_basis": instrument.adjustment_basis,
+                    "latest_closed_timestamp": row["latest_timestamp"] if row else None,
+                    "row_count": row["row_count"] if row else 0,
+                }
+            )
+    return {
+        "status": "ready" if any(cell["status"] == "ready" for cell in cells) else "blocked",
+        "manifest_version": manifest.version,
+        "manifest_hash": _manifest_hash(manifest),
+        "cells": cells,
+    }
+
+
+def _manifest_hash(manifest: MvpManifest) -> str:
+    from kline.mvp_manifest import manifest_digest
+
+    return manifest_digest(manifest)
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -1045,6 +1045,122 @@ class KlineStore:
             }
         return {"status": "ok", **counts}
 
+    def latest_mvp_run(self) -> dict[str, Any] | None:
+        """Return the newest persisted MVP run receipt summary."""
+
+        with self._session_factory() as session:
+            row = session.execute(
+                select(MvpRunRow)
+                .order_by(MvpRunRow.created_at.desc(), MvpRunRow.run_id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+        if row is None:
+            return None
+        return {
+            "run_id": row.run_id,
+            "status": row.status,
+            "manifest_version": row.manifest_version,
+            "manifest_hash": row.manifest_hash,
+            "started_at": row.started_at,
+            "completed_at": row.completed_at,
+            "window_start": row.window_start,
+            "window_end": row.window_end,
+            "candle_count": row.candle_count,
+            "observation_count": row.observation_count,
+            "quality_count": row.quality_count,
+            "transform_count": row.transform_count,
+            "watermark_count": row.watermark_count,
+            "receipt_hash": row.receipt_hash,
+            "error": row.error,
+        }
+
+    def mvp_latest_closed_bars(self) -> list[dict[str, Any]]:
+        """Return latest timestamp/row count for each source-aware MVP series."""
+
+        latest = (
+            select(
+                MvpCandleRow.source_id,
+                MvpCandleRow.instrument_id,
+                MvpCandleRow.timeframe,
+                MvpCandleRow.adjustment_basis,
+                MvpCandleRow.manifest_version,
+                func.max(MvpCandleRow.timestamp).label("latest_timestamp"),
+                func.count().label("row_count"),
+            )
+            .group_by(
+                MvpCandleRow.source_id,
+                MvpCandleRow.instrument_id,
+                MvpCandleRow.timeframe,
+                MvpCandleRow.adjustment_basis,
+                MvpCandleRow.manifest_version,
+            )
+            .subquery()
+        )
+        with self._session_factory() as session:
+            rows = session.execute(select(latest)).all()
+        return [
+            {
+                "source_id": row.source_id,
+                "instrument_id": row.instrument_id,
+                "timeframe": row.timeframe,
+                "adjustment_basis": row.adjustment_basis,
+                "manifest_version": row.manifest_version,
+                "latest_timestamp": row.latest_timestamp,
+                "row_count": row.row_count,
+            }
+            for row in rows
+        ]
+
+    def mvp_quality_summary(self) -> dict[str, Any]:
+        """Summarize persisted quality outcomes for the health surface."""
+
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(
+                    MvpQualityReceiptRow.status,
+                    func.count().label("count"),
+                    func.coalesce(func.sum(MvpQualityReceiptRow.gaps), 0).label("gaps"),
+                    func.coalesce(func.sum(MvpQualityReceiptRow.duplicates), 0).label("duplicates"),
+                    func.coalesce(func.sum(MvpQualityReceiptRow.blocked_cells), 0).label(
+                        "blocked_cells"
+                    ),
+                ).group_by(MvpQualityReceiptRow.status)
+            ).all()
+        return {
+            "by_status": {
+                row.status: {
+                    "count": int(row.count),
+                    "gaps": int(row.gaps),
+                    "duplicates": int(row.duplicates),
+                    "blocked_cells": int(row.blocked_cells),
+                }
+                for row in rows
+            }
+        }
+
+    def latest_mvp_backup(self) -> dict[str, Any] | None:
+        """Return the newest backup receipt without exposing database paths."""
+
+        with self._session_factory() as session:
+            row = session.execute(
+                select(MvpBackupReceiptRow)
+                .order_by(
+                    MvpBackupReceiptRow.created_at.desc(), MvpBackupReceiptRow.backup_id.desc()
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+        if row is None:
+            return None
+        return {
+            "backup_id": row.backup_id,
+            "run_id": row.run_id,
+            "status": row.status,
+            "checksum": row.checksum,
+            "size_bytes": row.size_bytes,
+            "restore_verified": row.restore_verified,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+        }
+
     def storage_health(self) -> dict[str, Any]:
         """Return an owner-side integrity receipt without exposing the database path."""
         with self._engine.connect() as connection:

--- a/tests/test_mvp_worker.py
+++ b/tests/test_mvp_worker.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from kline.models import Timeframe
+from kline.mvp_manifest import load_manifest, manifest_digest
+from kline.mvp_worker import (
+    MAX_INTERVAL_SECONDS,
+    MvpWorker,
+    TargetGuardResult,
+    WorkerError,
+    _SingleRunLock,
+    build_mvp_health,
+    build_mvp_serving_status,
+    next_due_at,
+)
+from kline.store import KlineStore
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_interval_is_capped_at_four_hours_and_overrun_does_not_drift(tmp_path: Path) -> None:
+    now = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
+    assert (
+        next_due_at(
+            last_started=now - timedelta(hours=5), now=now, interval_seconds=MAX_INTERVAL_SECONDS
+        )
+        == now
+    )
+    assert next_due_at(
+        last_started=now - timedelta(hours=1), now=now, interval_seconds=MAX_INTERVAL_SECONDS
+    ) == now + timedelta(hours=3)
+    with pytest.raises(WorkerError, match="no greater than four hours"):
+        MvpWorker(
+            load_manifest(MANIFEST_PATH),
+            KlineStore(str(tmp_path / "interval.db")),
+            interval_seconds=MAX_INTERVAL_SECONDS + 1,
+        )
+
+
+def test_single_run_lock_reports_contention(tmp_path: Path) -> None:
+    path = tmp_path / "worker.lock"
+    first = _SingleRunLock(path)
+    first.__enter__()
+    try:
+        with pytest.raises(WorkerError, match="already held"):
+            _SingleRunLock(path).__enter__()
+    finally:
+        first.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_worker_target_guard_blocks_without_calling_orchestrator(tmp_path: Path) -> None:
+    class NeverOrchestrator:
+        called = False
+
+        async def run_once(self, _plan):
+            self.called = True
+            raise AssertionError("orchestrator must not run when target is blocked")
+
+    orchestrator = NeverOrchestrator()
+    worker = MvpWorker(
+        load_manifest(MANIFEST_PATH),
+        KlineStore(str(tmp_path / "guard.db")),
+        orchestrator=orchestrator,
+        target_guard=lambda: TargetGuardResult("blocked", "/Volumes/Phone SSD", "mount missing"),
+        clock=lambda: datetime(2026, 8, 31, 5, tzinfo=timezone.utc),
+    )
+    result = await worker.run_once()
+    assert result.status == "blocked_target"
+    assert result.reason == "mount missing"
+    assert orchestrator.called is False
+    assert worker.health()["worker"]["status"] == "blocked_target"
+
+
+@pytest.mark.asyncio
+async def test_worker_runs_orchestrator_and_serving_reports_stable_cells(tmp_path: Path) -> None:
+    from tests.test_ingestion import FakeCryptoAdapter
+
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "worker.db"))
+    adapter = FakeCryptoAdapter()
+    worker = MvpWorker(
+        manifest,
+        store,
+        adapter_resolver=lambda instrument: (
+            adapter if instrument.instrument_id.startswith("CRYPTO.") else None
+        ),
+        interval_seconds=3600,
+        lock_path=tmp_path / "worker.lock",
+        clock=lambda: datetime(2026, 8, 31, 5, tzinfo=timezone.utc),
+    )
+
+    result = await worker.run_once()
+    assert result.status == "partial"
+    assert result.receipt is not None
+    health = worker.health()
+    assert health["status"] == "partial"
+    assert health["manifest_hash"] == manifest_digest(manifest)
+    assert health["worker"]["interval_seconds"] == 3600
+    assert health["raw_retention"]["status"] == "receipt_only"
+    assert health["row_counts"]["candles"] == 9
+
+    serving = worker.serving()
+    btc_4h = next(
+        cell
+        for cell in serving["cells"]
+        if cell["instrument_id"] == "CRYPTO.PERP.BTC"
+        and cell["timeframe"] == Timeframe.HOUR_4.value
+    )
+    assert btc_4h["status"] == "ready"
+    spx = next(
+        cell
+        for cell in serving["cells"]
+        if cell["instrument_id"] == "US.INDEX.SPX" and cell["timeframe"] == "1d"
+    )
+    assert spx["status"] == "blocked"
+
+    restarted = MvpWorker(
+        manifest,
+        store,
+        adapter_resolver=lambda instrument: (
+            adapter if instrument.instrument_id.startswith("CRYPTO.") else None
+        ),
+        interval_seconds=3600,
+        lock_path=tmp_path / "worker.lock",
+        clock=lambda: datetime(2026, 8, 31, 5, tzinfo=timezone.utc),
+    )
+    assert restarted.health()["worker"]["last_run_id"] == result.run_id
+
+
+def test_health_and_serving_are_explicit_before_any_run(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "empty.db"))
+    health = build_mvp_health(manifest, store, now=datetime(2026, 9, 1, tzinfo=timezone.utc))
+    serving = build_mvp_serving_status(manifest, store)
+
+    assert health["status"] == "blocked"
+    assert health["last_run"] is None
+    assert health["backup"] is None
+    assert serving["manifest_hash"] == manifest_digest(manifest)
+    assert all("instrument_id" in cell and "source_id" in cell for cell in serving["cells"])


### PR DESCRIPTION
## What
- Add a separate four-hour-bounded `MvpWorker` with non-blocking single-run lock, target guard callback, restart-state recovery, interval-overrun handling, and controlled `run_once`/`run_forever` entry points.
- Add local health and serving receipts exposing manifest hash, worker/run freshness, source/entitlement states, latest closed bars, quality summary, row counts, raw-retention policy, backup age, and stable instrument/timeframe statuses.
- Extend the storage read seam with latest-run, latest-bar, quality, and backup summaries.
- Keep all launchd/live DB changes out of this ticket.

## Why
The MVP needs an observable periodic worker before controlled SSD/NAS cutover. It must coexist with the resident `com.wendy.datafeed` service and remain explicit when the target is unavailable or a source is blocked.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (208 passed)
- `python3 -m ruff check src/kline/mvp_worker.py src/kline/store.py tests/test_mvp_worker.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No launchd install/modification, live database move, NAS mount, provider fallback, trading, or 30m/Treasury writes.

Closes #51