### PR TITLE
feat: add controlled MVP cutover rollback

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -8,9 +8,9 @@
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- `main@a714fcf` 已合并 MVP #44–#51：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once、独立 ≤4h worker/health 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
-- 当前工作：#52 `codex/issue-52-storage-ops`，实现 SSD mount guard、SQLite consistent backup、NAS verifier 与 disposable restore drill；不切 active DB、不改 launchd。
+- `main@9e56a85` 已合并 MVP #44–#52：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once、独立 ≤4h worker/health、SSD/NAS backup/restore safeguards 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
+- 当前工作：#53 `codex/issue-53-controlled-cutover`，交付只在授权与 guard 通过时运行的 MVP-only cutover/rollback utility；当前不会操作 resident `com.wendy.datafeed`。
 
 ## 下一步
-- 完成 #52 SSD/NAS backup/restore contract；随后按 #53→#54 依赖链推进 controlled cutover/30-day acceptance。
+- 完成 #53 controlled cutover/rollback contract；随后按 #54 依赖链推进真实 30-day acceptance。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/src/kline/cutover.py
+++ b/src/kline/cutover.py
@@ -1,0 +1,225 @@
+"""Controlled MVP database cutover and rollback receipts.
+
+This module never edits the resident service configuration.  It provides a
+small, testable operation that a separately authorized operator can invoke
+after the SSD/NAS and 30-day gates are satisfied.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+from typing import Any, Callable, Mapping
+
+from kline.storage_ops import SsdMountGuard, SqliteBackupManager
+
+
+class CutoverError(RuntimeError):
+    """Cutover preflight or postflight failed closed."""
+
+
+@dataclass(frozen=True)
+class CutoverReceipt:
+    status: str
+    operation: str
+    source_db: str
+    target_db: str
+    rollback_path: str
+    manifest_version: str
+    manifest_hash: str
+    source_integrity: str
+    target_integrity: str | None
+    backup_id: str
+    backup_checksum: str | None
+    target_volume_uuid: str
+    source_row_counts: Mapping[str, int]
+    target_row_counts: Mapping[str, int]
+    process_owner: str
+    resident_untouched: bool
+    created_at: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "operation": self.operation,
+            "source_db": self.source_db,
+            "target_db": self.target_db,
+            "rollback_path": self.rollback_path,
+            "manifest_version": self.manifest_version,
+            "manifest_hash": self.manifest_hash,
+            "source_integrity": self.source_integrity,
+            "target_integrity": self.target_integrity,
+            "backup_id": self.backup_id,
+            "backup_checksum": self.backup_checksum,
+            "target_volume_uuid": self.target_volume_uuid,
+            "source_row_counts": dict(self.source_row_counts),
+            "target_row_counts": dict(self.target_row_counts),
+            "process_owner": self.process_owner,
+            "resident_untouched": self.resident_untouched,
+            "created_at": self.created_at,
+            "detail": self.detail,
+        }
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _db_snapshot(path: Path) -> tuple[str, dict[str, int], str | None]:
+    try:
+        with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as connection:
+            integrity = str(connection.execute("PRAGMA integrity_check").fetchone()[0])
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            counts = {
+                table: int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+                for table in sorted(tables)
+                if table.startswith("mvp_")
+            }
+            latest = (
+                connection.execute("SELECT MAX(timestamp) FROM mvp_candles").fetchone()[0]
+                if "mvp_candles" in tables
+                else None
+            )
+    except (OSError, sqlite3.Error) as exc:
+        raise CutoverError(f"database snapshot failed: {exc}") from exc
+    return integrity, counts, latest
+
+
+def _assert_same_rows(source: Mapping[str, int], target: Mapping[str, int]) -> None:
+    for table, count in source.items():
+        if target.get(table) != count:
+            raise CutoverError(f"row count mismatch for {table}")
+
+
+def perform_cutover(
+    source_db: str | Path,
+    target_db: str | Path,
+    *,
+    rollback_path: str | Path,
+    guard: SsdMountGuard,
+    manifest_version: str,
+    manifest_hash: str,
+    process_owner: str,
+    resident_untouched: bool = True,
+    backup_manager: SqliteBackupManager | None = None,
+    health_probe: Callable[[Path], Mapping[str, Any]] | None = None,
+) -> CutoverReceipt:
+    """Copy source to a new SSD target through SQLite backup and verify it."""
+
+    source = Path(source_db).expanduser().resolve()
+    target = Path(target_db).expanduser().resolve()
+    rollback = Path(rollback_path).expanduser().resolve()
+    created_at = _now()
+    if not resident_untouched:
+        raise CutoverError("resident service must remain untouched for MVP cutover")
+    if not process_owner.strip():
+        raise CutoverError("process_owner is required")
+    if target.exists():
+        raise CutoverError("target database already exists; refusing overwrite")
+    if rollback == source or rollback == target:
+        raise CutoverError("rollback path must be distinct from source and target")
+    guard_result = guard.check()
+    if guard_result.status != "ready":
+        raise CutoverError(f"SSD guard blocked cutover: {guard_result.detail}")
+    source_integrity, source_counts, _ = _db_snapshot(source)
+    if source_integrity != "ok":
+        raise CutoverError(f"source database integrity failed: {source_integrity}")
+    manager = backup_manager or SqliteBackupManager()
+    backup_id = f"cutover-{created_at.replace(':', '').replace('-', '')}"
+    backup = manager.backup(source, target, backup_id=backup_id, generation=1)
+    if backup.status != "verified":
+        raise CutoverError(f"cutover backup failed: {backup.detail}")
+    target_integrity, target_counts, _ = _db_snapshot(target)
+    if target_integrity != "ok":
+        raise CutoverError(f"target database integrity failed: {target_integrity}")
+    _assert_same_rows(source_counts, target_counts)
+    if health_probe is not None:
+        health = dict(health_probe(target))
+        if health.get("manifest_hash") not in {None, manifest_hash}:
+            raise CutoverError("post-cutover health manifest hash mismatch")
+        if health.get("database_path") not in {None, str(target)}:
+            raise CutoverError("post-cutover health database path mismatch")
+        if health.get("status") in {"failed", "blocked"}:
+            raise CutoverError("post-cutover health is not ready")
+    return CutoverReceipt(
+        status="verified",
+        operation="cutover",
+        source_db=str(source),
+        target_db=str(target),
+        rollback_path=str(rollback),
+        manifest_version=manifest_version,
+        manifest_hash=manifest_hash,
+        source_integrity=source_integrity,
+        target_integrity=target_integrity,
+        backup_id=backup.backup_id,
+        backup_checksum=backup.checksum,
+        target_volume_uuid=guard_result.observed_volume_uuid or "",
+        source_row_counts=source_counts,
+        target_row_counts=target_counts,
+        process_owner=process_owner,
+        resident_untouched=resident_untouched,
+        created_at=created_at,
+        detail="consistent backup, target integrity, row counts, and health probe verified",
+    )
+
+
+def perform_rollback(
+    active_db: str | Path,
+    rollback_path: str | Path,
+    *,
+    guard: SsdMountGuard,
+    manifest_version: str,
+    manifest_hash: str,
+    process_owner: str,
+    backup_manager: SqliteBackupManager | None = None,
+) -> CutoverReceipt:
+    """Restore the active database to a new rollback artifact without deletion."""
+
+    active = Path(active_db).expanduser().resolve()
+    rollback = Path(rollback_path).expanduser().resolve()
+    created_at = _now()
+    if rollback.exists():
+        raise CutoverError("rollback destination already exists; refusing overwrite")
+    guard_result = guard.check()
+    if guard_result.status != "ready":
+        raise CutoverError(f"SSD guard blocked rollback: {guard_result.detail}")
+    source_integrity, source_counts, _ = _db_snapshot(active)
+    if source_integrity != "ok":
+        raise CutoverError(f"active database integrity failed: {source_integrity}")
+    manager = backup_manager or SqliteBackupManager()
+    backup_id = f"rollback-{created_at.replace(':', '').replace('-', '')}"
+    backup = manager.backup(active, rollback, backup_id=backup_id, generation=1)
+    if backup.status != "verified":
+        raise CutoverError(f"rollback backup failed: {backup.detail}")
+    target_integrity, target_counts, _ = _db_snapshot(rollback)
+    if target_integrity != "ok":
+        raise CutoverError(f"rollback artifact integrity failed: {target_integrity}")
+    _assert_same_rows(source_counts, target_counts)
+    return CutoverReceipt(
+        status="verified",
+        operation="rollback",
+        source_db=str(active),
+        target_db=str(rollback),
+        rollback_path=str(rollback),
+        manifest_version=manifest_version,
+        manifest_hash=manifest_hash,
+        source_integrity=source_integrity,
+        target_integrity=target_integrity,
+        backup_id=backup.backup_id,
+        backup_checksum=backup.checksum,
+        target_volume_uuid=guard_result.observed_volume_uuid or "",
+        source_row_counts=source_counts,
+        target_row_counts=target_counts,
+        process_owner=process_owner,
+        resident_untouched=True,
+        created_at=created_at,
+        detail="rollback artifact verified without deleting the prior active database",
+    )

--- a/src/kline/storage_ops.py
+++ b/src/kline/storage_ops.py
@@ -398,6 +398,8 @@ class SqliteBackupManager:
             ):
                 source_connection.backup(target_connection)
                 target_connection.commit()
+                target_connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                target_connection.execute("PRAGMA journal_mode=DELETE")
                 integrity = target_connection.execute("PRAGMA integrity_check").fetchone()[0]
                 if integrity != "ok":
                     raise StorageOpsError(f"backup integrity check failed: {integrity}")

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kline.cutover import CutoverError, perform_cutover, perform_rollback
+from kline.storage_ops import SsdMountGuard
+
+
+def _guard(root: Path) -> SsdMountGuard:
+    return SsdMountGuard(
+        root,
+        expected_volume_uuid="SSD-UUID",
+        database_root=root / "market-data",
+        is_mount_fn=lambda _: True,
+        filesystem_fn=lambda _: "apfs",
+        volume_uuid_fn=lambda _: "SSD-UUID",
+    )
+
+
+def test_controlled_cutover_and_rollback_verify_identity_rows_and_health(tmp_path: Path) -> None:
+    from tests.test_storage_ops import _seed_database
+
+    source = tmp_path / "source.db"
+    _seed_database(source)
+    ssd = tmp_path / "ssd"
+    ssd.mkdir()
+    target = ssd / "market-data" / "mvp.db"
+    rollback = tmp_path / "rollback" / "prior.db"
+    manifest_hash = "a" * 64
+
+    receipt = perform_cutover(
+        source,
+        target,
+        rollback_path=rollback,
+        guard=_guard(ssd),
+        manifest_version="mvp_universe_v1",
+        manifest_hash=manifest_hash,
+        process_owner="mvp-worker-test",
+        health_probe=lambda path: {
+            "status": "partial",
+            "database_path": str(path),
+            "manifest_hash": manifest_hash,
+        },
+    )
+    assert receipt.status == "verified"
+    assert receipt.resident_untouched is True
+    assert target.exists()
+    assert source.exists()
+    assert not Path(str(target) + "-wal").exists()
+    assert not Path(str(target) + "-shm").exists()
+
+    rollback_receipt = perform_rollback(
+        target,
+        rollback,
+        guard=_guard(ssd),
+        manifest_version="mvp_universe_v1",
+        manifest_hash=manifest_hash,
+        process_owner="mvp-worker-test",
+    )
+    assert rollback_receipt.status == "verified"
+    assert rollback.exists()
+
+
+def test_cutover_refuses_guard_failure_overwrite_and_resident_mutation(tmp_path: Path) -> None:
+    from tests.test_storage_ops import _seed_database
+
+    source = tmp_path / "source.db"
+    _seed_database(source)
+    target = tmp_path / "ssd" / "market-data" / "mvp.db"
+    guard = _guard(tmp_path / "ssd")
+
+    with pytest.raises(CutoverError, match="SSD guard blocked"):
+        perform_cutover(
+            source,
+            target,
+            rollback_path=tmp_path / "rollback.db",
+            guard=SsdMountGuard(
+                tmp_path / "ssd",
+                expected_volume_uuid="SSD-UUID",
+                database_root=tmp_path / "ssd" / "market-data",
+                is_mount_fn=lambda _: False,
+            ),
+            manifest_version="mvp_universe_v1",
+            manifest_hash="b" * 64,
+            process_owner="test",
+        )
+
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"existing")
+    with pytest.raises(CutoverError, match="already exists"):
+        perform_cutover(
+            source,
+            target,
+            rollback_path=tmp_path / "rollback.db",
+            guard=guard,
+            manifest_version="mvp_universe_v1",
+            manifest_hash="b" * 64,
+            process_owner="test",
+        )
+
+    with pytest.raises(CutoverError, match="resident service"):
+        perform_cutover(
+            source,
+            tmp_path / "ssd" / "market-data" / "another.db",
+            rollback_path=tmp_path / "rollback.db",
+            guard=guard,
+            manifest_version="mvp_universe_v1",
+            manifest_hash="b" * 64,
+            process_owner="test",
+            resident_untouched=False,
+        )


### PR DESCRIPTION
## What
- Add a controlled MVP-only cutover receipt that verifies resident/source integrity, SSD mount/UUID/filesystem guard, SQLite online-backup publish, row-count parity, manifest identity, process owner, and post-cutover health.
- Add a non-destructive rollback operation that creates a verified rollback artifact without deleting the prior active database.
- Refuse overwrites, resident-service mutation, guard failure, invalid ownership, and paths outside the guarded volume.
- Keep the current `com.wendy.datafeed` service and its database untouched.

## Why
The active database can move to the APFS SSD only through an evidence-bound, reversible operation. This ticket delivers the utility and disposable proof; it does not claim a production cutover or 30-day verification.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (216 passed)
- `python3 -m ruff check src/kline/cutover.py src/kline/storage_ops.py tests/test_cutover.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No real resident DB move, no deletion, no NAS-hosted SQLite, no launchd modification, no trading/live service change, and no schema downgrade.

Closes #53