### PR TITLE
feat: add evidence-gated MVP acceptance receipt

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Market Data Database
+
+The bounded context for maintaining durable, source-identified market candle data for Park's research systems. It is designed to grow by expanding its instrument universe without weakening its data, recovery, or operating contracts.
+
+## Language
+
+**Market Data Database**:
+A long-lived maintained source of truth for market candles, their instrument identities, and their source provenance.
+_Avoid_: Cache, scrape dump, throwaway database, temporary datafeed
+
+**MVP Universe**:
+A deliberately bounded set of 100 A-share stocks and 100 US-listed company stocks, plus the approved cross-market index/commodity/crypto instruments, used to prove the real database lifecycle before expanding coverage. Membership combines objective liquidity with explicit theme coverage; it reduces breadth, not durability, correctness, recoverability, or observability.
+_Avoid_: Toy dataset, fixture universe, all-market database
+
+**Candle Instrument**:
+An instrument or price index that can truthfully provide OHLC candles for its declared timeframes. Daily Treasury yield and curve-level series such as DGS2, DGS10, and T10Y2Y are outside this database.
+_Avoid_: Macro level series, synthetic Treasury candle
+
+**Index Identity**:
+A canonical market index is stored as its own instrument identity, separate from an ETF proxy that tracks it. The MVP uses S&P 500 Index (`SPX`) and Nasdaq-100 Index (`NDX`), not SPY or QQQ substitutes.
+_Avoid_: ETF proxy as index, SPY-as-SPX, QQQ-as-NDX
+
+**MVP Manifest Freeze**:
+After the first successful end-to-end run, the 100 A-share and 100 US-stock members remain unchanged for 30 calendar days. New hot or liquid candidates enter a reserve pool and only join through a versioned manifest change.
+_Avoid_: Daily silent rotation, live ranking as membership, replacing missing data with a new stock

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -8,9 +8,9 @@
 - `main@7f6b44d` 的 K 线 envelope 会同时返回 requested/selected source、provider、source mode、execution-venue、fresh 与 synthetic 身份；严格消费者不再从模糊 provider 名称推断来源。
 - Alibaba Cloud 上的 trading-system Paper 通过 loopback datafeed 消费 Binance USD-M Futures 的 GOLD 最新/历史 K 线；Cloud preflight 已验证 execution-venue 身份、SQLite quick-check 与新鲜度。datafeed 只拥有行情合同，不拥有 scheduler、StrategyPlan 或交易命令权限。
 - Park 2026-07-21 裁定为产品(非基础设施),上 Portfolio 板。
-- `main@9e56a85` 已合并 MVP #44–#52：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once、独立 ≤4h worker/health、SSD/NAS backup/restore safeguards 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
-- 当前工作：#53 `codex/issue-53-controlled-cutover`，交付只在授权与 guard 通过时运行的 MVP-only cutover/rollback utility；当前不会操作 resident `com.wendy.datafeed`。
+- `main@e9f580e` 已合并 MVP #44–#53：216 instrument manifest、独立 `mvp_*` storage/receipt/watermark schema、calendar/4H/weekly quality seam、TuShare gate、授权 US seam、16 cross-market mapping、resumable run_once、独立 ≤4h worker/health、SSD/NAS backup/restore safeguards、controlled cutover/rollback utility 已就绪；当前 A/US/index entitlement 仍 pending，manifest 不会宣称 verified，resident DB/NAS 尚未切换。
+- 当前工作：#54 `codex/issue-54-mvp-acceptance`，运行真实 30-day acceptance gate 并发布结果；在真实授权数据、NAS restore 和 active manifest 未具备前，输出必须保持 `blocked`。
 
 ## 下一步
-- 完成 #53 controlled cutover/rollback contract；随后按 #54 依赖链推进真实 30-day acceptance。
+- 完成 #54 acceptance gate/receipt；若仍 blocked，下一步由 operator 提供 TuShare/US entitlement、挂载并验证 NAS，再启动真实 30-day window；不得把测试 receipt 当 verified。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。

