### PR TITLE
feat: add SSD NAS backup and restore safeguards

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -8,9 +8,9 @@
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- `main@74e8810` 已合并 MVP #44–#50：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
-- 当前工作：#51 `codex/issue-51-mvp-worker`，实现独立 ≤4h worker、single-run lock、SSD guard callback 与 health/serving status；不改 resident launchd、不切 live DB。
+- `main@a714fcf` 已合并 MVP #44–#51：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once、独立 ≤4h worker/health 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
+- 当前工作：#52 `codex/issue-52-storage-ops`，实现 SSD mount guard、SQLite consistent backup、NAS verifier 与 disposable restore drill；不切 active DB、不改 launchd。
 
 ## 下一步
-- 完成 #51 MVP worker/health surface；随后按 #52→#54 依赖链推进 SSD/NAS/30-day acceptance。
+- 完成 #52 SSD/NAS backup/restore contract；随后按 #53→#54 依赖链推进 controlled cutover/30-day acceptance。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/src/kline/storage_ops.py
+++ b/src/kline/storage_ops.py
@@ -1,0 +1,537 @@
+"""Safe SSD mount, SQLite backup, NAS verification, and restore operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import os
+from pathlib import Path
+import plistlib
+import shutil
+import sqlite3
+import subprocess
+from typing import Any, Callable, Mapping
+from uuid import uuid4
+
+
+class StorageOpsError(RuntimeError):
+    """An operational storage safety check failed."""
+
+
+@dataclass(frozen=True)
+class MountGuardResult:
+    status: str
+    mount_path: str
+    expected_volume_uuid: str
+    observed_volume_uuid: str | None
+    filesystem: str | None
+    database_root: str
+    detail: str
+
+    def to_worker_guard(self):
+        from kline.mvp_worker import TargetGuardResult
+
+        return TargetGuardResult(self.status, self.mount_path, self.detail)
+
+
+CommandRunner = Callable[[list[str]], str]
+
+
+class SsdMountGuard:
+    """Fail closed unless the expected APFS volume is mounted at the target path."""
+
+    def __init__(
+        self,
+        mount_path: str | Path,
+        *,
+        expected_volume_uuid: str,
+        database_root: str | Path,
+        is_mount_fn: Callable[[str], bool] | None = None,
+        filesystem_fn: Callable[[str], str] | None = None,
+        volume_uuid_fn: Callable[[str], str | None] | None = None,
+    ) -> None:
+        self.mount_path = Path(mount_path).expanduser()
+        self.expected_volume_uuid = expected_volume_uuid.strip().upper()
+        self.database_root = Path(database_root).expanduser()
+        self._is_mount = is_mount_fn or os.path.ismount
+        self._filesystem = filesystem_fn or self._default_filesystem
+        self._volume_uuid = volume_uuid_fn or self._default_volume_uuid
+
+    @staticmethod
+    def _default_filesystem(path: str) -> str:
+        try:
+            result = subprocess.run(
+                ["stat", "-f", "%T", path],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise StorageOpsError("unable to inspect target filesystem") from exc
+        return result.stdout.strip()
+
+    @staticmethod
+    def _default_volume_uuid(path: str) -> str | None:
+        try:
+            result = subprocess.run(
+                ["diskutil", "info", "-plist", path],
+                check=True,
+                capture_output=True,
+            )
+            payload = plistlib.loads(result.stdout)
+        except (OSError, subprocess.CalledProcessError, plistlib.InvalidFileException):
+            return None
+        for key in ("VolumeUUID", "APFSVolumeUUID", "DiskUUID"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def check(self) -> MountGuardResult:
+        mount = str(self.mount_path.resolve())
+        db_root = str(self.database_root.resolve())
+        if not self.expected_volume_uuid:
+            return MountGuardResult(
+                "blocked",
+                mount,
+                "",
+                None,
+                None,
+                db_root,
+                "expected volume UUID is required",
+            )
+        if not self._is_mount(mount):
+            return MountGuardResult(
+                "blocked",
+                mount,
+                self.expected_volume_uuid,
+                None,
+                None,
+                db_root,
+                "target volume is not mounted",
+            )
+        try:
+            relative = self.database_root.resolve().relative_to(self.mount_path.resolve())
+        except ValueError:
+            return MountGuardResult(
+                "blocked",
+                mount,
+                self.expected_volume_uuid,
+                None,
+                None,
+                db_root,
+                "database root is outside target volume",
+            )
+        if str(relative) == ".":
+            return MountGuardResult(
+                "blocked",
+                mount,
+                self.expected_volume_uuid,
+                None,
+                None,
+                db_root,
+                "database root must be a child of target volume",
+            )
+        try:
+            filesystem = self._filesystem(mount).strip().casefold()
+        except StorageOpsError as exc:
+            return MountGuardResult(
+                "blocked",
+                mount,
+                self.expected_volume_uuid,
+                None,
+                None,
+                db_root,
+                str(exc),
+            )
+        observed = self._volume_uuid(mount)
+        if filesystem != "apfs":
+            detail = f"target filesystem is {filesystem or 'unknown'}, expected apfs"
+            status = "blocked"
+        elif not observed or observed.upper() != self.expected_volume_uuid:
+            detail = "target volume UUID does not match expected UUID"
+            status = "blocked"
+        else:
+            detail = "target APFS volume and database root verified"
+            status = "ready"
+        return MountGuardResult(
+            status, mount, self.expected_volume_uuid, observed, filesystem, db_root, detail
+        )
+
+
+@dataclass(frozen=True)
+class NasHealthResult:
+    status: str
+    target_root: str
+    filesystem: str | None
+    free_bytes: int
+    required_bytes: int
+    probe_checksum: str | None
+    generations: int
+    detail: str
+
+
+class NasVerifier:
+    """Verify a NAS backup target without ever opening SQLite on that share."""
+
+    def __init__(
+        self,
+        target_root: str | Path,
+        *,
+        required_bytes: int = 0,
+        retention_generations: int = 3,
+        filesystem_fn: Callable[[str], str | None] | None = None,
+        disk_usage_fn: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.target_root = Path(target_root).expanduser()
+        self.required_bytes = max(0, required_bytes)
+        self.retention_generations = max(1, retention_generations)
+        self._filesystem = filesystem_fn or (lambda _path: None)
+        self._disk_usage = disk_usage_fn or shutil.disk_usage
+
+    def check(self) -> NasHealthResult:
+        target = str(self.target_root.resolve())
+        if not self.target_root.is_dir():
+            return NasHealthResult(
+                "blocked",
+                target,
+                None,
+                0,
+                self.required_bytes,
+                None,
+                0,
+                "NAS target directory is unavailable",
+            )
+        usage = self._disk_usage(target)
+        free_bytes = int(getattr(usage, "free", usage[2] if isinstance(usage, tuple) else 0))
+        if free_bytes < self.required_bytes:
+            return NasHealthResult(
+                "blocked",
+                target,
+                self._filesystem(target),
+                free_bytes,
+                self.required_bytes,
+                None,
+                0,
+                "NAS target has insufficient free space",
+            )
+        probe = self.target_root / f".mvp-write-probe-{uuid4().hex}"
+        payload = uuid4().hex.encode("ascii")
+        checksum = hashlib.sha256(payload).hexdigest()
+        try:
+            probe.write_bytes(payload)
+            if probe.read_bytes() != payload:
+                raise OSError("NAS read-back mismatch")
+        except (OSError, ValueError) as exc:
+            return NasHealthResult(
+                "blocked",
+                target,
+                self._filesystem(target),
+                free_bytes,
+                self.required_bytes,
+                None,
+                0,
+                f"NAS write/read-back failed: {exc}",
+            )
+        finally:
+            try:
+                probe.unlink()
+            except FileNotFoundError:
+                pass
+        generations = len(list(self.target_root.glob("mvp-backup-*.db")))
+        status = "ready" if generations <= self.retention_generations else "retention_overdue"
+        detail = (
+            "NAS target write/read-back verified"
+            if status == "ready"
+            else "NAS target exceeds configured retention generations"
+        )
+        return NasHealthResult(
+            status,
+            target,
+            self._filesystem(target),
+            free_bytes,
+            self.required_bytes,
+            checksum,
+            generations,
+            detail,
+        )
+
+    def verify_backup(
+        self, backup_path: str | Path, *, expected_checksum: str | None = None
+    ) -> NasHealthResult:
+        health = self.check()
+        if health.status not in {"ready", "retention_overdue"}:
+            return health
+        path = Path(backup_path).resolve()
+        try:
+            path.relative_to(self.target_root.resolve())
+        except ValueError:
+            return NasHealthResult(
+                "blocked",
+                health.target_root,
+                health.filesystem,
+                health.free_bytes,
+                health.required_bytes,
+                None,
+                health.generations,
+                "backup is outside configured NAS target",
+            )
+        if not path.is_file():
+            return NasHealthResult(
+                "blocked",
+                health.target_root,
+                health.filesystem,
+                health.free_bytes,
+                health.required_bytes,
+                None,
+                health.generations,
+                "backup file is missing",
+            )
+        checksum = _sha256_file(path)
+        if expected_checksum and checksum.lower() != expected_checksum.lower():
+            return NasHealthResult(
+                "blocked",
+                health.target_root,
+                health.filesystem,
+                health.free_bytes,
+                health.required_bytes,
+                checksum,
+                health.generations,
+                "backup checksum mismatch",
+            )
+        return NasHealthResult(
+            "ready",
+            health.target_root,
+            health.filesystem,
+            health.free_bytes,
+            health.required_bytes,
+            checksum,
+            health.generations,
+            "backup checksum verified",
+        )
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    backup_id: str
+    status: str
+    source_db: str
+    destination: str
+    checksum: str | None
+    size_bytes: int
+    generation: int
+    created_at: str
+    detail: str
+    restore_verified: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.__dict__.copy()
+
+    def to_storage_receipt(self, *, run_id: str):
+        """Convert a verified backup result into the #45 durable receipt type."""
+
+        from kline.storage import BackupReceiptWrite
+
+        if not self.checksum:
+            raise StorageOpsError("failed backup has no checksum to persist")
+        return BackupReceiptWrite(
+            backup_id=self.backup_id,
+            run_id=run_id,
+            destination=self.destination,
+            status=self.status,
+            checksum=self.checksum,
+            size_bytes=self.size_bytes,
+            restore_verified=self.restore_verified,
+            policy={"generation": self.generation, "source_db": self.source_db},
+        )
+
+
+class SqliteBackupManager:
+    """Use SQLite's online backup API and atomically publish one main DB file."""
+
+    def __init__(self, *, clock: Callable[[], datetime] | None = None) -> None:
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self.failpoint: Callable[[str], None] | None = None
+
+    def backup(
+        self,
+        source_db: str | Path,
+        destination_db: str | Path,
+        *,
+        backup_id: str,
+        generation: int,
+    ) -> BackupResult:
+        source = Path(source_db).expanduser().resolve()
+        destination = Path(destination_db).expanduser().resolve()
+        created_at = self._clock().astimezone(timezone.utc).replace(microsecond=0).isoformat()
+        if not source.is_file():
+            return BackupResult(
+                backup_id,
+                "failed",
+                str(source),
+                str(destination),
+                None,
+                0,
+                generation,
+                created_at,
+                "source database is missing",
+            )
+        if generation < 1:
+            return BackupResult(
+                backup_id,
+                "failed",
+                str(source),
+                str(destination),
+                None,
+                0,
+                generation,
+                created_at,
+                "generation must be positive",
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(f".{destination.name}.tmp-{uuid4().hex}")
+        try:
+            with (
+                sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection,
+                sqlite3.connect(temporary) as target_connection,
+            ):
+                source_connection.backup(target_connection)
+                target_connection.commit()
+                integrity = target_connection.execute("PRAGMA integrity_check").fetchone()[0]
+                if integrity != "ok":
+                    raise StorageOpsError(f"backup integrity check failed: {integrity}")
+            if callable(self.failpoint):
+                self.failpoint("before_publish")
+            os.replace(temporary, destination)
+            checksum = _sha256_file(destination)
+            return BackupResult(
+                backup_id,
+                "verified",
+                str(source),
+                str(destination),
+                checksum,
+                destination.stat().st_size,
+                generation,
+                created_at,
+                "SQLite online backup and integrity check passed",
+            )
+        except Exception as exc:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+            return BackupResult(
+                backup_id,
+                "failed",
+                str(source),
+                str(destination),
+                None,
+                0,
+                generation,
+                created_at,
+                f"consistent backup failed: {exc}",
+            )
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    status: str
+    backup_path: str
+    restored_path: str | None
+    integrity: str
+    table_names: tuple[str, ...]
+    row_counts: Mapping[str, int]
+    latest_closed_bar: str | None
+    detail: str
+
+
+class SqliteRestoreDrill:
+    """Restore one backup into a disposable local DB and verify MVP receipts."""
+
+    REQUIRED_TABLES = (
+        "mvp_candles",
+        "mvp_runs",
+        "mvp_watermarks",
+        "mvp_source_observations",
+        "mvp_quality_receipts",
+        "mvp_transform_receipts",
+        "mvp_entitlement_receipts",
+        "mvp_backup_receipts",
+    )
+
+    def restore(
+        self,
+        backup_path: str | Path,
+        restore_root: str | Path,
+        *,
+        expected_row_counts: Mapping[str, int] | None = None,
+    ) -> RestoreResult:
+        backup = Path(backup_path).expanduser().resolve()
+        root = Path(restore_root).expanduser().resolve()
+        if not backup.is_file():
+            return RestoreResult(
+                "failed", str(backup), None, "missing", (), {}, None, "backup file is missing"
+            )
+        root.mkdir(parents=True, exist_ok=True)
+        restored = root / f"mvp-restore-{uuid4().hex}.db"
+        try:
+            with (
+                sqlite3.connect(f"file:{backup}?mode=ro", uri=True) as source,
+                sqlite3.connect(restored) as target,
+            ):
+                source.backup(target)
+                integrity = str(target.execute("PRAGMA integrity_check").fetchone()[0])
+                tables = tuple(
+                    row[0]
+                    for row in target.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+                    ).fetchall()
+                )
+                missing = [name for name in self.REQUIRED_TABLES if name not in tables]
+                if integrity != "ok" or missing:
+                    raise StorageOpsError(
+                        f"restore checks failed: integrity={integrity}, missing={missing}"
+                    )
+                counts = {
+                    name: int(target.execute(f"SELECT COUNT(*) FROM {name}").fetchone()[0])
+                    for name in self.REQUIRED_TABLES
+                }
+                if expected_row_counts:
+                    for name, expected in expected_row_counts.items():
+                        if counts.get(name) != expected:
+                            raise StorageOpsError(f"row count mismatch for {name}")
+                latest = target.execute("SELECT MAX(timestamp) FROM mvp_candles").fetchone()[0]
+            return RestoreResult(
+                "verified",
+                str(backup),
+                str(restored),
+                integrity,
+                tables,
+                counts,
+                latest,
+                "restore integrity/schema/row-count/receipt checks passed",
+            )
+        except Exception as exc:
+            try:
+                restored.unlink()
+            except FileNotFoundError:
+                pass
+            return RestoreResult(
+                "failed",
+                str(backup),
+                str(restored),
+                "failed",
+                (),
+                {},
+                None,
+                f"restore drill failed: {exc}",
+            )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/tests/test_storage_ops.py
+++ b/tests/test_storage_ops.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from collections import namedtuple
+from pathlib import Path
+
+from kline.storage_ops import (
+    NasVerifier,
+    SsdMountGuard,
+    SqliteBackupManager,
+    SqliteRestoreDrill,
+)
+from kline.store import KlineStore
+
+
+Usage = namedtuple("Usage", "total used free")
+
+
+def _seed_database(path: Path) -> KlineStore:
+    from tests.test_mvp_storage import _candle, _key, _run
+
+    store = KlineStore(str(path))
+    key = _key()
+    store.commit_mvp_run(_run(run_id="run-backup", key=key, candles=(_candle(key),)))
+    return store
+
+
+def test_ssd_mount_guard_fail_closed_for_absent_wrong_and_valid_targets(tmp_path: Path) -> None:
+    mount = tmp_path / "ssd"
+    db_root = mount / "market-data"
+    absent = SsdMountGuard(
+        mount,
+        expected_volume_uuid="ABC",
+        database_root=db_root,
+        is_mount_fn=lambda _: False,
+    ).check()
+    assert absent.status == "blocked"
+    assert "not mounted" in absent.detail
+
+    wrong_fs = SsdMountGuard(
+        mount,
+        expected_volume_uuid="ABC",
+        database_root=db_root,
+        is_mount_fn=lambda _: True,
+        filesystem_fn=lambda _: "hfs",
+        volume_uuid_fn=lambda _: "ABC",
+    ).check()
+    assert wrong_fs.status == "blocked"
+    assert "expected apfs" in wrong_fs.detail
+
+    mount.mkdir()
+    ready = SsdMountGuard(
+        mount,
+        expected_volume_uuid="ABC",
+        database_root=db_root,
+        is_mount_fn=lambda _: True,
+        filesystem_fn=lambda _: "APFS",
+        volume_uuid_fn=lambda _: "abc",
+    ).check()
+    assert ready.status == "ready"
+    assert ready.to_worker_guard().status == "ready"
+
+
+def test_ssd_mount_guard_rejects_database_root_outside_volume(tmp_path: Path) -> None:
+    mount = tmp_path / "ssd"
+    mount.mkdir()
+    result = SsdMountGuard(
+        mount,
+        expected_volume_uuid="ABC",
+        database_root=tmp_path / "elsewhere",
+        is_mount_fn=lambda _: True,
+        filesystem_fn=lambda _: "apfs",
+        volume_uuid_fn=lambda _: "ABC",
+    ).check()
+    assert result.status == "blocked"
+    assert "outside target volume" in result.detail
+
+
+def test_nas_verifier_checks_space_write_readback_and_checksum(tmp_path: Path) -> None:
+    nas = tmp_path / "nas"
+    nas.mkdir()
+    ready = NasVerifier(
+        nas,
+        required_bytes=100,
+        retention_generations=2,
+        filesystem_fn=lambda _: "smbfs",
+        disk_usage_fn=lambda _: Usage(1000, 100, 900),
+    ).check()
+    assert ready.status == "ready"
+    assert ready.probe_checksum
+
+    backup = nas / "mvp-backup-001.db"
+    backup.write_bytes(b"backup")
+    verified = NasVerifier(nas, disk_usage_fn=lambda _: Usage(1000, 100, 900)).verify_backup(backup)
+    assert verified.status == "ready"
+    mismatch = NasVerifier(nas, disk_usage_fn=lambda _: Usage(1000, 100, 900)).verify_backup(
+        backup, expected_checksum="0" * 64
+    )
+    assert mismatch.status == "blocked"
+    assert "checksum mismatch" in mismatch.detail
+
+    insufficient = NasVerifier(
+        nas, required_bytes=901, disk_usage_fn=lambda _: Usage(1000, 100, 900)
+    ).check()
+    assert insufficient.status == "blocked"
+    assert "insufficient" in insufficient.detail
+
+
+def test_sqlite_online_backup_and_restore_drill_verify_mvp_schema(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    _seed_database(source)
+    destination = tmp_path / "nas" / "mvp-backup-001.db"
+    manager = SqliteBackupManager()
+    result = manager.backup(source, destination, backup_id="backup-001", generation=1)
+
+    assert result.status == "verified"
+    assert result.checksum and result.size_bytes > 0
+    assert not destination.with_suffix(destination.suffix + "-wal").exists()
+    receipt = result.to_storage_receipt(run_id="run-backup")
+    assert receipt.restore_verified is False
+    assert receipt.checksum == result.checksum
+
+    restored = SqliteRestoreDrill().restore(
+        destination,
+        tmp_path / "restore",
+        expected_row_counts={"mvp_candles": 1, "mvp_runs": 1},
+    )
+    assert restored.status == "verified"
+    assert restored.integrity == "ok"
+    assert restored.latest_closed_bar
+    assert "mvp_transform_receipts" in restored.table_names
+
+
+def test_backup_interruption_is_typed_failure_and_does_not_publish(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    _seed_database(source)
+    destination = tmp_path / "nas" / "mvp-backup-002.db"
+    manager = SqliteBackupManager()
+    manager.failpoint = lambda stage: (
+        (_ for _ in ()).throw(RuntimeError("interrupted")) if stage == "before_publish" else None
+    )
+    result = manager.backup(source, destination, backup_id="backup-002", generation=2)
+
+    assert result.status == "failed"
+    assert "interrupted" in result.detail
+    assert not destination.exists()
+
+
+def test_restore_rejects_corrupt_or_wrong_row_count_backup(tmp_path: Path) -> None:
+    backup = tmp_path / "corrupt.db"
+    backup.write_bytes(b"not sqlite")
+    result = SqliteRestoreDrill().restore(backup, tmp_path / "restore")
+    assert result.status == "failed"
+
+    source = tmp_path / "source.db"
+    _seed_database(source)
+    destination = tmp_path / "backup.db"
+    verified = SqliteBackupManager().backup(
+        source, destination, backup_id="backup-003", generation=3
+    )
+    assert verified.status == "verified"
+    wrong = SqliteRestoreDrill().restore(
+        destination,
+        tmp_path / "restore-wrong",
+        expected_row_counts={"mvp_candles": 99},
+    )
+    assert wrong.status == "failed"
+    assert "row count mismatch" in wrong.detail


### PR DESCRIPTION
## What
- Add `SsdMountGuard` requiring the expected APFS mount, volume UUID, and database root before opening/creating a target DB.
- Add `SqliteBackupManager` using SQLite online backup API, integrity check, hash, generation, and atomic temp-file publish; never copies live WAL/SHM files.
- Add `NasVerifier` for target availability, free space, write/read-back, checksum, and retention generation checks.
- Add `SqliteRestoreDrill` for disposable restore, integrity/schema/row-count/latest-bar/receipt verification.
- Return typed operational receipts and keep the worker target guard integration local-only.

## Why
The MVP needs a proven storage safety path before any SSD activation or NAS backup promotion. This ticket makes failure explicit while leaving the resident database and launchd untouched.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (214 passed)
- `python3 -m ruff check src/kline/storage_ops.py tests/test_storage_ops.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No live DB cutover, no direct SMB/NFS SQLite open, no deletion/VACUUM, no launchd modification, and no NAS credential capture.

Closes #52