--- a/docs/research/kline-source-landscape-2026-08-31.md
+++ b/docs/research/kline-source-landscape-2026-08-31.md
@@ -1,0 +1,379 @@
+# 全市场 K 线定时采集：数据源、容量与 NAS 部署调研
+
+> 调研日期：2026-08-31<br>
+> 状态：**Daily v2 的 19 项清单已本地核实；数据授权、15m 适用范围和 NAS 能力尚未验明，不能直接进入实现**<br>
+> 范围：OHLCV/K 线；`15m`、`4h`、`1d`、`1w`，明确不做 `30m`；全 A 股、全美股、Daily 的跨市场资产清单。
+
+> 2026-08-31 scope update：Park 已决定将 `DGS2`、`DGS10`、`T10Y2Y` 从 Candle MVP 排除；美股公司 universe 收缩为固定约 30 只，SPX 与 Nasdaq 保持独立指数 identity。后续 spec 不再以旧 19 项数量为目标，而会生成新的 versioned MVP manifest。
+
+## 1. 先给结论
+
+这不是“给现有 datafeed 加一个 cron”这么小的改动，而是三个系统问题叠在一起：全市场数据授权、数亿行数据的增量/回填、以及网络存储上的数据库可靠性。
+
+1. **A 股主源：TuShare Pro 是这次个人/体验版唯一现实的全市场候选。** 它有包含 SSE/SZSE/BSE、上市/退市状态的股票主表，原生 `15m`、`1d`、`1w`，历史分钟自 2009 年；`4h` 必须从 `15m`/`60m` 派生。历史分钟个人价目前为 ¥2,000/年，实时分钟另为 ¥1,000/月；机构价是个人价的 10 倍。[股票主表](https://tushare.pro/document/1?doc_id=25)、[历史分钟](https://tushare.pro/document/2?doc_id=370)、[权限与现价](https://tushare.pro/document/1?doc_id=290)
+2. **美股主源：Massive（原 Polygon.io）在技术上最匹配。** 它有 point-in-time ticker master、退市标记、全市场分钟/日 flat files、全市场分钟 WebSocket `AM.*`、公司行动和分拆前/后口径。[ticker master](https://massive.com/docs/rest/stocks/tickers/all-tickers)、[分钟 flat files](https://massive.com/docs/flat-files/stocks/minute-aggregates)、[全市场分钟流](https://massive.com/docs/websocket/stocks/aggregates-per-minute)
+3. **但 Massive 目前有明确的合同阻断。** 个人市场数据条款把用途限定为个人、非商业，并默认 display-only；未经许可禁止再分发、衍生作品和 non-display/投资策略用途，终止后还要求删除数据。持久化到数据库并用于指标、回测或 agent 分析不能仅凭“API 能调”推定为获准，必须拿到书面许可或适用的 Business/Enterprise 合同。[市场数据条款](https://massive.com/terms/market_data_terms.pdf)、[Business 方案](https://massive.com/business)
+4. **Alpaca 可做低成本美股 pilot，但不是理想的全量回填主源。** 它原生请求支持 `15Min`、`4Hour`、`1Day`、`1Week`，SIP 覆盖全美交易所，历史自 2016；但没有全市场 flat-file 下载路径，历史 securities master 对退市和 point-in-time 的保证弱于 Massive。[bars API](https://docs.alpaca.markets/us/reference/stockbars)、[套餐与历史范围](https://docs.alpaca.markets/us/docs/about-market-data-api)
+5. **Yahoo/yfinance、腾讯和新浪不能继续承担生产主源。** yfinance 自己声明未获 Yahoo 背书、数据限个人使用；Yahoo 条款禁止未经许可的自动抓取。腾讯/新浪端点没有一手 API 合同、SLA、限流、历史范围和归档许可。[yfinance README](https://github.com/ranaroussi/yfinance/blob/main/README.md)、[Yahoo Terms](https://legal.yahoo.com/us/en/yahoo/terms/otos/index.html)
+6. **Futu、Tiger、Longbridge/Longport 都不能做全市场主源。** 三者的历史 K 线按“唯一证券数”计额度，上限分别约 2,000、2,000、3,000，均低于约 5,534 只 A 股，也低于完整美股 universe；适合作为当前 19 个资产或抽样 QA 源，不适合作为全量源。[Futu quota](https://openapi.futunn.com/futu-api-doc/en/intro/authority.html)、[Tiger quota](https://quant.itigerup.com/openapi/zh/python/permission/historySubscribe.html)、[Longbridge quota](https://open.longbridge.com/docs/quote/pull/history-candlestick)
+7. **不能把当前 SQLite 文件直接放到 SMB/NFS NAS share 上继续由 Mac 打开。** 当前 `KlineStore` 强制启用 WAL；SQLite 官方明确说 WAL 不支持网络文件系统，而且网络文件锁/同步错误可能造成损坏。[当前 store](../../src/kline/store.py)、[SQLite WAL](https://www.sqlite.org/wal.html)、[SQLite over network](https://www.sqlite.org/useovernet.html)
+8. **MVP 的当前存储主选已经收敛：外接 APFS SSD 做 active SQLite，NAS 做一致性备份和冷层。** 2026-08-31 现场检查确认 `/Volumes/Phone SSD` 是 1 TB APFS SSD、约 895 GiB 可用；这足以承载 bounded MVP。未来需要多客户端/更大 universe 时，再在 NAS 本机运行 PostgreSQL 并由 datafeed 通过 TCP 访问。任何阶段都不允许 Mac 通过 SMB 直接打开 NAS 上的 `.db`。
+9. **Daily v2 的 19 项已经核实，不再是未知项。** 它比 datafeed 的旧 17 项多 `ethereum` 和 `hype`；当前 Daily 只给 BTC/ETH/HYPE/WTI/Gold/Silver 请求 `4h/30m`，其余 13 项只请求 daily。新需求是把 `30m` 改成 `15m`，但“15m 只给这 6 项，还是扩到全部 19 项”仍需 Park 明确。[Daily v2 registry](</Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/market_regime_weekly_source.py>)、[Daily timeframe matrix](</Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/market_regime_daily_source.py>)
+10. **本地空间的第一大现存问题不是 candle rows，而是无界 raw/runtime artifacts。** 只读快照中 live datafeed DB 为 157.7 MiB、38,989 根 candle，但 `raw_upstream_responses` 已占 147.9 MiB（主 DB 的 93.8%）；ParkMarketRegime runtime 已约 12 GB，未找到针对这些 K-line/runtime artifacts 的 prune/retention job。全市场化前必须先立 retention 合同。
+
+### 推荐的目标架构
+
+| 轨道 | 推荐主源 | 增量 | 回填/校准 | 数据库口径 |
+|---|---|---|---|---|
+| 全 A 股 | TuShare Pro（先过许可确认） | 历史分钟定时范围拉取；若必须盘中完整则购实时分钟并做日累计/范围补洞 | `stk_mins` 分证券分段；未来可升级到交易所许可源 | 原始未复权 `15m` + 原始 `1d`；`4h`、`1w` 派生；`adj_factor` 独立保存 |
+| 全美股 | Massive（先过 non-display/存储许可） | `AM.*` 全市场分钟流，在内存聚合成 `15m`；或按 watermark 拉 custom bars | 全市场 minute/day flat files；每日 grouped aggregate 校准 | 未复权 `15m` + 未复权 `1d`；公司行动独立；`4h`、`1w` 派生 |
+| Daily v2 crypto perps | Hyperliquid `BTC/ETH/HYPE`（保留现有 perp identity） | 原生 candle WebSocket 或每 4 小时 watermark 补取 | `candleSnapshot` 只保留最近 5,000 根；官方 S3 不提供 candles，必须从现在开始自行留存 | 原生 `15m/4h/1d/1w`；不能用 Binance spot 静默回填成同一 series |
+| BTC/ETH spot（仅在 Park 明确改 identity 时） | Binance Spot | 每 4 小时按 watermark 拉闭合 K 线 | 官方 daily/monthly ZIP + checksum，自 2020 起批量 | Binance 原生 `15m/4h/1d/1w`，按单一 venue 标识 |
+| Daily v2 其余 16 项 | 已核实的 v2 registry，逐项更换生产 source | 依市场日历 | 来源特定 | 保留当前 ETF/rate/index/futures 语义；禁止 Yahoo/腾讯/新浪静默 fallback |
+
+**不建议马上买任何数据套餐。** 先让 Park 定义 universe、session、19 项的 `15m` 适用范围和用途（仅个人查看，还是回测/agent/未来产品），再把用途原文发给 TuShare/Massive 索取书面确认。
+
+## 2. 现有 datafeed 的真实基线
+
+- 当前 repo 已经有 source-aware 的 candle key、质量/来源收据，以及 `raw_timeframe` / `timeframe_origin` 语义；这些应该保留，而不是另起一套数据格式。[README](../../README.md)、[Kline schema](../../src/kline/models.py)
+- 当前持久层是 SQLite + WAL，唯一键是 `source_id + ticker + asset_class + timeframe + timestamp`，还有一条 ticker/timeframe 索引。[store](../../src/kline/store.py)、[models](../../src/kline/models.py)
+- 当前 A 股 adapter 只有 TuShare 日线/周线路径；周线实际上从日线聚合。腾讯/新浪仅绑定三个上海指数的日线和派生周线。[A-share adapter](../../src/kline/providers/ashare.py)、[Sina adapter](../../src/kline/providers/sina.py)
+- 当前美股/指数/商品主要依赖 yfinance；`4h` 从 `1h` 派生，`1w` 从 `1d` 派生。yfinance 文档只承诺最近 60 日的 intraday，因此不能承担长期 `15m` 回填。[US adapter](../../src/kline/providers/us.py)、[yfinance download docs](https://ranaroussi.github.io/yfinance/reference/api/yfinance.download.html)
+- 当前 Tiger adapter 只接了一个 COMEX futures 合约路径，只支持 `1m/5m/1d`，不是 A 股或美股全市场 adapter。[Tiger adapter](../../src/kline/providers/tiger.py)
+- datafeed 当前 committed Phase 1 matrix 是较旧的 **17 个资产 / 39 个 cell**；它缺少 ETH 和 HYPE。[datafeed 17 项清单](../../ops/phase1_matrix.py)
+- Daily v2 的实际 `WEEKLY_KEYS` 已明确是 **19 项**：`dxy, us2y, us10y, us2s10s, sp500, nasdaq, us_dividend, vix, bitcoin, ethereum, hype, shanghai, star50, china_dividend, nikkei, kospi, wti, gold, silver`。对应 registry 还明确：DXY/SP500/Nasdaq 使用 UUP/SPY/QQQ ETF，BTC/ETH/HYPE 是 Hyperliquid USDC 永续，WTI/Gold/Silver 是 continuous futures。[Daily v2 source registry](</Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/market_regime_weekly_source.py>)、[Daily v2 candle contract](</Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/market_regime_weekly_contract.py>)
+- Daily v2 当前 timeframe contract 是 daily 全 19 项；只有 BTC/ETH/HYPE/WTI/Gold/Silver 额外请求 `4h` 和 `30m`。这次需求应被写成一次显式 migration：**删除 `30m`，新增 `15m`**，而不是继续兼容 30m。[Daily timeframe matrix](</Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/market_regime_daily_source.py>)
+
+因此，`17 vs 19` 不是待 Park 补清单的问题，而是 **Daily v2 manifest 已前进、datafeed Phase 1 matrix 滞后**。后续 spec 应以 Daily v2 的 19 个 stable keys 为准，并单独决定 `15m` 是否仍只适用于 6 个 intraday assets。
+
+### 2.1 Live local storage audit（2026-08-31 11:54 CST）
+
+只读检查 launchd 和 SQLite 后的实际状态：
+
+| 项目 | 观察值 | 含义 |
+|---|---:|---|
+| Live DB path | `/Users/wendy/datafeed/data/kline.db` | launchd `KLINE_DB_PATH` 指向这里，不是 repo 内的空样例 DB。[launchd plist](</Users/wendy/Library/LaunchAgents/com.wendy.datafeed.plist>) |
+| Main DB | 165,330,944 bytes = **157.7 MiB** | 同时有约 6.7 MiB WAL；这是活跃文件，大小会变动。 |
+| `klines` | **38,989 rows** | `klines` table + 两条索引合计 9,981,952 bytes，实测约 **256 bytes/candle row**。这支持后文的 200–350 B/row 规划区间。 |
+| `raw_upstream_responses` | 548 rows / **147.9 MiB** | 平均约 276 KiB/response，占主 DB 93.8%；当前数据库膨胀主要来自完整 raw body，而不是 normalized candles。 |
+| `source_observations` | 735 rows | 体量很小，receipt 不是当前空间问题。 |
+| ParkMarketRegime runtime | **约 12 GB / 70,825 files** | 其中 intraday 目录约 64,183 files；在 app/scheduler 中未找到对这些 K-line/runtime artifacts 的 prune/retention 实现。 |
+| NAS mount | `/Volumes/personal_folder` **当前未挂载** | 本轮无法验证容量、文件系统、网络性能、Docker/PostgreSQL 或 UPS；NAS 部署只能保持 `unverified`。 |
+| External SSD | `/Volumes/Phone SSD`：1 TB APFS，约 **895 GiB available** | 当前适合作为 MVP active database volume；仍需 mount guard、断连失败语义、备份和受控切换。 |
+
+审计使用 `sqlite3 -readonly ... count(*)` 和 `dbstat`，未写数据库。这个样本说明：在讨论把 DB 搬到 NAS 之前，必须先把 raw response 和 Daily runtime 的 retention 定义清楚；否则搬迁只会把无界增长换一个磁盘继续发生。
+
+## 3. Universe 和时间级别必须先定义
+
+### 3.1 “全 A 股”
+
+中国上市公司协会 2026-07 月报给出境内上市公司 5,541 家，其中约 5,534 家有 A 股；这是本报告容量估算采用的基数。[官方月报](https://sp.capco.org.cn:82/file/202608/202607yuebao/202607yuebao.pdf)
+
+实现口径应包括：
+
+- SSE、SZSE、BSE；
+- 当前上市、暂停、待上市、退市状态；
+- 历史退市证券，避免幸存者偏差；
+- 代码变更和上市/退市日期；
+- 不含 B 股、ETF、基金、可转债，除非 Park 明确扩大范围。
+
+TuShare `stock_basic` 有 `SSE/SZSE/BSE`、`L/D/P/G/UN`、`list_date/delist_date`，适合作为体验版 universe master。[TuShare stock_basic](https://tushare.pro/document/1?doc_id=25)
+
+### 3.2 “全美股”不是一个自然唯一集合
+
+至少要在以下两种口径中选一个：
+
+- **公司股票口径（本报告基准）**：约 6,500 个 active common shares/ADRs，排除 ETF、基金、权证、优先股和 OTC；
+- **全可交易 ticker 口径（容量上界）**：约 10,000+ active tickers，可能包含 ETF、OTC 和其他 security types。Massive 的 full-market snapshot 公开写的是 10,000+ actively traded tickers。[Massive full-market snapshot](https://massive.com/docs/rest/stocks)
+
+Massive ticker master 可按 `type`、`market`、`exchange`、`active`、`date` 过滤，`active=false` 表示已退市，并提供 `delisted_utc`、CIK、FIGI 等字段。[All Tickers](https://massive.com/docs/rest/stocks/tickers/all-tickers)
+
+### 3.3 `4h` 不是只写一个字符串
+
+- A 股常规交易分为 09:30–11:30、13:00–15:00 两段，合计约 4 小时；16 根 `15m` 合成一个 session bar 后，OHLCV 往往与日线高度重合。[SSE trading hours](https://english.sse.com.cn/start/trading/schedule/)、[SZSE trading hours](https://www.szse.cn/English/services/trading/tradOverview/)
+- 美股 core session 是 09:30–16:00 ET，共 6.5 小时；若用 session-relative `4h`，每天会出现一个完整 4h 和一个 2.5h closing stub。若丢掉“不完整 4h”，会永久丢失每日下午数据。[NYSE trading hours](https://www.nyse.com/trade/hours-calendars)
+- 若按 fixed wall-clock 4h bucket，则必须确定 anchor、时区，以及是否包含美股 04:00–20:00 extended hours。
+
+所以必须选择并版本化一种规则：
+
+1. `regular_session_relative`：保留 closing stub，并显式标 `is_partial_session_bucket=true`；或
+2. `extended_hours_fixed_4h`：使用 America/New_York 固定锚点；或
+3. 对 A 股取消物理存储 `4h`，仅按兼容接口返回当日 session aggregate。
+
+当前 datafeed 的“固定 4h + 丢弃不完整 bucket”规则不能原样推广到全美股。[现有 timeframe contract](../../README.md)
+
+### 3.4 `1w` 应由已闭合 `1d` 派生
+
+即使供应商返回 vendor-weekly，也建议把 `1d` 作为统一基础，按交易所时区和交易日历生成 completed week。这样 A 股、美股和 24/7 BTC 的周界线不会被供应商默认设置暗中改变。供应商原生周线只用作 reconciliation，不作为第二套事实源。
+
+## 4. A 股数据源审查
+
+### 4.1 推荐：TuShare Pro（体验版主源，许可待确认）
+
+| 维度 | 一手证据与判断 |
+|---|---|
+| 时间级别 | `stk_mins` 原生返回 `1/5/15/30/60m`；无 `4h`，所以 `4h` 派生。`daily` 和 `weekly` 都有原生接口，但生产架构仍建议 `1d→1w`。[历史分钟](https://tushare.pro/document/2?doc_id=370)、[日线](https://tushare.pro/document/1?doc_id=27)、[周线](https://tushare.pro/document/2?doc_id=144) |
+| 历史 | 历史分钟文档说超过 10 年，权限表标明自 2009；每次最多 8,000 行。[历史分钟](https://tushare.pro/document/2?doc_id=370)、[权限表](https://tushare.pro/document/1?doc_id=290) |
+| Universe/退市 | `stock_basic` 一次最多 6,000 行，覆盖全市场 A 股，含 SSE/SZSE/BSE、上市/退市/暂停/待上市和上市/退市日期。[stock_basic](https://tushare.pro/document/1?doc_id=25) |
+| 复权 | 日线接口是未复权；`adj_factor` 可按股票或交易日拉全历史，`pro_bar` 支持 qfq/hfq。qfq 以查询 `end_date` 为锚且使用“分红再投”口径，因此调整后历史会随锚点变化。[日线](https://tushare.pro/document/1?doc_id=27)、[复权因子](https://tushare.pro/document/2?doc_id=28)、[复权说明](https://tushare.pro/document/2?doc_id=146) |
+| 频控/价格 | 历史分钟 ¥2,000/年、500 次/分钟、8,000 行/次；实时分钟 ¥1,000/月、500 次/分钟、一次最多 300 公司。普通 5,000 积分权限 ¥500/年、500 次/分钟；机构价为个人 10 倍。[权限与价格](https://tushare.pro/document/1?doc_id=290) |
+| 批量/回填 | 日线可按 `trade_date` 一次拉全市场；分钟是按 symbol/time range，5,534 个 symbol 的一轮理论最低约 11 分钟，仅是频控下限，不含分页、网络、重试和服务端延迟。完整十多年回填会是数万请求，必须可断点续跑。 |
+| 盘中更新 | 历史分钟是 EOD 产品；若要求盘中有完整 `15m`，要用单独的 `rt_min` / `rt_min_daily` 权限。仅每 4 小时取“最新一根”会漏掉期间的 15m bars。[实时分钟](https://tushare.pro/document/2?doc_id=374)、[当日分钟累计](https://tushare.pro/document/2?doc_id=457) |
+| 许可 | 服务协议只授予个人、不可转让、非商业、可撤销、有期限的许可，并写明仅作个人查看使用。文档虽然提供本地 MySQL + cron 示例，也不能自动推导出策略回测、agent non-display 使用或未来对外产品已获许可。[服务协议](https://tushare.pro/document/1?doc_id=405)、[本地 MySQL 示例](https://tushare.pro/document/1?doc_id=231) |
+
+**结论：** 技术上采用；合同上先把“个人 NAS 长期保存、生成指标、个人回测/agent 分析、不对外提供原始数据”原样提交 TuShare，拿书面确认。
+
+### 4.2 官方交易所源（权威升级路线，不适合个人 MVP）
+
+| 来源 | 能力 | 历史/批量 | 许可与成本 | 判断 |
+|---|---|---|---|---|
+| 上证所信息 | 原生日 K、分钟 K、证券基本信息；`15m/4h/1w` 需自行派生。[产品说明](https://www.sseinfo.com/services/assortment/historical/) | 按交易日落 `Day.csv` / `Minute.csv`；每日增量约 18:00 经 rsync。[接口结构](https://www.sseinfo.com/services/assortment/market/hqywwd/wdzsjk/c/10800481/files/43b75567ae224148bd576acf11d30bd3.pdf)、[每日数据](https://www.sseinfo.com/services/assortment/znsj/znfwnr/c/10767767/files/1e1427dfec484ab288fd67201b73e561.pdf) | 当前价表：每日数据 ¥8,000/月/用户；历史 L1 ¥30,000/年；单购日 K ¥10,000/年、分钟 K ¥20,000/年；行情使用需许可。[价格](https://www.sseinfo.com/services/cpfwjg/)、[授权声明](https://www.sseinfo.com/aboutus/authstatement/) | 技术上是沪市权威 bulk source，但只覆盖沪市且合同/成本高。 |
+| 深交所/深证信 | 历史增强行情是全深市 3 秒快照、逐笔、委托队列、证券信息/状态，不是现成 K 线；所有档次需聚合。[产品](https://www.szsi.cn/cpfw/fwsq/hq/yw-2.htm) | 历史自 2008-01-01，盘后自动落客户本地服务器；L1 网络接入提供 TCP、C++/Java API、DBF。[L1 接入](https://www.szsi.cn/cpfw/fwsq/hq/hlhqfw.htm) | 非展示自用申请面向指定机构/机房，不应假设家庭 NAS 符合。[申请条件](https://www.szsi.cn/cpfw/fwsq/hq/sqlc-3.htm) | 权威但属于机构级 raw-feed 工程。 |
+| 北交所 | 公开股票列表和行情页面不等于历史 K 线 API；任何机构或个人使用、发布、传播行情都需中证股转科技许可。[授权指南](https://www.bse.cn/application/guide.html) | 未找到公开历史 K 线 API 产品。 | 独立许可流程。 | “全 A 股”不能只买沪深两源；BSE 是单独合同。 |
+
+### 4.3 Broker APIs（抽样/19 项备用，不是全量主源）
+
+| 来源 | Vendor-returned 档次/历史 | Universe/调整 | 配额与结论 |
+|---|---|---|---|
+| Futu | vendor 返回 `15m/240m/1d/1w`；≤60m 近 8 年、日线近 20 年、日以上不限制；240m 的回溯范围未明确。[period enum](https://openapi.futunn.com/futu-api-doc/en/quote/quote.html)、[history K](https://openapi.futunn.com/futu-api-doc/en/quote/request-history-kline.html) | raw/qfq/hfq 和复权因子；静态信息有退市标记，但市场枚举没有 BSE。[rehab](https://openapi.futunn.com/futu-api-doc/en/quote/get-rehab.html)、[static info](https://openapi.futunn.com/futu-api-doc/en/quote/get-static-info.html) | 每 7 日 100/300/1,000/2,000 个历史证券，远低于 5,534；不能做全 A 股。[quota](https://openapi.futunn.com/futu-api-doc/en/intro/authority.html) |
+| Tiger | Python/底层文档对 A 股 240m 支持有冲突；日/周和 intraday 历史范围也因市场而异。[stock bars](https://quant.itigerup.com/openapi/zh/python/operation/quotation/stock.html) | 默认前复权或 raw；当前 symbol/status 不能证明完整 point-in-time 退市 universe。 | 历史唯一证券额度低于全市场，K 线约 60 次/分钟；文档冲突本身就是生产风险。[quota](https://quant.itigerup.com/openapi/zh/python/permission/historySubscribe.html)、[rate limit](https://quant.itigerup.com/openapi/en/python/permission/requestLimit.html) |
+| Longbridge/Longport | `15m/240m/1d/1w`；A 股日线自 1999-11，分钟自 2022-08。[periods](https://open.longbridge.com/docs/quote/objects)、[history](https://open.longbridge.com/docs/quote/pull/history-candlestick) | raw/qfq；CN board 没有 BSE；current security list 不是历史 universe。[security list](https://open.longbridge.com/docs/cli/market-data/security-list) | 每自然月 100–3,000 个唯一证券，60 次/30 秒；仍不足全市场。[history quota](https://open.longbridge.com/docs/quote/pull/history-candlestick) |
+
+### 4.4 腾讯/新浪
+
+当前 repo 的 Tencent/Sina 路径只服务 3 个明确上海指数，且只承诺 `1d` 和派生 `1w`。截至调研日，没有找到发布方的一手 API 文档、SLA、限流、历史范围、复权定义、point-in-time universe 或长期归档许可。新浪协议还明确限制未经书面许可的机器人/蜘蛛复制下载。[当前 Tencent adapter](../../src/kline/providers/ashare.py)、[当前 Sina adapter](../../src/kline/providers/sina.py)、[新浪财经协议](https://finance.sina.com.cn/roll/2021-05-12/doc-ikmxzfmm2033220.shtml)
+
+**结论：** 不进入生产 source registry；最多保留为人工 spot-check，且不能把“网页能返回”写成“可靠且获授权”。
+
+## 5. 美股数据源审查
+
+### 5.1 推荐：Massive（技术主选，许可阻断）
+
+| 维度 | 一手证据与判断 |
+|---|---|
+| 时间级别 | custom bars 用 `multiplier × timespan`，可请求 15-minute、4-hour、day、week；这些是 Massive 从 minute/day base aggregates 生成的 vendor aggregation，不是交易所原生的独立 4h/周线。[Custom Bars](https://massive.com/docs/rest/stocks/aggregates/custom-bars) |
+| Coverage | 股票概览写明覆盖 19 个主要交易所、dark pools、FINRA facilities、OTC；full-market snapshot 为 10,000+ active tickers。[stocks overview](https://massive.com/docs/rest/stocks) |
+| Universe/退市 | ticker master 每日更新，可按日期做 point-in-time 查询，`active=false`/`delisted_utc` 表示退市，历史记录可追溯至 2003-09-10。[All Tickers](https://massive.com/docs/rest/stocks/tickers/all-tickers) |
+| 回填 | 全市场分钟和日 K 以压缩 CSV flat files 提供，次日约 11:00 ET 完成；分钟历史自 2003-09-10。2025 年全市场 1m ZIP 总量约 5.4 GB，可直接估算批量回填网络量。[Minute Aggregates](https://massive.com/docs/flat-files/stocks/minute-aggregates)、[Flat Files Quickstart](https://massive.com/docs/flat-files) |
+| 盘中 | WebSocket `AM.*` 可订阅全部股票分钟 OHLCV；官方 FAQ 说除期权 quotes 外，不限制单连接 ticker 数，前提是消费端跟得上。[minute WebSocket](https://massive.com/docs/websocket/stocks/aggregates-per-minute)、[WebSocket FAQ](https://massive.com/knowledge-base/categories/faq) |
+| 复权/公司行动 | REST 默认 split-adjusted，可用 `adjusted=false` 取 raw；不做 dividend adjustment。splits、dividends 和 ticker events 有独立端点。建议 canonical 一律 raw，再在本地版本化复权。[adjustment semantics](https://massive.com/knowledge-base/article/is-massives-stock-data-adjusted-for-splits-or-dividends)、[corporate actions](https://massive.com/docs/rest/stocks) |
+| API/价格 | Individual：Free 2 年/5 calls-min；$29/月 5 年、$79/月 10 年、$199/月 20+ 年，付费档写明 unlimited API calls 和 flat files。[Individual pricing](https://massive.com/pricing?product=stocks) |
+| 许可 | Individual 条款是个人、非商业、display-only；未经许可不得 non-display、构建策略/衍生作品或再分发，终止后要求删除。Business Stocks 当前 $2,499/月，但实际 non-display/存储范围仍要在合同里确认。[market-data terms](https://massive.com/terms/market_data_terms.pdf)、[business pricing](https://massive.com/business) |
+
+**技术结论：** 它是唯一一个同时解决全市场 intraday、bulk backfill、退市 universe 和公司行动的自助候选。
+
+**合同结论：** 在书面许可前，状态必须保持 `blocked_for_license`，不能因为 $29/$79 套餐页面写了 flat files 就开始建立永久策略数据库。
+
+### 5.2 Alpaca（pilot / fallback）
+
+| 维度 | 一手证据与判断 |
+|---|---|
+| 时间级别 | bars API 接受 `[1-59]Min`、`[1-23]Hour`、`1Day`、`1Week`；官方 FAQ 明确分钟/日是 base，小时由分钟、周由日聚合。[bars](https://docs.alpaca.markets/us/reference/stockbars)、[aggregation FAQ](https://docs.alpaca.markets/us/docs/market-data-faq) |
+| Coverage/历史 | SIP 是全美交易所/100% reported volume；IEX 只是单一交易所。Basic 与 Algo Trader Plus 均标注历史自 2016。[plans](https://docs.alpaca.markets/us/docs/about-market-data-api) |
+| Universe | `/v2/assets` 是当前可交易/数据消费 master，可包含 inactive；官方还建议每天更新，但没有承诺完整 point-in-time delisted universe。[assets](https://docs.alpaca.markets/us/reference/get-v2-assets-1)、[assets FAQ](https://docs.alpaca.markets/us/v1.1/docs/broker-api-faq) |
+| 调整 | 默认 raw；可选 split、dividend、spin-off 或组合；`asof` 处理 FB→META 等 symbol mapping。[bars](https://docs.alpaca.markets/us/reference/stockbars) |
+| 批量/频控 | 多 symbol endpoint 每页总计最多 10,000 bars；Basic 200 req/min，$99/月 Algo Trader Plus 10,000 req/min。没有公开的全市场 flat-file archive。[plans](https://docs.alpaca.markets/us/docs/about-market-data-api) |
+| 权利 | 客户协议禁止未经书面同意复制、分发、销售或商业利用 market data；若不是单纯个人查看，也要先问清持久化/non-display 权限。[current agreement](https://files.alpaca.markets/disclosures/library/AcctAppMarginAndCustAgmt.pdf) |
+
+**结论：** 可以做 50–200 个 symbol 的技术 pilot 或 Massive license 等待期验证；全 universe 多年分钟回填和退市 survivorship 控制不如 Massive。
+
+### 5.3 Nasdaq Data Link / Nasdaq Cloud Data Service（不做主源）
+
+- 传统 Data Link/Sharadar Equity Prices 是 premium daily dataset，适合 EOD、公司行动和 active/delisted reference；它不是 `15m` 全市场主源。Sharadar 公开资料写有 6,000+ active、10,000+ delisted companies，并提供 batch export。[Sharadar](https://data.nasdaq.com/databases/SF1)
+- Nasdaq Cloud Data Service 的 Bars API 有 `15minute/1day/1week`，没有 `4h`；`15minute` 的公开 range matrix 只支持很短窗口，访问需 sales onboarding/OAuth。[Bars spec](https://github.com/Nasdaq/NasdaqCloudDataService-REST-API/blob/main/restapi/bars-all.md)、[onboarding](https://docs.data.nasdaq.com/docs/api-for-real-time-or-delayed-data)
+- Data Link 文档站在 2026-08-31 退役，正好是本调研日期，形成额外迁移风险。[Data Link notice](https://docs.data.nasdaq.com/docs/getting-started)
+
+**结论：** 可作为未来 daily/reference 二源，不值得为这次四档 K 线单独接入。
+
+### 5.4 Databento（机构级备选，不是更简单的 Massive 替代）
+
+Databento 提供 unadjusted `1m/1h/1d` OHLCV 和 point-in-time symbology；`15m/4h/1w` 都需本地派生。它有批量下载和独立公司行动/adjustment factors，数据治理质量高。[OHLCV schemas](https://databento.com/docs/schemas-and-data-formats/ohlcv)、[symbology](https://databento.com/docs/standards-and-conventions/symbology)、[adjustment factors](https://databento.com/docs/examples/adjustment-factors/applying-adjustment-factors)
+
+但是其 100%-volume `EQUS.SUMMARY` 是 daily；intraday 完整 consolidated universe 需要组合多个 feed，而不是一个简单 dataset。[equities coverage](https://databento.com/equities) 因此它适合将来对 provenance 有机构级要求时评估，不是本次个人体验版首选。
+
+### 5.5 Yahoo/yfinance（现有兼容源，退出生产）
+
+- yfinance 支持 `15m/1h/1d/1wk`，无 `4h`，所以当前 repo 用 `1h→4h`；官方库文档说 intraday 不可超过最近 60 日。[download docs](https://ranaroussi.github.io/yfinance/reference/api/yfinance.download.html)
+- 没有正式的 full active + delisted ticker master、稳定限流、SLA 或 bulk archive。
+- yfinance README 明确写它未获 Yahoo 背书，只用于 research/education，并提醒 Yahoo Finance API 仅供 personal use；Yahoo Terms 禁止未经许可的自动抓取，并限制构建替代数据库/feed。[yfinance README](https://github.com/ranaroussi/yfinance/blob/main/README.md)、[Yahoo Terms](https://legal.yahoo.com/us/en/yahoo/terms/otos/index.html)
+
+**结论：** 保留为短期兼容/人工核对，不再给任何“全量、定时、生产”任务当主源。
+
+## 6. 跨市场 19 项：清单已核实，剩余的是语义冲突
+
+Daily v2 的 19 项已经由 `WEEKLY_KEYS` 和 registry 核实；当前 `CONTEXT_4H_KEYS` 是 BTC、ETH、HYPE、WTI、Gold、Silver。真正未决的是新 `15m` 要沿用这 6 项的 intraday 边界，还是扩到全部 19 项。[Daily v2 source registry](</Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/market_regime_weekly_source.py>)
+
+有几类不能直接满足“四个时间级别、OHLCV”这一统一合同：
+
+1. `DGS2`、`DGS10`、`T10Y2Y` 是每日 yield/level observation，不是可交易品种，也没有 `15m/4h` OHLCV。Park 已决定把它们从 Candle MVP 排除；若未来仍需要，应进入独立 macro-level 数据轨，而不是转换成 synthetic candles。
+2. S&P/Nasdaq/VIX/DXY/Nikkei/KOSPI 等指数未必有 volume；volume 应允许 `NULL/not_applicable`，不能用 `0` 冒充真实零成交量。当前 `Candle.volume` 必填，需要合同级 schema 决策。[当前 Candle](../../src/kline/models.py)
+3. `GC=F/CL=F/SI=F` 是 Yahoo continuous-futures symbols。切到正式 futures source 后，供应商通常返回具体合约，如 `GCJ5`；必须定义主力/近月选择、roll date、价格拼接和 volume/open-interest 规则。Massive 的官方 futures API 是具体合约并提供 point-in-time contract master，不会替我们决定连续合约算法。[Futures aggregates](https://massive.com/docs/rest/futures/aggregates)、[Contracts](https://massive.com/docs/rest/futures/contracts)
+4. Massive indices 支持 10,000+ 指数、分钟/日 aggregates 和 `15m/4h/day/week` custom bars，但 index aggregate 历史只到 2023-02-14；不能假设它自动覆盖并许可当前全部跨国 19 项。[indices API](https://massive.com/docs/rest/indices)
+5. Daily v2 的 BTC/ETH/HYPE identity 是 **Hyperliquid USDC perpetuals**，不是 Binance spot。Hyperliquid `candleSnapshot` 和 candle WebSocket 原生支持 `15m/4h/1d/1w`，但 REST 只保留最近 5,000 根 candle：`15m` 约 52 天、`4h` 约 833 天。官方历史 S3 明确不提供 candles，因此若保留 perp identity，必须从现在起持续采集并自行归档；不能等几年后再完整回填。[Hyperliquid candle API](https://hyperliquid.gitbook.io/Hyperliquid-docs/for-developers/api/info-endpoint)、[candle WebSocket](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions)、[historical data limits](https://hyperliquid.gitbook.io/hyperliquid-docs/historical-data)
+6. Hyperliquid REST 按 IP 总计 1,200 weight/min，普通 `info` 请求 weight 20，`candleSnapshot` 还按每 60 items 增加 weight；三个 symbol 每 4 小时增量远低于该上限。公开 API 文档没有给出长期归档/再分发许可，外卖或团队共享仍需书面确认。[rate limits](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits-and-user-limits)
+7. Binance Spot 可作为 **不同 instrument identity** 的 BTC/ETH 交叉验证或在 Park 明确改为 spot 后的主源；`/api/v3/klines` 原生支持 `15m/4h/1d/1w`，每次最多 1,000 bars、weight 2，`exchangeInfo` 是当前 symbol/status master。[Binance klines](https://developers.binance.com/en/docs/catalog/core-trading-spot-trading/api/rest-api/market)、[Spot REST limits](https://developers.binance.com/en/docs/products/spot/rest-api)
+8. Binance 官方还发布 daily/monthly K-line ZIP 和 checksum，helper 可批量下载全部 symbol/interval，自 2020-01-01 起默认回填；repo 的 MIT license 明确覆盖代码，但没有找到对原始 market data 商业再分发的清晰授权。[Binance public data](https://github.com/binance/binance-public-data)、[download helper](https://github.com/binance/binance-public-data/blob/master/python/README.md)
+
+### 19 项 manifest 必须包含
+
+| 字段 | 为什么不可省 |
+|---|---|
+| `instrument_id` | 稳定内部身份，不把 Yahoo/Binance/vendor symbol 当领域身份 |
+| `display_name` / `asset_class` | 区分指数值、ETF、spot、具体期货合约、宏观 level |
+| `provider_symbol` + `source_id` | 一项一源；禁止无声替换 |
+| `market_timezone` + `calendar_id` | 生成 closed `4h/1d/1w` |
+| `session_policy` | regular / extended / 24x7；4h anchor 和 closing stub |
+| `volume_semantics` | traded volume / quote-derived / not_applicable |
+| `adjustment_policy` | raw、split、total-return、futures roll |
+| `required_timeframes` | 宏观序列可明确只做 `1d/1w`，而不是伪造 intraday |
+
+## 7. 推荐的采集与派生合同
+
+### 7.1 不要按四个 timeframe 重复抓四份事实
+
+对股票推荐只持久化两个基础层：
+
+- `15m_raw_unadjusted`；
+- `1d_raw_unadjusted`。
+
+然后：
+
+- `15m → 4h`，使用版本化 session rule；
+- `1d → 1w`，只发布 completed week；
+- qfq/hfq/total-return 是 `raw + corporate_actions/adj_factor + as_of` 的可重算视图；
+- 如查询性能需要，可物化 `4h/1w`，但必须记录 `derived_from_timeframe`、`aggregation_rule_version`、`source_id` 和 input range。
+
+这既符合“只要 K 线、指标以后计算”的要求，也避免供应商四个档次互相不一致。
+
+### 7.2 每 4 小时 heartbeat 的正确语义
+
+每次运行不是“取最新一根”，而是：
+
+1. 从 `(source, instrument, base_timeframe)` watermark 读取上次成功闭合 bar；
+2. 从 watermark 前重叠 1–2 根开始取，到“当前已闭合 bar”为止；
+3. 幂等 upsert，记录 source receipt、延迟、缺口、重复/乱序、entitlement/rate-limit 错误；
+4. 只在基础层完整后物化 `4h/1w`；
+5. 服务重启自动 catch-up，不依赖一次 cron 必须成功。
+
+按市场拆节奏：
+
+- BTC/24x7：固定每 4 小时拉最近区间，保留 1–2 根 overlap；
+- A 股：盘中是否需要由 Park 决定；至少午间、收盘后和供应商 EOD 完成后 reconcile；
+- 美股：若获 Massive streaming 权限，实时聚合、每 4 小时 checkpoint；次日 flat file 再做 authoritative reconciliation；
+- daily/weekly：市场收盘并经过供应商 finalized window 后生成，不要在开盘中间发布“完整日线/周线”。
+
+### 7.3 质量和安全边界
+
+- source 失败保持 gap/blocked，禁止生成 synthetic bars；
+- 不把 Yahoo/腾讯/新浪当自动 fallback；
+- 不把 adjusted 与 unadjusted 写入同一个 series key；
+- symbol rename/delist 不覆盖旧 identity；
+- partial/live bars 与 closed bars 分开，数据库默认只服务 closed；
+- source 修订时保留 revision/observed_at，避免悄悄改历史；
+- API secret、broker credential 仍只在人控配置中，不进入数据库 receipt、日志或 NAS snapshot 的明文。
+
+## 8. 行数与存储量级
+
+以下是容量规划，不是对实际供应商数据完整性的断言。
+
+### 8.1 假设
+
+| 项目 | 基准假设 |
+|---|---:|
+| Active A 股 | 5,500（官方 2026-07 约 5,534，取整） |
+| Active 美股公司股票 | 6,500（common shares/ADRs，排除 ETF/OTC）；上界另算 10,000 tickers |
+| A 股交易日 / 15m bars | 244 日/年；16 bars/日 |
+| 美股 regular-session 交易日 / 15m bars | 252 日/年；26 bars/日 |
+| Materialized 4h | A 股 1/日；美股 2/日（第二根是 closing stub） |
+| Weekly | 52/年 |
+| 19 项 roster | 额外按最坏 24x7 计算，实际上会有重叠且多数不是 24x7 |
+
+年增量（6,500 美股口径）：
+
+- A 股：`5,500 × (3,904 15m + 244 4h + 244 1d + 52 1w)` ≈ **2,444 万 rows/年**；
+- 美股：`6,500 × (6,552 15m + 504 4h + 252 1d + 52 1w)` ≈ **4,784 万 rows/年**；
+- 合计约 **7,230 万 rows/年**，19 项的额外量小于约 70 万 rows/年。
+
+### 8.2 两个 retention 场景
+
+| 场景 | 保留规则 | 6,500 美股口径 | 10,000 ticker 上界 |
+|---|---|---:|---:|
+| A：个人研究 hot/warm | `15m+4h` 2 年；`1d+1w` 10 年 | ≈ **1.75 亿 rows** | ≈ **2.35 亿 rows** |
+| B：深历史 | `15m+4h` 5 年；`1d+1w` 20 年 | ≈ **4.20 亿 rows** | ≈ **5.65 亿 rows** |
+
+### 8.3 磁盘估算
+
+当前 SQLite schema 使用多列 TEXT、7 个数值/时间字段和两条复合索引。[schema](../../src/kline/models.py) 在没有代表性数据 benchmark 前，按下面的规划范围：
+
+| 介质/布局 | 规划假设 | 场景 A | 场景 B |
+|---|---:|---:|---:|
+| 当前风格 SQLite，含索引 | 200–350 bytes/row | **35–82 GB** | **84–198 GB** |
+| 排序 + 压缩 Parquet 冷存储 | 40–80 bytes/row | **7–19 GB** | **17–45 GB** |
+
+还必须另留：
+
+- 至少 1 份一致性备份；
+- WAL/checkpoint、索引重建/VACUUM 临时空间；
+- source raw payload/flat files；
+- 未来 universe 增长和 revisions。
+
+因此设备规划应留 **2–3 倍 headroom**。若当前 `raw_upstream_responses.response_body` 对全量请求长期保存 JSON，它可能比 normalized candles 更大；生产版应只长期保留 manifest、checksum、request/receipt 和短 TTL/sampled raw payload，而不是永久复制每次完整响应。[当前 raw response schema](../../src/kline/models.py)
+
+## 9. NAS / 数据库部署
+
+### 9.1 明确禁止：Mac 上的 SQLite 直接打开 NAS SMB/NFS 文件
+
+当前 store 每次连接执行 `PRAGMA journal_mode=WAL`。[store](../../src/kline/store.py) SQLite 官方明确说明：
+
+- WAL 要求所有进程在同一 host，**不支持 network filesystem**；[WAL](https://www.sqlite.org/wal.html)
+- 网络文件系统的 sync/locking 可能实现不正确，导致性能差、事务失败甚至数据库损坏；早期测试“看起来能用”不是安全证据；[SQLite over a network](https://www.sqlite.org/useovernet.html)
+- 官方选择清单说，如果数据和发 SQL 的 application 被网络分开，应选 client/server database。[When to use SQLite](https://www.sqlite.org/whentouse.html)
+
+所以 `KLINE_DB_PATH=/Volumes/NAS/.../kline.db` 对当前实现是 **NO-GO**。
+
+### 9.2 三种部署方式的区别
+
+| 方式 | 是否安全 | 是否节省本地空间 | 适用判断 |
+|---|---|---|---|
+| 外接 APFS SSD active SQLite + NAS 一致性备份 | **是，MVP 主选** | 是，active DB 不占内置盘 | `/Volumes/Phone SSD` 已现场验证为 APFS。必须设置稳定 mount path、启动前 mount guard、断连 fail-closed，并用 Online Backup API、`VACUUM INTO` 或 `sqlite3_rsync` 生成一致快照再传 NAS。[SQLite Backup API](https://www.sqlite.org/backup.html) |
+| 在 NAS 本机运行 datafeed/SQLite，DB 在 NAS 本地 volume | **可以**，前提是所有 SQLite read/write 都在 NAS 同一 host | 是 | 由 NAS 上的单一服务通过 HTTP/API 对外；Mac 不经 SMB 直接开 DB。需要验证 NAS 容器/runtime、CPU/RAM、UPS 和监控。 |
+| 在 NAS 运行 PostgreSQL/MariaDB 服务，datafeed 走 TCP | **推荐的目标形态** | 是 | 数据库引擎和文件都在 NAS 本机；网络上传的是 SQL/API，不是 SQLite file I/O。适合 1–5 亿行、分区、并发读取、在线备份。 |
+
+### 9.3 推荐迁移顺序
+
+1. **现在：** 不热搬活动 DB；先完成 SSD mount guard、SQLite 一致性备份、integrity check 和 rollback 合同。
+2. **MVP：** 将 active SQLite 受控切到 APFS SSD，以约 500 A 股、20–30 美股和去除 Treasury 后的跨市场 roster 跑 30 天，实测 bytes/row、写入速率、回填速度、缺口率和供应商修订。
+3. **备份/冷层：** NAS 挂载与能力验证后，保存一致性 SQLite backup、供应商 flat files 和压缩 Parquet；不把 live WAL database 放在 SMB share。
+4. **扩容门槛：** 只有当 universe、并发或保留期超出 SQLite MVP 预算时，才在 NAS 本机部署 PostgreSQL，并通过现有 storage port 切换 adapter。
+5. **切换：** 任何 storage cutover 都要双写/校验一个完整交易周，row counts、OHLCV checksum、最新 closed bar、delist/rename cases 全部一致后再切读流量。
+
+## 10. 必须由 Park 决定或补证的事项
+
+这些不是工程师可以替 Park 猜的偏好：
+
+1. **19 项保留合同：** Daily v2 的 19 项已验明；请确认是否原样保留，还是替换/删除某些 rate-level、perpetual 或 continuous-futures identity。
+2. **统一四档还是按资产适用：** 美债 yield/利差是否豁免 `15m/4h`；指数 volume 是否允许 `NULL`。
+3. **全美股口径：** common shares/ADRs，还是 ETF/OTC/优先股/权证也要。
+4. **历史保留：** 采用场景 A、B，还是别的 retention；是否保存 delisted 的完整 intraday。
+5. **盘中 SLA：** “每 4 小时任务会补齐 15m”是否足够，还是 A/美股盘中每根 15m 都要在 15–20 分钟内出现。
+6. **session：** 美股 regular-only 还是 extended；`4h` 采用 session-relative closing stub 还是 fixed wall-clock。
+7. **价格口径：** canonical raw；是否需要 qfq、hfq、total return；调整后的值是 query-time 还是物化。
+8. **Gold/WTI/Silver 身份：** spot、具体 futures，还是自定义 continuous futures；若 continuous，谁定义 roll rule。
+9. **用途/授权：** 纯个人查看、个人回测/agent、团队共享、未来产品化分别对应不同数据合同。必须向 TuShare/Massive 书面确认。
+10. **NAS 能力：** 厂牌/型号、CPU 架构、RAM、可用盘、RAID/文件系统、Docker/VM/PostgreSQL 支持、UPS、1/2.5/10GbE、外网和备份目标。
+
+## 11. 建议的下一步（仍然不改代码）
+
+1. Park 回答上面 10 个 decision gates；把已验明的 19 项 manifest（或 Park 明确批准的改版）固化成合同。
+2. 向 TuShare 和 Massive 发送完全相同的用途说明，拿到“持久化、本地/NAS、指标、回测/agent、是否允许长期保留”的书面答复。
+3. 只读检查 NAS 能力和当前实际数据库路径/大小/写入者；不要先搬文件。
+4. 做一个有上限的 source spike：50 A 股 + 50 美股 + 19 项，覆盖 `15m/4h/1d/1w`、上市/退市、分拆/分红、market holiday、服务重启 catch-up。
+5. 用 spike 实测后再写 spec/tickets；届时数据库选择和容量就有真实数据，而不是估算。
+
+---
+
+### 证据等级说明
+
+- 本文只把官方文档、官方代码仓库、交易所/供应商条款和本 repo 代码当事实来源。
+- 价格、权限和历史范围是 2026-08-31 的页面状态，采购前必须重新核对。
+- “未找到公开许可/API 合同”表示证据缺口，不表示法律上必然禁止；在拿到书面授权前，生产判断保持 fail-closed。

--- a/docs/research/mvp-universe-100x100-2026-08-31.md
+++ b/docs/research/mvp-universe-100x100-2026-08-31.md
@@ -1,0 +1,366 @@
+# Datafeed MVP Universe：A 股 100 + US-listed 100
+
+> 调研日期：2026-08-31  
+> 状态：**候选 manifest，等待第一次真实数据快照通过流动性闸门后冻结**  
+> 用途：验证定期 K 线采集、补洞、派生周期、身份映射、幂等写入、监控与恢复；**不是投资建议、选股建议或收益预测**。
+
+## 1. 结论
+
+当前建议把第一版 universe 定义成两个固定集合：**恰好 100 只 A 股 + 恰好 100 只 US-listed operating-company stocks**。这两个集合只服务端到端数据管道验证，不包含 Treasury K 线，也不把 ETF、基金、指数、权证或优先股混入股票集合。
+
+- A 股：100 只，优先沿用 Park 旧 repo 的八个 primary themes，并加入用户点名的股票。
+- 美股：100 只，扩展既有 30 只样本，覆盖 Nasdaq/NYSE、科技/半导体、消费、金融、医药、能源和工业；允许 ADR，但只把美国交易所挂牌的 receipt 当作独立 instrument。
+- 15 分钟与日线是采集基础层；4 小时与周线由有明确口径的聚合器派生。集合本身不因某天热点变化而每日轮换。
+- 第一次所有源成功写入后，记录 `effective_at`、源快照时间、资格计算、替换记录和 hash，并冻结 30 个自然日。
+
+旧 A 股 repo 的主题定义与数据政策是本提案的主要先验来源：[universe/theme 说明](</Users/wendy/work/trading-co/ashare/docs/ashare_universe_and_focus_themes.md>)、[canonical focus-theme config](</Users/wendy/work/trading-co/ashare/config/ashare_focus_themes.json>)。其中 primary themes 是算力/AI 基建、电力、存储、新能源、商业航天、创新药、稀有金属、人形机器人；金融、白酒、消费、军工和 AI 应用属于 secondary themes。
+
+## 2. 选择与冻结合同
+
+### 2.1 第一次运行前的资格闸门
+
+名单下方是明确的候选集合；**当前报告不伪造“最近成交额”数字**。实现时必须从交易所/已授权数据源取一次带 `as_of` 的快照，计算资格并保存 receipt：
+
+| 市场 | 基本资格 | 流动性最低门槛 | 特殊处理 |
+|---|---|---|---|
+| A 股 | SSE/SZSE 上市的普通 A 股；非 ETF/基金/可转债；非 `ST/*ST`；快照时非停牌 | 最近 20 个交易日中至少 18 个非零交易日；日成交额中位数 `>= RMB 300m` | `688825`、`688836` 是用户明确要求的次新锚点；上市交易不足 20 日时，至少需 5 个交易日且可用窗口成交额中位数 `>= RMB 500m`，标为 `new_listing_exception`，不把缺失历史当成 0 |
+| US-listed | Nasdaq/NYSE 等美国交易所挂牌的 operating-company common stock/ADR；`ETF=N`、`Test Issue=N`；不含基金、指数产品、权证、优先股；快照价格 `>= USD 5` | 最近 20 个交易日中至少 18 个非零交易日；日美元成交额中位数 `>= USD 20m` | ADR 记录 `instrument_type=ADR`、发行人和 ratio；不因一日异动自动换入/换出 |
+
+若候选在第一次快照未过闸门，执行者不得静默改写 manifest：应从预先同样筛选的 reserve 中替换，生成 `ashare_mvp_v1.1` 或 `us_stock_mvp_v1.1`，留下原因、旧/新代码和快照链接。若没有合格 reserve，状态是 `blocked`，不是把低流动性股票伪装为已验证。`new_listing_exception` 在满 20 个交易日后重新计算，仍不符合则发起版本变更。
+
+### 2.2 冻结与后续 refresh
+
+1. 第一次真实端到端 run 成功（源响应、闭合 K 线、质量检查、写库和 receipt 都成功）后，冻结两个集合 30 个自然日。
+2. 冻结期间只修正明确的 identity 错误、重复或源映射错误；修正也必须生成新 manifest version，不能重写历史 universe。
+3. 30 日后按版本刷新，不按日轮换。建议以最近 60 个交易日的滚动日美元/RMB 成交额中位数为主体排名，保留每个主题的最低配额和最多配额；先过上市状态、证券类型、停牌/ST/价格闸门，再按分层排名选入。
+4. 主题配额是覆盖约束，不是推荐权重。例如 A 股先为算力/AI 基建、存储、机器人、商业航天、新能源/电力、金融/消费、医药、资源/工业各留有代表；美股保留技术、消费、金融、健康、能源/工业五层。
+5. 每次刷新写出 `selection_as_of`、窗口、阈值、候选全集摘要、入选/落选及原因、数据源 receipt、manifest hash。任何变更都通过 `v1.1`、`v2.0` 等版本可追溯。
+
+### 2.3 当前身份核查结果
+
+用户的几个名称中，官方资料支持以下校正：
+
+- “长兴国际”按代码应为 **长鑫科技 `688825`**。上交所公告写明证券简称“长鑫科技”、证券代码 `688825`，2026-07-27 起上市交易。[SSE 上市公告](https://www.sse.com.cn/disclosure/announcement/listing/ipo/c/c_20260724_10826610.shtml)
+- “宇树机器人”按代码应为 **宇树科技 `688836`**。上交所公告写明证券简称“宇树科技”、证券代码 `688836`，2026-08-19 起上市交易。[SSE 上市公告](https://www.sse.com.cn/disclosure/announcement/listing/ipo/c/c_20260818_10829204.shtml)
+- “中国银行证券”按代码应为 **中银证券 `601696`**；它不是“中国银行” `601988`。上交所公开名单同时展示了 `601696 中银证券` 与 `601988 中国银行`，因此本 manifest 选前者。[SSE official list example](https://www.sse.com.cn/lawandrules/sselawsrules2025/trade/specific/margin/c/c_20260710_10825136.shtml)
+- “天福通信”按代码应为 **天孚通信 `300394`**；“易盛”按上下文应为 **新易盛 `300502`**。深交所公开市场资料使用这两个正式简称，并将 `300394`、`300502` 列为成交活跃股票；`300502` 的深交所上市公告也明确该简称与代码。[SZSE activity publication](https://docs.static.szse.cn/www/market/periodical/month/W020260511542157601085.html)、[SZSE 新易盛上市公告](https://www.szse.cn/aboutus/trends/news/t20160303_518692.html)
+- `600519 贵州茅台`、`688525 佰维存储` 均可在上交所上市公司/披露资料中核对。[贵州茅台 SSE filing](https://www.sse.com.cn/disclosure/listedinfo/announcement/c/new/2021-03-31/600519_20210331_3.pdf)、[佰维存储 SSE announcements](https://www.sse.com.cn/disclosure/listedinfo/announcement/?productId=688789)
+- `300308 中际旭创` 可在深交所市场活跃资料及巨潮官方披露检索中核对。[SZSE activity publication](https://docs.static.szse.cn/www/market/periodical/month/W020260511542157601085.html)、[CNINFO official search](https://www.cninfo.com.cn/new/fulltextSearch?keyWord=%E4%B8%AD%E9%99%85%E6%97%AD%E5%88%9B)
+
+因此，本提案中上述八个用户锚点没有发现“代码对应未上市证券”的情况；真正的风险是 `688836` 历史很短，必须在冻结前保留次新例外标记并通过可用窗口门槛。
+
+## 3. A 股 MVP：恰好 100 只
+
+下面每一行是一个主题桶；桶是**主验证角色**，实际 theme membership 仍允许一只股票属于多个旧 repo 主题。代码均为六位 A 股代码；本版本没有纳入北交所，是因为目标是高流动性、且首轮先验证 SSE/SZSE 采集路径。
+
+### 3.1 算力 / AI 基建 / CPO / PCB / 存储 / 半导体（30）
+
+| 代码 | 证券简称 | 主验证角色 |
+|---|---|---|
+| 300308 | 中际旭创 | CPO/光模块 |
+| 300394 | 天孚通信 | 光器件/光模块 |
+| 300502 | 新易盛 | 光模块 |
+| 002281 | 光迅科技 | 光通信 |
+| 000988 | 华工科技 | 光通信/激光 |
+| 002463 | 沪电股份 | PCB |
+| 002916 | 深南电路 | PCB/封装基板 |
+| 600183 | 生益科技 | 覆铜板/PCB 材料 |
+| 300476 | 胜宏科技 | 高端 PCB |
+| 603228 | 景旺电子 | PCB |
+| 688183 | 生益电子 | 高速 PCB |
+| 601138 | 工业富联 | AI 服务器/制造 |
+| 000977 | 浪潮信息 | 服务器/算力 |
+| 603019 | 中科曙光 | 服务器/超算 |
+| 688256 | 寒武纪 | AI 芯片 |
+| 688041 | 海光信息 | CPU/DCU |
+| 688981 | 中芯国际 | 晶圆制造 |
+| 688347 | 华虹公司 | 晶圆制造 |
+| 002371 | 北方华创 | 半导体设备 |
+| 603501 | 韦尔股份 | CIS/半导体 |
+| 688008 | 澜起科技 | 接口芯片/内存 |
+| 603986 | 兆易创新 | 存储/MCU |
+| 688825 | 长鑫科技 | DRAM；次新锚点 |
+| 688525 | 佰维存储 | 存储/封测 |
+| 301308 | 江波龙 | 存储模组 |
+| 300475 | 香农芯创 | 存储分销/芯片链 |
+| 002049 | 紫光国微 | 特种芯片 |
+| 002156 | 通富微电 | 封装测试 |
+| 600584 | 长电科技 | 封装测试 |
+| 002475 | 立讯精密 | 精密制造/消费电子 |
+
+### 3.2 人形机器人 / AI 应用 / 商业航天 / 军工（16）
+
+| 代码 | 证券简称 | 主验证角色 |
+|---|---|---|
+| 300124 | 汇川技术 | 工控/机器人 |
+| 688017 | 绿的谐波 | 减速器 |
+| 002747 | 埃斯顿 | 工业机器人 |
+| 603728 | 鸣志电器 | 电机/机器人 |
+| 601689 | 拓普集团 | 汽车零部件/机器人 |
+| 002050 | 三花智控 | 执行器/热管理 |
+| 688169 | 石头科技 | 服务机器人/智能硬件 |
+| 688836 | 宇树科技 | 人形机器人；次新锚点 |
+| 002230 | 科大讯飞 | AI 应用 |
+| 300418 | 昆仑万维 | AI 应用/平台 |
+| 688111 | 金山办公 | AI 软件 |
+| 601360 | 三六零 | AI/安全 |
+| 600760 | 中航沈飞 | 军工 |
+| 002025 | 航天电器 | 航天/军工电子 |
+| 600118 | 中国卫星 | 商业航天/卫星 |
+| 002179 | 中航光电 | 军工连接器 |
+
+### 3.3 金融 / 消费 / 白酒（14）
+
+| 代码 | 证券简称 | 主验证角色 |
+|---|---|---|
+| 601318 | 中国平安 | 综合金融 |
+| 600036 | 招商银行 | 银行 |
+| 600030 | 中信证券 | 券商 |
+| 300059 | 东方财富 | 券商/金融科技 |
+| 601696 | 中银证券 | 券商；用户代码锚点 |
+| 600519 | 贵州茅台 | 白酒/消费；用户锚点 |
+| 000858 | 五粮液 | 白酒 |
+| 000568 | 泸州老窖 | 白酒 |
+| 600809 | 山西汾酒 | 白酒 |
+| 600887 | 伊利股份 | 食品饮料 |
+| 000333 | 美的集团 | 家电/消费 |
+| 000651 | 格力电器 | 家电/消费 |
+| 600690 | 海尔智家 | 家电/消费 |
+| 688036 | 传音控股 | 消费电子/出海 |
+
+### 3.4 新能源 / 电力（15）
+
+| 代码 | 证券简称 | 主验证角色 |
+|---|---|---|
+| 300750 | 宁德时代 | 动力电池 |
+| 002594 | 比亚迪 | 新能源汽车/电池 |
+| 300014 | 亿纬锂能 | 电池/储能 |
+| 300274 | 阳光电源 | 逆变器/储能 |
+| 601012 | 隆基绿能 | 光伏 |
+| 600438 | 通威股份 | 光伏/硅料 |
+| 002812 | 恩捷股份 | 锂电隔膜 |
+| 300450 | 先导智能 | 锂电设备 |
+| 002466 | 天齐锂业 | 锂资源 |
+| 002074 | 国轩高科 | 动力电池 |
+| 600905 | 三峡能源 | 新能源发电 |
+| 600406 | 国电南瑞 | 电网/电力自动化 |
+| 600089 | 特变电工 | 电力设备/新能源 |
+| 600875 | 东方电气 | 发电设备 |
+| 600011 | 华能国际 | 电力 |
+
+### 3.5 医药 / 医疗（10）
+
+| 代码 | 证券简称 | 主验证角色 |
+|---|---|---|
+| 600276 | 恒瑞医药 | 创新药 |
+| 603259 | 药明康德 | CRO |
+| 300760 | 迈瑞医疗 | 医疗器械 |
+| 300015 | 爱尔眼科 | 医疗服务 |
+| 300122 | 智飞生物 | 生物医药 |
+| 000661 | 长春高新 | 生物医药 |
+| 600436 | 片仔癀 | 医药/消费 |
+| 300142 | 沃森生物 | 疫苗/生物医药 |
+| 600196 | 复星医药 | 综合医药 |
+| 002422 | 科伦药业 | 医药/创新药 |
+
+### 3.6 资源 / 能源 / 工业（15）
+
+| 代码 | 证券简称 | 主验证角色 |
+|---|---|---|
+| 601899 | 紫金矿业 | 有色/黄金 |
+| 603993 | 洛阳钼业 | 有色金属 |
+| 600111 | 北方稀土 | 稀土 |
+| 002738 | 中矿资源 | 锂/稀有金属 |
+| 601088 | 中国神华 | 煤炭/能源 |
+| 601857 | 中国石油 | 油气 |
+| 600028 | 中国石化 | 油气/化工 |
+| 600019 | 宝钢股份 | 钢铁 |
+| 600309 | 万华化学 | 化工 |
+| 601600 | 中国铝业 | 铝/有色 |
+| 600362 | 江西铜业 | 铜/有色 |
+| 600547 | 山东黄金 | 黄金 |
+| 601919 | 中远海控 | 航运/周期 |
+| 600031 | 三一重工 | 工程机械 |
+| 601989 | 中国重工 | 船舶/军工工业 |
+
+**A 股计数：30 + 16 + 14 + 15 + 10 + 15 = 100；代码去重数 = 100。**
+
+## 4. US-listed MVP：恰好 100 只
+
+这是美国交易所挂牌的 operating-company stocks；ADR 仍是挂牌证券，但在 instrument master 中单独标注，不与境外普通股 K 线拼接。下列公司名为标准英文简称；最终写库时以 SEC/交易所 security master 的正式名称为准。
+
+### 4.1 Technology / semiconductors / cloud / internet（41）
+
+| Ticker | Company | 主验证角色 |
+|---|---|---|
+| NVDA | NVIDIA | GPU/AI compute |
+| AAPL | Apple | mega-cap/消费电子 |
+| MSFT | Microsoft | 云/软件 |
+| AMZN | Amazon | 云/电商 |
+| GOOGL | Alphabet Class A | 平台/AI；只收 Class A |
+| META | Meta Platforms | 平台；`FB -> META` alias |
+| AVGO | Broadcom | 半导体/基础设施软件 |
+| AMD | Advanced Micro Devices | CPU/GPU |
+| INTC | Intel | 半导体/制造 |
+| MU | Micron Technology | DRAM/NAND/HBM |
+| QCOM | Qualcomm | 无线/芯片 |
+| TXN | Texas Instruments | 模拟芯片 |
+| ORCL | Oracle | 数据库/云 |
+| CRM | Salesforce | 企业软件/NYSE |
+| PLTR | Palantir Technologies | AI 软件；NYSE -> Nasdaq venue history |
+| NFLX | Netflix | 流媒体 |
+| ADBE | Adobe | 创意软件/AI 应用 |
+| NOW | ServiceNow | 企业软件 |
+| PANW | Palo Alto Networks | 网络安全 |
+| CRWD | CrowdStrike | 网络安全 |
+| SNOW | Snowflake | 云数据平台 |
+| CSCO | Cisco | 网络设备 |
+| IBM | IBM | 企业 IT |
+| SMCI | Super Micro Computer | AI 服务器 |
+| AMAT | Applied Materials | 半导体设备 |
+| LRCX | Lam Research | 半导体设备 |
+| KLAC | KLA | 半导体检测 |
+| MRVL | Marvell Technology | 数据中心芯片 |
+| ADI | Analog Devices | 模拟/工业芯片 |
+| ARM | Arm Holdings ADS | CPU IP；ADR/ADS |
+| ASML | ASML Holding NY Registry Shares | 光刻设备；ADR |
+| TSM | Taiwan Semiconductor Manufacturing ADS | 代工；NYSE ADR，1 ADR 对应 5 股普通股 |
+| WDC | Western Digital | 存储 |
+| UBER | Uber Technologies | 平台/出行 |
+| APP | AppLovin | 移动广告/AI 应用 |
+| INTU | Intuit | 财务软件 |
+| CDNS | Cadence Design Systems | EDA |
+| BABA | Alibaba ADS | 电商/云；ADR |
+| PDD | PDD Holdings ADS | 电商；ADR |
+| JD | JD.com ADS | 电商；ADR |
+| MELI | MercadoLibre | 拉美电商/支付 |
+
+### 4.2 Consumer / auto / travel / communication（15）
+
+| Ticker | Company | 主验证角色 |
+|---|---|---|
+| TSLA | Tesla | 电动车/机器人 |
+| WMT | Walmart | 零售 |
+| COST | Costco Wholesale | 零售 |
+| KO | Coca-Cola | 饮料；用户点名 |
+| PEP | PepsiCo | 食品饮料 |
+| MCD | McDonald's | 餐饮 |
+| NKE | NIKE | 运动消费 |
+| HD | Home Depot | 家居零售 |
+| DIS | Walt Disney | 媒体/娱乐 |
+| CMCSA | Comcast | 通信/媒体 |
+| GM | General Motors | 汽车 |
+| F | Ford Motor | 汽车；低价股边界但非 penny |
+| LULU | lululemon athletica | 消费/服饰 |
+| BKNG | Booking Holdings | 旅游平台 |
+| PG | Procter & Gamble | 日用消费 |
+
+### 4.3 Finance / payments / market infrastructure（14）
+
+| Ticker | Company | 主验证角色 |
+|---|---|---|
+| JPM | JPMorgan Chase | 银行 |
+| BAC | Bank of America | 银行 |
+| V | Visa | 支付 |
+| MA | Mastercard | 支付 |
+| BRK.B | Berkshire Hathaway Class B | 保险/多元；点号符号边界 |
+| WFC | Wells Fargo | 银行 |
+| GS | Goldman Sachs | 投行 |
+| MS | Morgan Stanley | 投行/财富管理 |
+| BLK | BlackRock | 资管 |
+| SCHW | Charles Schwab | 券商/财富管理 |
+| COF | Capital One Financial | 消费金融 |
+| AXP | American Express | 支付/信用卡 |
+| COIN | Coinbase Global | 加密资产平台；高波动数据边界 |
+| HOOD | Robinhood Markets | 券商/交易平台 |
+
+### 4.4 Healthcare / pharma / medtech（14）
+
+| Ticker | Company | 主验证角色 |
+|---|---|---|
+| LLY | Eli Lilly | 制药；暂将“利来”解释为礼来 |
+| JNJ | Johnson & Johnson | 综合医疗 |
+| UNH | UnitedHealth Group | 医疗服务/保险 |
+| ABBV | AbbVie | 制药 |
+| MRK | Merck & Co. | 制药 |
+| PFE | Pfizer | 制药 |
+| TMO | Thermo Fisher Scientific | 生命科学工具 |
+| ABT | Abbott Laboratories | 医疗器械/诊断 |
+| ISRG | Intuitive Surgical | 医疗器械 |
+| AMGN | Amgen | 生物制药 |
+| GILD | Gilead Sciences | 生物制药 |
+| BMY | Bristol Myers Squibb | 制药 |
+| REGN | Regeneron Pharmaceuticals | 生物制药 |
+| DHR | Danaher | 生命科学/诊断 |
+
+### 4.5 Energy / industrial / materials / utility（16）
+
+| Ticker | Company | 主验证角色 |
+|---|---|---|
+| XOM | Exxon Mobil | 能源 |
+| CVX | Chevron | 能源 |
+| COP | ConocoPhillips | 能源 |
+| SLB | SLB | 油服 |
+| CAT | Caterpillar | 工程机械 |
+| DE | Deere & Company | 农机/工业 |
+| GE | GE Aerospace | 航空工业 |
+| RTX | RTX | 航空航天/防务 |
+| NEE | NextEra Energy | 电力/公用事业 |
+| LMT | Lockheed Martin | 防务 |
+| LIN | Linde | 工业气体 |
+| NEM | Newmont | 黄金资源 |
+| OXY | Occidental Petroleum | 能源 |
+| ETN | Eaton | 电气设备 |
+| HON | Honeywell International | 工业自动化 |
+| UNP | Union Pacific | 铁路/运输 |
+
+**US 计数：41 + 15 + 14 + 14 + 16 = 100；ticker 去重数 = 100。**
+
+## 5. 美股身份与上市状态边界
+
+2026-08-31 对 Nasdaq Trader 的 `nasdaqlisted.txt` 与 `otherlisted.txt` 做了只读核对：这 100 个 canonical tickers（将 `BRK.B` 作为 provider 变体匹配）均能在官方目录中找到，且目录字段 `ETF=N`、`Test Issue=N`。SEC 的官方 ticker/CIK JSON 作为发行人身份交叉核对源：[Nasdaq-listed directory](https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt)、[other-exchange directory](https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt)、[SEC company tickers](https://www.sec.gov/files/company_tickers.json)。这证明“属于当前目录中的非 ETF 证券”，不等于证明每一只在任何窗口都达到成交额门槛；成交额仍必须在第一次 run 用带时间的 market-activity snapshot 计算。
+
+需在 instrument master 中明确处理：
+
+1. **GOOGL vs GOOG：** Alphabet Class A (`GOOGL`) 与 Class C (`GOOG`) 是不同股票类别；本版只收 `GOOGL`，不把同一发行人两个类别误计成两家公司。[Alphabet SEC filing](https://abc.xyz/assets/53/aa/c8121b9b5900f38838f4cfe6b7b6/fdab9de6a195d67ce5861b525627ac73.pdf)
+2. **META alias：** Meta 的 SEC 文件记录 `FB -> META` 更名，稳定 `instrument_id` 必须串联历史，不得从更名日截断。[Meta SEC 8-K](https://www.sec.gov/Archives/edgar/data/1326801/000132680122000070/may312022-exhibit991.htm)
+3. **PLTR venue history：** ticker 保持 `PLTR` 时从 NYSE 转 Nasdaq；`primary_exchange` 需要有效期历史，而不是只存当前交易所。[Palantir SEC 8-K](https://www.sec.gov/Archives/edgar/data/1321655/000132165524000219/pltr-20241114.htm)
+4. **BRK.B provider normalization：** canonical display ticker 为 `BRK.B`，但 provider 可能使用 `BRK/B`、`BRK-B` 或 `BRK B`；映射应按 provider 保存，不能全局字符串替换。[Berkshire SEC 10-K](https://www.sec.gov/Archives/edgar/data/1067983/000119312526083899/brka-20251231.htm)
+5. **TSM ADR：** `TSM` 是 NYSE ADR/ADS，不是台湾普通股 `2330`；必须保存 ADR ratio 和 issuer identity，不把两地 K 线直接拼接。[TSMC investor disclosure](https://investor.tsmc.com/english/dividends/1q26)
+6. **LLY 语义：** `LLY` 是 Eli Lilly；“利来”仍是用户输入的中文不确定项，冻结前应确认。如果不是礼来，必须移出并生成新 manifest version。[Eli Lilly SEC 10-K](https://www.sec.gov/Archives/edgar/data/59478/000005947826000013/lly-20251231.htm)
+
+## 6. 数据源与验证证据边界
+
+- A 股上市状态、证券简称和证券类型：第一次 run 通过 [SSE 股票列表](https://www.sse.com.cn/assortment/stock/list/share/)、[SSE 暂停/终止列表](https://www.sse.com.cn/assortment/stock/list/delisting/)、[SZSE 股票产品目录](https://www.szse.cn/market/product/stock/list/index.html)核对。成交额/活跃度只使用对应交易所或已授权 provider 的当前快照，不从旧网页抄排名。
+- SSE 提供按成交量、成交金额、涨跌幅等维度的[主板活跃股排名](https://www.sse.com.cn/market/stockdata/activity/main/)与[科创板活跃股排名](https://www.sse.com.cn/market/stockdata/activity/star/)；SZSE 定期发布成交概况与活跃股票资料。[SZSE monthly market publication](https://docs.static.szse.cn/www/market/periodical/month/W020260511542157601085.html)
+- 美股当前目录/证券类型使用 Nasdaq Trader 与 SEC。当前流动性筛选应调用 [Nasdaq market movers](https://api.nasdaq.com/api/marketmovers?assetclass=stocks) 或已授权市场数据源，保存 `as_of`、窗口和字段定义；不把页面的“Average Volume”未经窗口说明写成 20 日成交量。
+- 这些名单只定义 instrument universe，不证明 TuShare、Massive、Alpaca 或任何 provider 允许长期保存、派生或 agent 使用。许可仍按 [K-line source landscape](./kline-source-landscape-2026-08-31.md)中的合同闸门处理；未获授权的源不能因为“能返回数据”就进入生产。
+
+## 7. 预期端到端验证覆盖
+
+### A 股
+
+- 30 只算力/AI/光模块/PCB/存储/半导体：能压测多个高频热点板块、科创板/创业板代码和同一产业链的并发抓取。
+- 16 只机器人/AI 应用/商业航天/军工：覆盖多个概念 membership、科创板次新和军工交易日数据。
+- 14 只金融/消费/白酒：覆盖大盘蓝筹、低波动分红型股票和用户明确的证券/消费锚点。
+- 15 只新能源/电力、10 只医药、15 只资源/工业：覆盖周期、商品敏感、医药和长交易历史，便于比较停牌、涨跌停、成交额与公司行动。
+- `688825` 与 `688836` 刻意测试新上市窗口；这两个名字的历史完整性不得用旧数据补造。
+
+### US-listed
+
+- 41 只科技/半导体/云/互联网：覆盖高成交、高价、拆股、软件、存储和 ADR。
+- 15 只消费/汽车/旅游、14 只金融、14 只医疗、16 只能源/工业：覆盖 Nasdaq/NYSE 日历、行业差异、分红、公司行动与高低价格尺度。
+- `GOOGL`、`META`、`PLTR`、`BRK.B`、`TSM`、`ARM`、`ASML`、`BABA/PDD/JD` 刻意保留 identity edge cases；其作用是验证 provider symbol map、CIK/issuer map、venue history、ADR ratio 和 alias，而不是表达偏好。
+
+## 8. 推荐下一步
+
+把本文件作为后续 `to-spec` 的 universe 输入，但先不要把“候选 100/100”写成已经验证的生产事实。下一张实现合同应要求：
+
+1. 读取两个 versioned manifest 并拒绝重复/未知证券类型；
+2. 用一次真实、带时间戳的 market-activity snapshot 跑完上面的门槛；
+3. 生成可审计的 selection receipt 和 `effective_at`；
+4. 首次成功 run 后固定 30 天，不允许日常自动轮换；
+5. 对 `688836` 新上市、`LLY` 中文名称解释、ADR、ticker alias 和 venue history 做明确验收；
+6. 只在真实数据、质量收据、幂等重跑、备份/恢复均通过后，才把 `mvp_v1` 标记为 `verified`。
+
+**最终建议：采用这份 100 A 股 + 100 US-listed 股票候选清单，先完成小而真实的端到端闭环；把流动性阈值、30 天冻结和版本化 refresh 作为 database 的正式维护合同。**

--- a/docs/research/mvp-us-stock-basket-2026-08-31.md
+++ b/docs/research/mvp-us-stock-basket-2026-08-31.md
@@ -1,0 +1,116 @@
+# 美股 K 线数据库 MVP：固定 30 只股票样本
+
+> 调研日期：2026-08-31  
+> 用途：验证真实市场数据数据库的采集、补洞、公司行动、标识映射、查询和恢复；**不是投资建议，也不是选股推荐**。  
+> 范围：美国交易所上市的公司证券；不含 ETF、基金、权证、优先股、低价股和指数产品。
+
+## 1. 结论
+
+建议将美股 MVP 固定为以下 **30 只**：
+
+`NVDA, TSLA, AAPL, MSFT, AMZN, GOOGL, META, AMD, AVGO, INTC, PLTR, NFLX, CRM, JPM, BAC, V, WMT, COST, KO, PG, LLY, JNJ, UNH, XOM, CVX, F, DIS, CAT, BRK.B, TSM`
+
+这个 basket 不是按某一天成交量机械取前 30。那样会被低价股、单日异动和不可用证券类型污染。这里采用两层筛选：
+
+1. **主体层：**高流动性、高重要度的美国大公司，覆盖 Nasdaq 与 NYSE 及多个行业；
+2. **验证层：**刻意加入拆股、分红、代码更名、同发行人多类别股票、ADR、交易所迁移和符号标点等真实数据边界。
+
+SPX 和 Nasdaq-100（`NDX`）属于独立的指数 manifest，不计入这 30 只，也不以 SPY/QQQ 之类 ETF 偷换指数身份。Park 已确认 “Nasdaq” 采用 Nasdaq-100（`NDX`）。
+
+## 2. 事实快照与判断边界
+
+### 2.1 已核实的当前快照事实
+
+- 2026-08-31（中国时间、美股常规时段前）从 Nasdaq 官方 [Stock Screener API](https://api.nasdaq.com/api/screener/stocks?tableonly=true&limit=10000&offset=0&download=true) 取得证券名称、最新显示价格、成交量、市值和行业字段；并从每只证券的官方 `summary` endpoint 取得 Nasdaq 标记为 `Average Volume` 的数值。
+- Nasdaq 官方 [market-movers endpoint](https://api.nasdaq.com/api/marketmovers?assetclass=stocks) 在 2026-08-31 04:07 ET 的 “Most Active by Dollar Volume” 快照中包含 `NVDA`、`MSFT`、`AMZN`、`AAPL` 和 `TSLA`，支持把它们作为高流动性核心；这仍然只是一时点事实，不是永久排名。
+- Nasdaq Trader 在文件页脚标记为 `08/31/2026 03:02` 的 [Nasdaq-listed directory](https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt) 和 [other-exchange directory](https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt) 核实了本清单的当前主要上市地；字段定义见 [Symbol Directory Definitions](https://www.nasdaqtrader.com/trader.aspx?id=symboldirdefs)。
+- Nasdaq endpoint 没有同时返回可供持久引用的行情 `as-of` 时间，官方页面也没有说明 `Average Volume` 的平均窗口。因此下表只把它作为 **2026-08-31 筛选时的流动性证据**，不把它写成“30 日均量”或长期保证。
+- 30 只中最低的 Nasdaq-labelled Average Volume 仍约为 223 万股（COST），最高约为 1.324 亿股（NVDA）；价格快照从约 $13.88（F）到约 $1,174.61（LLY），足以同时测试高低价格和不同交易活跃度。
+
+### 2.2 属于本报告的选择判断
+
+- “大/重要”“适合 MVP”“验证价值高”是本报告的工程判断，不是交易所事实。
+- 一日或一个接口窗口的流动性会变化，所以 basket 在 MVP 开始后不应按行情自动轮换。
+- 纳入一只股票不表达看多、看空、预期收益或资产配置意见。
+
+## 3. 精确 basket 与每只股票的验证职责
+
+下表的价格和 `Avg vol` 均为 2026-08-31 调研时 Nasdaq 官方 summary endpoint 的显示值；`M` 为百万股。ticker 链接直接指向该证券的官方 Nasdaq JSON summary。
+
+| # | Ticker | 主要上市地 | 价格快照 | Avg vol | 纳入理由与数据库验证职责 |
+|---:|---|---|---:|---:|---|
+| 1 | [NVDA](https://api.nasdaq.com/api/quote/NVDA/summary?assetclass=stocks) | Nasdaq | $217.55 | 132.39M | 超高流动性半导体主体；2024 年 10:1 拆股，用于检验拆股日前后 OHLCV、volume 与 adjustment factor。 |
+| 2 | [TSLA](https://api.nasdaq.com/api/quote/TSLA/summary?assetclass=stocks) | Nasdaq | $348.75 | 39.50M | 高流动性汽车股；历史拆股和大波动/跳空用于检验极端 bar 与公司行动重算。 |
+| 3 | [AAPL](https://api.nasdaq.com/api/quote/AAPL/summary?assetclass=stocks) | Nasdaq | $319.70 | 55.37M | 高流动性 mega-cap；同时覆盖历史拆股和规律现金分红。 |
+| 4 | [MSFT](https://api.nasdaq.com/api/quote/MSFT/summary?assetclass=stocks) | Nasdaq | $513.53 | 38.30M | 高美元成交额的软件公司；作为稳定、高价、分红型科技基准。 |
+| 5 | [AMZN](https://api.nasdaq.com/api/quote/AMZN/summary?assetclass=stocks) | Nasdaq | $266.43 | 49.70M | 高流动性消费/云计算主体；2022 年 20:1 拆股，适合验证历史回填是否混用复权口径。 |
+| 6 | [GOOGL](https://api.nasdaq.com/api/quote/GOOGL/summary?assetclass=stocks) | Nasdaq | $346.59 | 30.63M | Alphabet Class A；专门验证同一发行人的 class-share identity。MVP **只收 GOOGL，不收 GOOG**。 |
+| 7 | [META](https://api.nasdaq.com/api/quote/META/summary?assetclass=stocks) | Nasdaq | $578.02 | 18.02M | 大型平台公司；`FB → META` 是必须正确归并、不能切断历史的 ticker alias 案例。 |
+| 8 | [AMD](https://api.nasdaq.com/api/quote/AMD/summary?assetclass=stocks) | Nasdaq | $465.58 | 26.43M | 高流动性半导体；与 NVDA/INTC 构成同业但价格和成交特征不同的并发采集样本。 |
+| 9 | [AVGO](https://api.nasdaq.com/api/quote/AVGO/summary?assetclass=stocks) | Nasdaq | $368.79 | 22.11M | 高美元成交额半导体/基础设施软件公司；用于拆股和现金分红的交叉验证。 |
+| 10 | [INTC](https://api.nasdaq.com/api/quote/INTC/summary?assetclass=stocks) | Nasdaq | $89.47 | 112.14M | 高 share-volume、相对低价的大型半导体；压测每周期新增 bar 与 volume 精度。 |
+| 11 | [PLTR](https://api.nasdaq.com/api/quote/PLTR/summary?assetclass=stocks) | Nasdaq | $186.29 | 42.58M | 高流动性软件股；2024 年在 ticker 不变时从 NYSE 转 Nasdaq，验证 venue history 不可覆盖成单一静态值。 |
+| 12 | [NFLX](https://api.nasdaq.com/api/quote/NFLX/summary?assetclass=stocks) | Nasdaq | $81.72 | 42.68M | 高流动性媒体股；2025 年 10:1 拆股是离 MVP 最近的明确公司行动样本。 |
+| 13 | [CRM](https://api.nasdaq.com/api/quote/CRM/summary?assetclass=stocks) | NYSE | $256.00 | 7.22M | NYSE 大型软件公司；验证同一行业跨交易所的 calendar/session 和 symbol routing。 |
+| 14 | [JPM](https://api.nasdaq.com/api/quote/JPM/summary?assetclass=stocks) | NYSE | $357.62 | 19.16M | 大型银行；补足金融行业和规律分红数据。 |
+| 15 | [BAC](https://api.nasdaq.com/api/quote/BAC/summary?assetclass=stocks) | NYSE | $62.32 | 63.92M | 高 share-volume 银行；与高价 JPM 形成同业的价格/成交量对照。 |
+| 16 | [V](https://api.nasdaq.com/api/quote/V/summary?assetclass=stocks) | NYSE | $381.60 | 7.96M | 大型支付网络；覆盖 NYSE 高价、较低 share-volume 但高美元成交额的证券。 |
+| 17 | [WMT](https://api.nasdaq.com/api/quote/WMT/summary?assetclass=stocks) | Nasdaq | $103.09 | 24.48M | 高流动性零售；用于消费行业、拆股与分红链路。 |
+| 18 | [COST](https://api.nasdaq.com/api/quote/COST/summary?assetclass=stocks) | Nasdaq | $945.47 | 2.23M | 接近千美元价格、较低 share-volume；检验价格精度及正常交易与“低活跃/缺失”不可混淆。 |
+| 19 | [KO](https://api.nasdaq.com/api/quote/KO/summary?assetclass=stocks) | NYSE | $89.66 | 15.55M | 用户明确要求；长期拆股与季度现金分红使其成为 corporate-action reconciliation 基准。 |
+| 20 | [PG](https://api.nasdaq.com/api/quote/PG/summary?assetclass=stocks) | NYSE | $143.78 | 6.57M | 大型日用消费公司；补足较稳定的现金分红型日常消费样本。 |
+| 21 | [LLY](https://api.nasdaq.com/api/quote/LLY/summary?assetclass=stocks) | NYSE | $1,174.61 | 3.41M | **暂把用户说的“利来”解释为“礼来 / Eli Lilly”**；同时提供最高价和医药大型股样本，开始 freeze 前需口头确认这一解释。 |
+| 22 | [JNJ](https://api.nasdaq.com/api/quote/JNJ/summary?assetclass=stocks) | NYSE | $268.04 | 6.43M | 大型医疗保健与规律现金分红样本；用于与 LLY 的同行业数据对照。 |
+| 23 | [UNH](https://api.nasdaq.com/api/quote/UNH/summary?assetclass=stocks) | NYSE | $392.95 | 2.99M | 医疗保险服务，补足非制药医疗子行业及较低 share-volume 的高价股票。 |
+| 24 | [XOM](https://api.nasdaq.com/api/quote/XOM/summary?assetclass=stocks) | NYSE | $156.71 | 24.58M | 高流动性能源公司；检验能源事件日的成交放大及现金分红。 |
+| 25 | [CVX](https://api.nasdaq.com/api/quote/CVX/summary?assetclass=stocks) | NYSE | $201.86 | 9.83M | 第二只大型能源公司；用于同业数据一致性和 provider gap 对照。 |
+| 26 | [F](https://api.nasdaq.com/api/quote/F/summary?assetclass=stocks) | NYSE | $13.88 | 70.55M | basket 中低价、高 share-volume 边界；与 TSLA 构成汽车行业价格尺度对照。 |
+| 27 | [DIS](https://api.nasdaq.com/api/quote/DIS/summary?assetclass=stocks) | NYSE | $108.10 | 11.43M | 大型媒体/体验公司；与 NFLX 形成同主题但不同交易所和公司行动历史的对照。 |
+| 28 | [CAT](https://api.nasdaq.com/api/quote/CAT/summary?assetclass=stocks) | NYSE | $800.25 | 3.26M | 高价工业公司；补足工业周期行业并测试低 share-volume 但高 notional 的正常数据。 |
+| 29 | [BRK.B](https://api.nasdaq.com/api/quote/BRK%2FB/summary?assetclass=stocks) | NYSE | $505.00 | 5.84M | Class B 与点号 ticker；专门验证 `BRK.B / BRK/B / BRK-B` provider symbol normalization，不收 BRK.A。 |
+| 30 | [TSM](https://api.nasdaq.com/api/quote/TSM/summary?assetclass=stocks) | NYSE | $417.52 | 10.48M | 唯一 ADR/ADS 样本；验证美国 K 线与境外发行人、ADR ratio、跨币种分红事件的身份边界。 |
+
+## 4. 关键边界的一手证据
+
+1. **Alphabet 只选一个 class。** Alphabet 的 SEC 文件明确列出 `GOOGL` 为 Class A、`GOOG` 为 Class C，均在 Nasdaq；Class B 不公开交易。[Alphabet filing](https://abc.xyz/assets/53/aa/c8121b9b5900f38838f4cfe6b7b6/fdab9de6a195d67ce5861b525627ac73.pdf) MVP 选择 `GOOGL`，不是因为它“更值得投资”，而是避免同一发行人被算成两只独立公司，同时仍保留 class-share 测试。
+2. **META 历史不能从 2022 年重新开始。** Meta 向 SEC 披露其 Class A 股票于 2022-06-09 从 `FB` 改为 `META`，上市地与 CUSIP 不变。[Meta 8-K exhibit](https://www.sec.gov/Archives/edgar/data/1326801/000132680122000070/may312022-exhibit991.htm) 数据库应以稳定 `instrument_id` 串联 `FB → META`。
+3. **PLTR 是 venue history 测试。** Palantir 的 SEC 8-K 记录其在 ticker 保持 `PLTR` 时，于 2024-11-26 从 NYSE 转至 Nasdaq。[Palantir 8-K](https://www.sec.gov/Archives/edgar/data/1321655/000132165524000219/pltr-20241114.htm) `primary_exchange` 不应只保存当前字符串并抹掉历史有效期。
+4. **BRK.B 必须做 provider symbol map。** Berkshire 2025 Form 10-K 明确 NYSE symbols 为 `BRK.A` 与 `BRK.B`；Nasdaq API 却把路径/返回符号表示为 `BRK/B`。[Berkshire 10-K](https://www.sec.gov/Archives/edgar/data/1067983/000119312526083899/brka-20251231.htm) 建议 canonical display symbol 用 `BRK.B`，每个 provider 单独保存映射，禁止全局字符串替换。
+5. **TSM 是 ADR，不是台湾普通股的同一 ticker。** TSMC 官方披露其 depositary receipts 在 NYSE 以 `TSM` 上市，且 1 ADR 对应 5 股普通股。[TSMC dividend page](https://investor.tsmc.com/english/dividends/1q26)、[TSMC financial statement](https://investor.tsmc.com/chinese/encrypt/files/encrypt_file/qr/phase4_reports/2026-04/5b6b7f218129782a5bf0366e7fd06aadc5c1515a/FS.pdf) 应保存 ADR identity/ratio，不能把 `TSM` 与台湾 `2330` 的 K 线直接拼接。
+6. **LLY 是有意但暂定的语义解释。** Eli Lilly 2025 Form 10-K 确认 common stock ticker 为 `LLY`、上市地 NYSE。[Eli Lilly 10-K](https://www.sec.gov/Archives/edgar/data/59478/000005947826000013/lly-20251231.htm) 但“利来”本身可能是语音/输入误差，因此必须在 universe freeze 前让 Park 确认“利来 = 礼来”。
+7. **拆股必须是真实验收用例。** NVIDIA 官方记录 2024 年 10:1 拆股，[NVIDIA IR](https://investor.nvidia.com/news/press-release-details/2024/NVIDIA-Announces-Financial-Results-for-First-Quarter-Fiscal-2025/default.aspx)；Tesla 官方记录 2022 年 3:1 拆股，[Tesla IR](https://ir.tesla.com/press-release/tesla-announces-three-one-stock-split)；Apple 官方列出 2020 年 4:1 拆股，[Apple IR FAQ](https://investor.apple.com/investor-relations/faq/default.aspx)；Amazon 官方列出 2022 年 20:1 拆股，[Amazon IR FAQ](https://ir.aboutamazon.com/faqs/default.aspx/1000/)；Netflix 的 SEC 文件记录 2025 年 10:1 拆股。[Netflix 8-K](https://www.sec.gov/Archives/edgar/data/1065280/000106528025000407/nflx-20251030.htm) 这些能验证 raw/adjusted 数据不能被混存。
+8. **KO 是分红与拆股基准，而不只是用户点名。** Coca-Cola 官方说明股票在 NYSE 以 `KO` 交易、通常每年派息四次，并列出自 1919 年以来的拆股记录。[Coca-Cola shareholder FAQ](https://investors.coca-colacompany.com/shareowners/faqs)
+
+## 5. 30 天 freeze 合同
+
+建议将第一次端到端成功运行时的清单登记为 `us_mvp_v1`，并从该时刻起冻结 **连续 30 个自然日**：
+
+- 30 天内不按成交量、市值、价格涨跌或指数调整自动增删；
+- ticker 更名只新增 alias，不创建新的 instrument，不删除旧历史；
+- 拆股、分红和 venue 变化更新事件/映射表，不改 basket membership；
+- 停牌、缺数或退市不立即换股——保留成员与状态，让 MVP 真实检验 fail-closed、补洞和缺失语义；
+- 唯一允许在启动前变更的是确认“利来”不是 Eli Lilly。若启动后发现 identity 错误，必须创建新 universe version 并记录原因，不能静默覆盖 `us_mvp_v1`；
+- 第 30 天只基于工程验收决定是否扩容：coverage、freshness、重复 bar、gap、公司行动一致性、重跑幂等、备份与恢复。不要依据收益表现决定保留或删除。
+
+## 6. 对数据库合同的最小要求
+
+这个 basket 暴露出一个 ticker 字符串不够表达证券身份。至少应有：
+
+| 字段 | MVP 要求 |
+|---|---|
+| `instrument_id` | 稳定内部 ID；不随 ticker 或 exchange 改变。 |
+| `display_symbol` | 当前人类显示代码，如 `BRK.B`。 |
+| `provider_symbol` + `source_id` | 每个数据源独立映射，如 provider 可能使用 `BRK/B` 或 `BRK-B`。 |
+| `security_type` | `common_stock` 或 `adr`；本 basket 只有 TSM 为 ADR。 |
+| `share_class` | 至少区分 GOOGL Class A、BRK.B Class B。 |
+| `primary_exchange_valid_from/to` | 支持 PLTR 这类 venue history。 |
+| `ticker_alias_valid_from/to` | 支持 `FB → META`，且历史查询仍归属同一 instrument。 |
+| `corporate_action` | split、cash dividend、ADR ratio 等事件独立保存。 |
+| `price_adjustment_basis` | raw 与 adjusted 必须显式，不能把两者塞进同一 series。 |
+| `universe_version` | `us_mvp_v1` + effective dates，确保 30 天 freeze 可复验。 |
+
+## 7. 仍需 Park 确认的一件事
+
+**“利来”是否就是“礼来制药 / Eli Lilly (`LLY`)”？** Nasdaq identity 已确认：`NDX`。
+
+除此之外，这 30 只可以直接作为后续 spec 的固定美股 MVP universe。它有足够流动性支持真实的 15m/4h/1d/1w 采集验证，也有足够复杂度暴露一个长期数据库必须解决的身份和公司行动问题，但仍远小于全美股。

--- a/docs/specs/market-data-database-mvp-v1.md
+++ b/docs/specs/market-data-database-mvp-v1.md
@@ -1,0 +1,152 @@
+# Market Data Database MVP v1
+
+## Outcome
+
+Deliver a real, resumable, source-auditable K-line database MVP that can ingest and serve a fixed 100 A-share + 100 US-listed stock universe plus the approved 16 cross-market Candle Instruments on a four-hour heartbeat, while preserving the existing datafeed's fail-closed and provenance boundaries.
+
+## Acceptance Criteria
+
+- [ ] A machine-readable manifest validates exactly 216 MVP instruments: 100 A-share stocks, 100 US-listed company stocks, and 16 cross-market instruments, with no duplicate identity or unsupported security type.
+- [ ] Every manifest cell declares source, provider symbol, required timeframe subset, calendar/timezone/session policy, volume semantics, adjustment basis, and aggregation-rule version; `not_applicable` and `blocked_for_entitlement` are explicit states.
+- [ ] Authorized source adapters can persist closed `15m`, `4h`, `1d`, and `1w` rows with source/instrument identity and transform receipts; no MVP writes `30m` or Treasury K-lines, and no query-only derivation is counted as stored data.
+- [ ] A four-hour scheduler performs watermark-based incremental catch-up with bounded retries, overlap, idempotent writes, and atomic run/quality/transform/watermark receipts; an interrupted run never advances its watermark.
+- [ ] The active SQLite database is opened only on the verified APFS SSD after volume/mount checks; consistent backups are copied to NAS, and a clean restore drill passes without opening SQLite over SMB/NFS.
+- [ ] Health output exposes run freshness, source/entitlement state, latest closed bar, gaps/duplicates, row counts, retention/backup age, and explicit failure states; raw payload retention is bounded and observable.
+- [ ] A real-data 30-calendar-day MVP receipt proves coverage, freshness, gap/duplicate handling, re-run idempotency, company-action/identity cases, and backup restore; mocks or HTTP 200 alone cannot mark the MVP verified.
+
+## In Scope
+
+The 100×100 MVP manifests, the 16 non-Treasury cross-market instruments, source/identity and corporate-action metadata, four persisted timeframes, periodic ingestion, quality/transform/run receipts, bounded raw retention, SSD mount guard, NAS backup/cold layer, health reporting, and the 30-day real-data acceptance run.
+
+## Forbidden Changes
+
+Do not hot-move or delete the current resident database; do not open live SQLite WAL files over SMB/NFS; do not silently substitute ETFs for SPX/NDX; do not silently fall back between providers; do not fabricate missing/partial bars; do not write Treasury or `30m` rows into the MVP namespace; do not add indicators, trading commands, credentials, public redistribution, or full-market expansion.
+
+## Problem Statement
+
+The current datafeed is a request-driven K-line service with a small SQLite cache. It does not yet own a resumable, periodic ingestion lifecycle for a bounded multi-market universe. The existing store also retains complete raw upstream payloads without a bounded retention policy, and the current source registry is older than the deployed Daily asset contract.
+
+Park wants a real, long-lived Market Data Database, but the first release must remain small enough to finish and observe end to end. The first release therefore uses a fixed MVP Universe rather than the full A-share and US-stock markets.
+
+## Solution
+
+Build a durable, source-aware ingestion capability around the existing datafeed ports and adapters.
+
+The MVP Universe is:
+
+- 100 A-share company stocks, selected for liquidity plus coverage of the approved hot-theme buckets;
+- 100 US-listed operating-company stocks, selected for liquidity plus sector and identity edge cases;
+- 16 non-Treasury cross-market instruments: SPX, NDX, DXY, SCHD, VIX, BTC, ETH, HYPE, Shanghai Composite, STAR 50, Shanghai Dividend, Nikkei 225, KOSPI, WTI, Gold, and Silver.
+
+Treasury yield/curve series (`DGS2`, `DGS10`, `T10Y2Y`) are excluded from the Candle Instrument universe. The database persists all four requested timeframes: `15m` and `1d` base candles plus `4h` and completed `1w` candles derived under explicit versioned rules. It does not collect `30m`.
+
+The first successful end-to-end run creates a versioned manifest and freezes its membership for 30 calendar days. New hot or liquid candidates remain in a reserve pool until a versioned refresh.
+
+The active MVP database runs on the verified local APFS SSD. The NAS is a backup and cold-storage target; a live SQLite file must not be opened by the Mac from an SMB/NFS share. A future PostgreSQL-on-NAS deployment is an expansion path, not an MVP prerequisite.
+
+## User Stories
+
+1. As Park, I want one versioned MVP Universe, so that a database failure cannot be confused with a silent stock-list change.
+2. As Park, I want exactly 100 A-share members, so that the first full run is bounded and affordable.
+3. As Park, I want exactly 100 US-listed company members, so that the US adapter is exercised without attempting the entire market.
+4. As Park, I want the A-share members to cover high-liquidity hot themes, so that the MVP remains useful for current research.
+5. As Park, I want user-named anchors such as 长鑫科技, 宇树科技, 贵州茅台, 中银证券, 中际旭创, 天孚通信, 新易盛, and 佰维存储 represented by verified tickers, so that colloquial names do not become incorrect database identities.
+6. As Park, I want SPX and NDX stored as actual index identities, so that SPY and QQQ are not silently substituted for the requested indices.
+7. As Park, I want the non-Treasury cross-market roster preserved, so that the existing research context remains available while Treasury level series stay out of the candle database.
+8. As Park, I want `30m` removed from the MVP contract, so that the system has one explicit intraday cadence rather than a legacy duplicate.
+9. As Park, I want each instrument to have a stable internal identity independent of provider ticker spelling, so that aliases and exchange changes do not split its history.
+10. As Park, I want provider symbols and source IDs stored separately, so that `BRK.B`, `BRK/B`, and similar variants cannot collide.
+11. As Park, I want security type and share class recorded, so that common stock, ADR, and multiple classes are not blended.
+12. As Park, I want ticker aliases and venue history to be effective-dated, so that `FB → META` and venue moves remain queryable.
+13. As Park, I want corporate actions recorded independently from candles, so that splits, dividends, spin-offs, and ADR ratios can be reconciled.
+14. As Park, I want raw/unadjusted candles distinguished from adjusted views, so that price history is never silently mixed.
+15. As Park, I want the A-share source to use my renewed/authorized TuShare entitlement, so that the MVP does not depend on an expired token.
+16. As Park, I want the US source to pass an explicit entitlement and storage-use gate, so that technical API access is not mistaken for permission to build a persistent database.
+17. As Park, I want every source request to record its source, provider symbol, request window, response identity, and policy, so that a bad bar can be traced to the upstream observation.
+18. As Park, I want the scheduler to run at least every four hours, so that 24/7 assets do not become stale.
+19. As Park, I want the scheduler to respect A-share and US market calendars, so that closed markets are not reported as failed requests.
+20. As Park, I want each run to begin from a persisted watermark with a small overlap, so that restarts and transient failures can catch up without duplicate rows.
+21. As Park, I want only closed bars promoted to the durable serving layer, so that a still-forming candle is not mistaken for a completed observation.
+22. As Park, I want `15m → 4h` aggregation to use an explicit session/bucket rule, so that partial sessions and lunch breaks are visible rather than silently dropped.
+23. As Park, I want `1d → 1w` aggregation to publish completed weeks only, so that the weekly series is reproducible across providers.
+24. As Park, I want derived candles to carry the input timeframe, source identity, aggregation-rule version, and input range, so that transformations are auditable.
+25. As Park, I want an upstream gap, malformed row, or stale response to remain blocked or unavailable, so that the system never fabricates a candle.
+26. As Park, I want retries to be bounded and idempotent, so that a provider outage does not create duplicate or contradictory data.
+27. As Park, I want the database to keep durable receipts without permanently storing every large raw response, so that storage growth is bounded.
+28. As Park, I want active SQLite on the APFS SSD, so that the MVP avoids the corruption risks of SQLite over SMB/NFS.
+29. As Park, I want consistent database backups on the NAS, so that the active database can be restored without copying a live WAL file.
+30. As Park, I want a restore drill before declaring the MVP ready, so that a backup file is proven usable rather than merely present.
+31. As Park, I want the service to fail closed when the SSD mount is absent, so that launchd cannot silently recreate a database on the internal disk.
+32. As Park, I want the NAS target to be health-checked before backup promotion, so that an unavailable share does not produce a false backup receipt.
+33. As Park, I want the first run to persist a manifest hash and effective timestamp, so that later reports can identify the exact universe used.
+34. As Park, I want the first 30 calendar days to keep membership fixed, so that freshness and coverage can be measured against a stable denominator.
+35. As Park, I want new hot names to enter a reserve pool, so that they can be considered without mutating the active universe.
+36. As Park, I want universe changes to create a new manifest version, so that history is not rewritten in place.
+37. As Park, I want a health view to show last successful run, next due time, source failures, row counts, latest closed bar, and backup age, so that I can operate the database without reading logs.
+38. As Park, I want the API to distinguish `ready`, `partial`, `blocked`, `stale`, and `not_applicable`, so that unsupported timeframes are not presented as provider outages.
+39. As Park, I want the 16 Candle cross-market instruments and the three excluded legacy Treasury aliases mapped explicitly, so that downstream Daily consumers can migrate without hidden ETF substitutions.
+40. As Park, I want no trading commands, broker credentials, or real-money paths in this capability, so that the Market Data Database remains a read-only/Paper boundary.
+41. As Park, I want the implementation to preserve the existing datafeed source/provenance envelope, so that current consumers do not lose source identity.
+42. As Park, I want a bounded real-data pilot before any full-market expansion, so that capacity, provider behavior, and licensing are measured rather than guessed.
+
+## Implementation Decisions
+
+- Reuse the existing MarketDataPort/adapter registry and source-aware candle identity, but do not call API-private fetch helpers from the scheduler. Add one high-level ingestion orchestration seam (conceptually `run_once(plan, clock) -> RunReceipt`) backed by separate source and storage ports; it owns scheduling, watermarking, quality promotion, persistence, and receipts.
+- Keep the normalized storage key source-aware and instrument-aware. Do not use display ticker as the only identity.
+- Add a versioned instrument/universe manifest model covering stable instrument ID, display symbol, provider symbol, source ID, asset/security type, share class, exchange/venue validity, ticker aliases, corporate actions, adjustment basis, and manifest version.
+- Add a machine-readable manifest for all 216 MVP instruments (100 A-share, 100 US-listed, and 16 cross-market) with `required_timeframes` as an explicit subset of `{15m, 4h, 1d, 1w}`, plus source, calendar, timezone, session, volume, adjustment, and aggregation-rule fields. `not_applicable` is a legal status and must not be disguised as source failure. Markdown research files are evidence, not runtime input.
+- Persist raw/unadjusted `15m` and `1d` company-stock candles, and persist the derived `4h` and completed `1w` rows in the serving database. Every derived row must have a transformation receipt containing input timeframe, source identity, aggregation-rule version, and input range; query-time calculation alone does not count as MVP database storage.
+- Treat `volume` as source-semantic: traded volume, quote-derived volume, or not applicable. Do not encode unavailable index volume as a false zero.
+- Allow `volume` to be NULL when `volume_semantics=not_applicable`; never use a false zero for an index without traded volume.
+- Use explicit market calendars and timezone metadata per instrument. Closed-bar eligibility must be deterministic and testable.
+- Use a four-hour heartbeat with persisted watermarks and one-to-two-bar overlap. A run fetches the missing closed range, upserts idempotently, records observations, and then promotes derived periods.
+- Define provider worker/thread boundaries, concurrency limits, retry/backoff, and per-source rate budgets so synchronous provider SDKs cannot block the async service or violate upstream limits.
+- Keep daily/weekly finalization tied to the provider's finalized session window. Do not publish an in-progress daily or weekly bar as complete.
+- Keep provider fallback explicit. A failed source is blocked/unavailable unless the caller or manifest names an allowed fallback; no Yahoo/Tencent/Sina silent substitution is permitted.
+- Treat 688825 and 688836 as deliberate new-listing cases. They may carry a typed `new_listing_exception` while their available history is shorter than the normal window; missing history is not filled with zeros or synthetic rows.
+- Use TuShare Pro as the A-share adapter after an operator supplies a current entitlement. The A-share MVP manifest is the exact 100-candidate list captured in the approved universe artifact, subject to the first-run liquidity/status gate.
+- Use a licensed/authorized US market-data adapter selected by the source-entitlement ticket. Massive is the technical whole-market reference; Alpaca is a bounded pilot alternative. Yahoo/yfinance is not the production authority.
+- Record an entitlement receipt for every production source, including source ID, allowed history, timeframe permissions, persistence rights, derived/non-display use, validity period, and evidence reference. Missing entitlement is a typed `blocked_for_entitlement` state.
+- Treat the exact 100×100 candidate lists as candidate manifests until the first real, timestamped liquidity snapshot passes. A failed candidate is replaced only from a pre-screened reserve and produces a new manifest version.
+- Freeze membership for 30 calendar days after the first successful end-to-end run. After the freeze, refresh by version using a documented rolling liquidity window and theme quotas; never rotate daily.
+- Run active SQLite only on a local filesystem owned by the host running the database. For the MVP, target the verified APFS SSD. Back up through SQLite's consistency-preserving backup API or equivalent, then copy the completed backup to NAS.
+- Do not place the live SQLite WAL database on an SMB/NFS mount. If future scale requires a database server, run PostgreSQL on the NAS host and access it over TCP; do not turn an SMB file path into a pseudo-server.
+- Persist durable run/quality/transform/backup receipts and keep large raw payloads under explicit TTL/sampling or cold-archive policy. Raw response retention must not be unbounded.
+- Make each ingestion attempt atomic at the contract level: candle upserts, quality receipt, transform receipt, and watermark advancement must all succeed before a run is `success`; an interruption must not advance the watermark.
+- Add an SSD mount guard that validates the target volume UUID, filesystem, and mount state before creating or opening the database. Failure exits without falling back to the internal disk.
+- Keep legacy Treasury and `30m` rows readable in an isolated legacy namespace if retained, but stop MVP writes and reject them from the new manifest; do not delete them as part of this MVP.
+- Keep launchd integration separate from the current resident service until the new MVP has passed a controlled cutover and rollback drill. No live DB hot move is part of the first implementation ticket.
+- Keep indicators (MACD, RSI, moving averages), research prose, news, fundamentals, options, broker execution, and public data redistribution outside this K-line MVP.
+
+## Testing Decisions
+
+- Tests must exercise external behavior at the highest available seam: manifest validation, source selection, closed-bar promotion, idempotent re-run, quality blocking, derived-timeframe receipts, backup/restore, and health reporting.
+- Unit tests cover identity normalization, manifest rules, calendar/bucket aggregation, watermark overlap, retention policy, and error classification.
+- Provider contract tests use recorded response shapes only for deterministic parsing; they must not claim live availability or licensing.
+- Bounded integration tests use real, authorized data for representative A-share/US instruments and the cross-market roster. A successful mock or HTTP 200 alone is not acceptance.
+- Scheduler tests cover first run, restart catch-up, transient failure, provider rate limit, market-closed window, duplicate overlap, and a run exceeding its four-hour interval.
+- Database tests cover source/instrument/timeframe uniqueness, raw-vs-adjusted separation, partial writes, WAL checkpoint/backup, restore into a clean database, and absent-SSD mount fail-closed behavior.
+- Acceptance requires a real 30-day MVP observation receipt with coverage/freshness/gap/duplicate counts, latest closed bars, source identities, manifest hash, and a successful restore drill.
+- Existing datafeed provider, provenance, store, timeframe, health, and live API tests are prior art; new tests should extend their public contracts rather than assert private implementation details.
+
+## Out of Scope
+
+- Full 5,000+ A-share coverage or all US-listed securities.
+- Dynamic daily universe rotation, automatic “hot stock” recommendations, or performance-based selection.
+- Treasury yield/curve K-lines (`DGS2`, `DGS10`, `T10Y2Y`) in this candle database.
+- `30m` candles.
+- Silent fallback between Yahoo, Tencent, Sina, TuShare, Massive, Alpaca, or other providers.
+- Persisting MACD, RSI, moving averages, news, research prose, fundamentals, options, or capital-flow data as part of this K-line MVP.
+- Public API resale, market-data redistribution, or team/commercial sharing before provider contracts explicitly allow it.
+- Real-money trading, broker order APIs, credentials, live execution paths, or strategy authorization.
+- Directly opening an SQLite file from an SMB/NFS NAS share.
+- Moving or deleting the current resident database before a separate backup/cutover/rollback contract passes.
+
+## Further Notes
+
+- The old A-share repo is a theme and candidate reference, not the canonical Market Data Database. Its current checkout has theme documentation/configuration but no verified active database to adopt.
+- The exact candidate lists and their source evidence are maintained as research artifacts; the implementation contract must re-check listing status and liquidity at the first real run.
+- The earlier 30-stock US research artifact is superseded by the 100-stock candidate manifest and must not be used as runtime input.
+- The user's current storage statement is sufficient for capacity planning, but NAS mount path, filesystem, Docker/PostgreSQL support, UPS, and network reliability remain deployment facts to verify before moving cold storage or the database server.
+- The current datafeed DB has a small normalized candle footprint but disproportionately large raw response bodies. The MVP must make retention observable from the first run.
+- Any source entitlement, token renewal, NAS login, or purchase is a user-controlled gate. The implementation must expose a typed blocked state rather than pretending the capability is verified.

--- a/docs/verification/mvp-acceptance-blocked-2026-08-31.json
+++ b/docs/verification/mvp-acceptance-blocked-2026-08-31.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "mvp-acceptance-v1",
+  "status": "blocked",
+  "generated_at": "2026-08-31T21:30:00+00:00",
+  "manifest_version": "mvp_universe_v1",
+  "manifest_hash": "fe0731ae0ea3e343400f6aff74249c91b00e7a31de2cbf6ab3ff98e5dcbc0173",
+  "window": {
+    "start": null,
+    "end": null
+  },
+  "evidence_kind": "not_supplied",
+  "criteria": {
+    "active_manifest": {
+      "status": "blocked",
+      "observed": "candidate"
+    },
+    "entitlement": {
+      "status": "blocked",
+      "blocked_instruments": 203
+    },
+    "evidence_kind": {
+      "status": "blocked",
+      "observed": "not_supplied"
+    },
+    "thirty_day_window": {
+      "status": "blocked",
+      "start": null,
+      "end": null
+    },
+    "real_coverage": {
+      "status": "blocked",
+      "health_status": null
+    },
+    "restore": {
+      "status": "blocked",
+      "observed": null
+    },
+    "membership_freeze": {
+      "status": "blocked"
+    }
+  },
+  "blockers": [
+    {
+      "code": "manifest_not_active",
+      "detail": "manifest must be activated by a real successful run"
+    },
+    {
+      "code": "entitlement_blocked",
+      "detail": "one or more manifest sources lack valid persistence entitlement"
+    },
+    {
+      "code": "real_evidence_required",
+      "detail": "mock/parser/HTTP-200 evidence cannot verify the MVP"
+    },
+    {
+      "code": "window_not_started",
+      "detail": "active manifest effective_at is missing"
+    },
+    {
+      "code": "coverage_not_verified",
+      "detail": "health must show a successful real-data run"
+    },
+    {
+      "code": "restore_not_verified",
+      "detail": "clean NAS restore with matching manifest hash is required"
+    },
+    {
+      "code": "freeze_policy_mismatch",
+      "detail": "active manifest must freeze membership for 30 days"
+    }
+  ]
+}

--- a/docs/verification/mvp-acceptance-blocked-2026-08-31.md
+++ b/docs/verification/mvp-acceptance-blocked-2026-08-31.md
@@ -1,0 +1,28 @@
+# Market Data Database MVP Acceptance
+
+- Status: **blocked**
+- Generated: `2026-08-31T21:30:00+00:00`
+- Manifest: `mvp_universe_v1`
+- Manifest hash: `fe0731ae0ea3e343400f6aff74249c91b00e7a31de2cbf6ab3ff98e5dcbc0173`
+- Evidence kind: `not_supplied`
+- Window: `not started` → `not started`
+
+## Criteria
+
+- `active_manifest`: **blocked** — {"observed": "candidate", "status": "blocked"}
+- `entitlement`: **blocked** — {"blocked_instruments": 203, "status": "blocked"}
+- `evidence_kind`: **blocked** — {"observed": "not_supplied", "status": "blocked"}
+- `thirty_day_window`: **blocked** — {"end": null, "start": null, "status": "blocked"}
+- `real_coverage`: **blocked** — {"health_status": null, "status": "blocked"}
+- `restore`: **blocked** — {"observed": null, "status": "blocked"}
+- `membership_freeze`: **blocked** — {"status": "blocked"}
+
+## Blockers
+
+- `manifest_not_active`: manifest must be activated by a real successful run
+- `entitlement_blocked`: one or more manifest sources lack valid persistence entitlement
+- `real_evidence_required`: mock/parser/HTTP-200 evidence cannot verify the MVP
+- `window_not_started`: active manifest effective_at is missing
+- `coverage_not_verified`: health must show a successful real-data run
+- `restore_not_verified`: clean NAS restore with matching manifest hash is required
+- `freeze_policy_mismatch`: active manifest must freeze membership for 30 days

--- a/src/kline/acceptance.py
+++ b/src/kline/acceptance.py
@@ -1,0 +1,238 @@
+"""Evidence-gated 30-day MVP acceptance receipt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from kline.mvp_manifest import MvpManifest, manifest_digest
+
+
+ACCEPTANCE_SCHEMA_VERSION = "mvp-acceptance-v1"
+REAL_EVIDENCE_KIND = "real_authorized"
+
+
+@dataclass(frozen=True)
+class AcceptanceResult:
+    status: str
+    generated_at: str
+    manifest_version: str
+    manifest_hash: str
+    window_start: str | None
+    window_end: str | None
+    evidence_kind: str
+    criteria: Mapping[str, Mapping[str, Any]]
+    blockers: tuple[Mapping[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": ACCEPTANCE_SCHEMA_VERSION,
+            "status": self.status,
+            "generated_at": self.generated_at,
+            "manifest_version": self.manifest_version,
+            "manifest_hash": self.manifest_hash,
+            "window": {"start": self.window_start, "end": self.window_end},
+            "evidence_kind": self.evidence_kind,
+            "criteria": {key: dict(value) for key, value in self.criteria.items()},
+            "blockers": [dict(blocker) for blocker in self.blockers],
+        }
+
+
+def evaluate_acceptance(
+    manifest: MvpManifest,
+    *,
+    health: Mapping[str, Any] | None = None,
+    restore: Mapping[str, Any] | None = None,
+    evidence_kind: str = "not_supplied",
+    now: datetime | None = None,
+) -> AcceptanceResult:
+    """Return ``verified`` only when every real-data gate has evidence."""
+
+    current = now or datetime.now(timezone.utc)
+    generated_at = _iso(current)
+    digest = manifest_digest(manifest)
+    blockers: list[dict[str, Any]] = []
+    criteria: dict[str, dict[str, Any]] = {}
+    status = manifest.selection_policy.get("status")
+    criteria["active_manifest"] = {
+        "status": "pass" if status == "active" else "blocked",
+        "observed": status,
+    }
+    if status != "active":
+        blockers.append(
+            {
+                "code": "manifest_not_active",
+                "detail": "manifest must be activated by a real successful run",
+            }
+        )
+    criteria["entitlement"] = {
+        "status": "pass"
+        if not any(item.source_status == "blocked_for_entitlement" for item in manifest.instruments)
+        else "blocked",
+        "blocked_instruments": sum(
+            item.source_status == "blocked_for_entitlement" for item in manifest.instruments
+        ),
+    }
+    if criteria["entitlement"]["blocked_instruments"]:
+        blockers.append(
+            {
+                "code": "entitlement_blocked",
+                "detail": "one or more manifest sources lack valid persistence entitlement",
+            }
+        )
+    criteria["evidence_kind"] = {
+        "status": "pass" if evidence_kind == REAL_EVIDENCE_KIND else "blocked",
+        "observed": evidence_kind,
+    }
+    if evidence_kind != REAL_EVIDENCE_KIND:
+        blockers.append(
+            {
+                "code": "real_evidence_required",
+                "detail": "mock/parser/HTTP-200 evidence cannot verify the MVP",
+            }
+        )
+
+    window_start = _parse_optional(manifest.effective_at)
+    window_end = window_start + timedelta(days=30) if window_start else None
+    criteria["thirty_day_window"] = {
+        "status": "pass" if window_end and window_end <= current else "blocked",
+        "start": _iso(window_start) if window_start else None,
+        "end": _iso(window_end) if window_end else None,
+    }
+    if window_end is None:
+        blockers.append(
+            {"code": "window_not_started", "detail": "active manifest effective_at is missing"}
+        )
+    elif window_end > current:
+        blockers.append(
+            {"code": "window_not_elapsed", "detail": "30 calendar days have not elapsed"}
+        )
+
+    health_status = health.get("status") if health else None
+    last_run = health.get("last_run") if health else None
+    health_pass = (
+        health_status == "ready"
+        and isinstance(last_run, Mapping)
+        and last_run.get("status") == "success"
+    )
+    criteria["real_coverage"] = {
+        "status": "pass" if health_pass else "blocked",
+        "health_status": health_status,
+    }
+    if not health_pass:
+        blockers.append(
+            {
+                "code": "coverage_not_verified",
+                "detail": "health must show a successful real-data run",
+            }
+        )
+
+    restore_pass = bool(
+        restore and restore.get("status") == "verified" and restore.get("manifest_hash") == digest
+    )
+    criteria["restore"] = {
+        "status": "pass" if restore_pass else "blocked",
+        "observed": restore.get("status") if restore else None,
+    }
+    if not restore_pass:
+        blockers.append(
+            {
+                "code": "restore_not_verified",
+                "detail": "clean NAS restore with matching manifest hash is required",
+            }
+        )
+
+    if health and health.get("row_counts", {}).get("candles", 0) <= 0:
+        blockers.append(
+            {
+                "code": "no_serving_rows",
+                "detail": "health row counts contain no persisted MVP candles",
+            }
+        )
+    criteria["membership_freeze"] = {
+        "status": "pass"
+        if status == "active"
+        and manifest.selection_policy.get("freeze_days_after_first_success") == 30
+        else "blocked"
+    }
+    if criteria["membership_freeze"]["status"] != "pass":
+        blockers.append(
+            {
+                "code": "freeze_policy_mismatch",
+                "detail": "active manifest must freeze membership for 30 days",
+            }
+        )
+
+    return AcceptanceResult(
+        status="verified" if not blockers else "blocked",
+        generated_at=generated_at,
+        manifest_version=manifest.version,
+        manifest_hash=digest,
+        window_start=_iso(window_start) if window_start else None,
+        window_end=_iso(window_end) if window_end else None,
+        evidence_kind=evidence_kind,
+        criteria=criteria,
+        blockers=tuple(blockers),
+    )
+
+
+def render_markdown(result: AcceptanceResult) -> str:
+    """Render a human-readable receipt without hiding blocker state."""
+
+    lines = [
+        "# Market Data Database MVP Acceptance",
+        "",
+        f"- Status: **{result.status}**",
+        f"- Generated: `{result.generated_at}`",
+        f"- Manifest: `{result.manifest_version}`",
+        f"- Manifest hash: `{result.manifest_hash}`",
+        f"- Evidence kind: `{result.evidence_kind}`",
+        f"- Window: `{result.window_start or 'not started'}` → `{result.window_end or 'not started'}`",
+        "",
+        "## Criteria",
+        "",
+    ]
+    for name, criterion in result.criteria.items():
+        lines.append(
+            f"- `{name}`: **{criterion.get('status', 'unknown')}** — {json.dumps(dict(criterion), ensure_ascii=False, sort_keys=True)}"
+        )
+    lines.extend(["", "## Blockers", ""])
+    if result.blockers:
+        lines.extend(f"- `{item.get('code')}`: {item.get('detail')}" for item in result.blockers)
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    result: AcceptanceResult, *, json_path: str | Path, markdown_path: str | Path
+) -> None:
+    """Write explicit JSON + Markdown receipts to caller-selected paths."""
+
+    json_target = Path(json_path)
+    markdown_target = Path(markdown_path)
+    json_target.parent.mkdir(parents=True, exist_ok=True)
+    markdown_target.parent.mkdir(parents=True, exist_ok=True)
+    json_target.write_text(
+        json.dumps(result.to_dict(), ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    markdown_target.write_text(render_markdown(result), encoding="utf-8")
+
+
+def _parse_optional(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from kline.acceptance import evaluate_acceptance, render_markdown, write_artifacts
+from kline.mvp_manifest import load_manifest
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_acceptance_remains_blocked_without_real_entitlement_and_30_day_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    result = evaluate_acceptance(
+        manifest,
+        evidence_kind="synthetic_test",
+        now=datetime(2026, 9, 30, tzinfo=timezone.utc),
+    )
+
+    assert result.status == "blocked"
+    codes = {item["code"] for item in result.blockers}
+    assert {
+        "manifest_not_active",
+        "entitlement_blocked",
+        "real_evidence_required",
+        "window_not_started",
+        "coverage_not_verified",
+        "restore_not_verified",
+    }.issubset(codes)
+    markdown = render_markdown(result)
+    assert "Status: **blocked**" in markdown
+    assert "real_evidence_required" in markdown
+
+    json_path = tmp_path / "acceptance.json"
+    markdown_path = tmp_path / "acceptance.md"
+    write_artifacts(result, json_path=json_path, markdown_path=markdown_path)
+    assert json_path.exists() and markdown_path.exists()
+    assert '"status": "blocked"' in json_path.read_text(encoding="utf-8")
+
+
+def test_acceptance_does_not_treat_verified_restore_without_matching_manifest_as_success() -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    result = evaluate_acceptance(
+        manifest,
+        health={"status": "ready", "last_run": {"status": "success"}, "row_counts": {"candles": 1}},
+        restore={"status": "verified", "manifest_hash": "0" * 64},
+        evidence_kind="real_authorized",
+        now=datetime(2026, 9, 30, tzinfo=timezone.utc),
+    )
+    assert result.status == "blocked"
+    assert any(item["code"] == "manifest_not_active" for item in result.blockers)
+    assert any(item["code"] == "restore_not_verified" for item in result.blockers)


### PR DESCRIPTION
## What
- Add an evidence-gated `evaluate_acceptance` contract that returns `verified` only for an active manifest, valid entitlement, real-authorized coverage, an elapsed 30-day freeze window, and a matching verified restore.
- Render/write human-readable JSON and Markdown acceptance receipts with explicit blockers; current execution produces `blocked`, not a fabricated success.
- Persist the project CONTEXT/glossary, source/licensing/NAS research, exact 100×100 candidate artifact, MVP spec, and the current blocked acceptance receipt.
- Update `REGISTRY.md` with the actual current state and operator next steps.

## Why
The MVP must be maintained as a real database project. Missing TuShare/US entitlement, NAS mount/restore proof, or 30-day real-data evidence must remain visible and actionable instead of being confused with parser tests or HTTP 200.

## Current acceptance result
- Status: `blocked`
- Manifest: `mvp_universe_v1` (`candidate`)
- Blocked entitlement instruments: 203
- Real authorized data/restore: not supplied/verified

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (218 passed)
- `python3 -m ruff check src/kline/acceptance.py tests/test_acceptance.py`
- `python3 -m ruff format --check ...`
- `git diff --check`

## Scope and safety
No provider purchase/renewal, no credentials, no full-market expansion, no public redistribution, no trading, no legacy data deletion, and no claim of verified production.

Closes #54