### PR TITLE
feat: promote 1h to a first-class MVP timeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ the source of truth for readiness.
 
 - `is_synthetic` 恒为 `false`，没有合成/占位数据路径。
 - `cache_policy=bypass` / `profile=realtime` / `profile=execution_live` 不读 cache。
-- Phase 1 `1d` / `1w` / `4h` cache rows without a persisted timeframe receipt are
+- Phase 1 `1h` / `1d` / `1w` / `4h` cache rows without a persisted timeframe receipt are
   blocked rather than relabeled; use `cache_policy=bypass` to obtain a fresh,
   source-bound response.
-- Phase 1 fresh `1d` / `1w` / `4h` upstream results are not written to the legacy
+- Phase 1 fresh `1h` / `1d` / `1w` / `4h` upstream results are not written to the legacy
   candle cache until the transformation receipt has a storage schema; `allow`
   may fetch upstream, while `require` returns `cache_miss`.
 - `quality=strict` 下，上游失败、空数据、陈旧、gap、乱序都返回错误/blocked envelope。
@@ -375,7 +375,7 @@ python -m kline
 
 | Source | Asset class | Provider | Market type | Realtime | Execution venue | 支持 Timeframe |
 |--------|-------------|----------|-------------|----------|-----------------|---------------|
-| `tushare_pro` | `a_share` | TuShare Pro | equity | false | false | 1d, 1w |
+| `tushare_pro` | `a_share` | TuShare Pro | equity | false | false | 1h, 1d, 1w (entitlement-gated) |
 | `tencent_kline` | `index` | Tencent Finance | A-share index | false | false | sh000001/sh000688/sh000015: 1d, 1w |
 | `sina_index` | `index` | Sina Finance | A-share index fallback | false | false | sh000001/sh000688/sh000015: 1d, 1w |
 | `treasury_official_csv` | `macro` | U.S. Treasury | yield level | false | false | DGS2/DGS10: 1d, 1w |
@@ -387,7 +387,7 @@ python -m kline
 | `binance_spot_public` | `crypto` | Binance Spot API | spot | true | false | BTC/BTCUSDT: 1m, 5m, 15m, 30m, 1h, 4h, 1d, 1w; other symbols: no Phase 1 4h guarantee |
 | `binance_usdm_futures` | `commodity` | Binance USD-M Futures | USD-M futures | true | true | XAUUSDT: 1m, 5m, 15m, 30m, 1h, 4h |
 | `binance_usdm_futures_research` | `crypto` | Binance USD-M Futures | USD-M perpetuals | true | false | BTCUSDT/ETHUSDT: 4h, 1d, 1w |
-| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | BTC/ETH/HYPE: 30m, 4h, 1d, 1w |
+| `hyperliquid_perpetual_public` | `crypto` | Hyperliquid public API | perpetual futures | false | false | BTC/ETH/HYPE: 30m, 1h, 4h, 1d, 1w |
 
 ## 技术栈
 

--- a/configs/mvp_manifest.json
+++ b/configs/mvp_manifest.json
@@ -29,6 +29,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -65,6 +66,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -101,6 +103,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -137,6 +140,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -173,6 +177,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -209,6 +214,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -245,6 +251,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -281,6 +288,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -317,6 +325,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -353,6 +362,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -389,6 +399,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -425,6 +436,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -461,6 +473,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -497,6 +510,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -533,6 +547,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -569,6 +584,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -605,6 +621,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -641,6 +658,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -677,6 +695,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -713,6 +732,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -749,6 +769,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -785,6 +806,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -821,6 +843,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -857,6 +880,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -893,6 +917,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -929,6 +954,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -965,6 +991,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1001,6 +1028,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1037,6 +1065,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1073,6 +1102,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1109,6 +1139,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1145,6 +1176,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1181,6 +1213,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1217,6 +1250,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1253,6 +1287,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1289,6 +1324,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1325,6 +1361,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1361,6 +1398,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1397,6 +1435,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1433,6 +1472,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1469,6 +1509,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1505,6 +1546,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1541,6 +1583,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1577,6 +1620,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1613,6 +1657,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1649,6 +1694,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1685,6 +1731,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1721,6 +1768,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1757,6 +1805,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1793,6 +1842,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1829,6 +1879,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1865,6 +1916,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1901,6 +1953,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1937,6 +1990,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -1973,6 +2027,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2009,6 +2064,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2045,6 +2101,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2081,6 +2138,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2117,6 +2175,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2153,6 +2212,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2189,6 +2249,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2225,6 +2286,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2261,6 +2323,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2297,6 +2360,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2333,6 +2397,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2369,6 +2434,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2405,6 +2471,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2441,6 +2508,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2477,6 +2545,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2513,6 +2582,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2549,6 +2619,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2585,6 +2656,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2621,6 +2693,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2657,6 +2730,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2693,6 +2767,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2729,6 +2804,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2765,6 +2841,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2801,6 +2878,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2837,6 +2915,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2873,6 +2952,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2909,6 +2989,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2945,6 +3026,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -2981,6 +3063,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3017,6 +3100,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3053,6 +3137,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3089,6 +3174,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3125,6 +3211,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3161,6 +3248,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3197,6 +3285,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3233,6 +3322,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3269,6 +3359,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3305,6 +3396,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3341,6 +3433,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3377,6 +3470,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3413,6 +3507,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3449,6 +3544,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3485,6 +3581,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3521,6 +3618,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3557,6 +3655,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3593,6 +3692,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3629,6 +3729,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3665,6 +3766,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3701,6 +3803,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3737,6 +3840,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3773,6 +3877,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3811,6 +3916,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3852,6 +3958,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3888,6 +3995,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3924,6 +4032,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3960,6 +4069,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -3996,6 +4106,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4032,6 +4143,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4068,6 +4180,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4104,6 +4217,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4142,6 +4256,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4177,6 +4292,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4213,6 +4329,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4249,6 +4366,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4285,6 +4403,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4321,6 +4440,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4357,6 +4477,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4393,6 +4514,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4429,6 +4551,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4465,6 +4588,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4501,6 +4625,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4537,6 +4662,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4573,6 +4699,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4609,6 +4736,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4645,6 +4773,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4682,6 +4811,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4719,6 +4849,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4756,6 +4887,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4792,6 +4924,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4828,6 +4961,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4864,6 +4998,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4900,6 +5035,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4936,6 +5072,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -4973,6 +5110,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5010,6 +5148,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5047,6 +5186,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5083,6 +5223,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5119,6 +5260,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5155,6 +5297,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5191,6 +5334,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5227,6 +5371,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5263,6 +5408,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5299,6 +5445,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5335,6 +5482,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5371,6 +5519,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5407,6 +5556,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5443,6 +5593,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5479,6 +5630,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5515,6 +5667,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5551,6 +5704,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5587,6 +5741,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5623,6 +5778,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5659,6 +5815,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5695,6 +5852,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5731,6 +5889,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5767,6 +5926,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5806,6 +5966,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5851,6 +6012,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5887,6 +6049,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5923,6 +6086,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5959,6 +6123,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -5995,6 +6160,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6031,6 +6197,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6067,6 +6234,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6103,6 +6271,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6139,6 +6308,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6175,6 +6345,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6211,6 +6382,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6247,6 +6419,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6283,6 +6456,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6319,6 +6493,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6355,6 +6530,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6391,6 +6567,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6427,6 +6604,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6463,6 +6641,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6499,6 +6678,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6535,6 +6715,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6571,6 +6752,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6607,6 +6789,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6643,6 +6826,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6679,6 +6863,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6715,6 +6900,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6751,6 +6937,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6787,6 +6974,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6823,6 +7011,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6859,6 +7048,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6895,6 +7085,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6931,6 +7122,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -6967,6 +7159,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7003,6 +7196,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7039,6 +7233,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7075,6 +7270,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7111,6 +7307,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7147,6 +7344,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7183,6 +7381,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7219,6 +7418,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7257,6 +7457,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7295,6 +7496,7 @@
       },
       "blocked_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7320,6 +7522,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "us_equities",
@@ -7359,6 +7562,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "us_equities",
@@ -7412,6 +7616,7 @@
         "fallback_policy": "none"
       },
       "blocked_timeframes": [
+        "1h",
         "1d",
         "1w"
       ],
@@ -7432,6 +7637,7 @@
       "provider_symbol": "BTC",
       "required_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7472,6 +7678,7 @@
       "provider_symbol": "ETH",
       "required_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7512,6 +7719,7 @@
       "provider_symbol": "HYPE",
       "required_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7556,6 +7764,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "cn_a",
@@ -7596,6 +7805,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "cn_a",
@@ -7636,6 +7846,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "cn_a",
@@ -7676,6 +7887,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "jp_equities",
@@ -7715,6 +7927,7 @@
       ],
       "not_applicable_timeframes": [
         "15m",
+        "1h",
         "4h"
       ],
       "calendar_id": "kr_equities",
@@ -7750,6 +7963,7 @@
       "provider_symbol": "CL=F",
       "required_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7790,6 +8004,7 @@
       "provider_symbol": "GC=F",
       "required_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7830,6 +8045,7 @@
       "provider_symbol": "SI=F",
       "required_timeframes": [
         "15m",
+        "1h",
         "4h",
         "1d",
         "1w"
@@ -7979,6 +8195,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8021,6 +8238,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8063,6 +8281,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8105,6 +8324,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8147,6 +8367,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8189,6 +8410,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8231,6 +8453,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8273,6 +8496,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8315,6 +8539,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8357,6 +8582,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8399,6 +8625,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8441,6 +8668,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8483,6 +8711,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8525,6 +8754,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8567,6 +8797,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8609,6 +8840,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8651,6 +8883,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8693,6 +8926,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8735,6 +8969,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8777,6 +9012,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8821,6 +9057,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8863,6 +9100,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8905,6 +9143,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8947,6 +9186,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -8989,6 +9229,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9031,6 +9272,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9073,6 +9315,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9115,6 +9358,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9157,6 +9401,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9199,6 +9444,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9241,6 +9487,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9283,6 +9530,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9325,6 +9573,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9367,6 +9616,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9409,6 +9659,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9451,6 +9702,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9493,6 +9745,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9535,6 +9788,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9577,6 +9831,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"
@@ -9619,6 +9874,7 @@
           "not_applicable_timeframes": [],
           "blocked_timeframes": [
             "15m",
+            "1h",
             "4h",
             "1d",
             "1w"

--- a/docs/research/timeframe-1h-contract-2026-09-01.md
+++ b/docs/research/timeframe-1h-contract-2026-09-01.md
@@ -1,7 +1,7 @@
 # 1h Timeframe Contract Receipt
 
-**Issue:** #68  
-**Observed:** 2026-09-01 (Asia/Shanghai)  
+**Issue:** #68
+**Observed:** 2026-09-01 (Asia/Shanghai)
 **Status:** contract implemented; source entitlement remains explicit
 
 ## Contract

--- a/docs/research/timeframe-1h-contract-2026-09-01.md
+++ b/docs/research/timeframe-1h-contract-2026-09-01.md
@@ -1,0 +1,32 @@
+# 1h Timeframe Contract Receipt
+
+**Issue:** #68  
+**Observed:** 2026-09-01 (Asia/Shanghai)  
+**Status:** contract implemented; source entitlement remains explicit
+
+## Contract
+
+- MVP persisted/queryable timeframes are `15m`, `1h`, `4h`, `1d`, and `1w`.
+- `30m` remains excluded from the MVP namespace.
+- `1h` native rows are `is_derived=false`.
+- `1h` rows derived from `15m` are `is_derived=true` and carry a transform receipt.
+- Existing 4h and completed-week transform semantics remain unchanged.
+
+## Runtime changes
+
+- Manifest and reserve identities classify all five timeframes.
+- SQLite series keys, transform receipts, and entitlement receipts accept `1h`.
+- The worker, ingestion orchestrator, health/serving matrix, TuShare MVP adapter, authorized-US adapter, and Hyperliquid source expose the new timeframe.
+- Calendar quality accepts `1h`; `cn_a_session_1h_v1` provides a deterministic 15m→1h transform.
+- Hyperliquid BTC/ETH/HYPE `1h` capability is registered as native; configured source validation remains source-aware.
+
+## Evidence
+
+- Full test suite: `241 passed`.
+- Ruff checks and `git diff --check`: passed.
+- The dedicated 1h tests cover manifest state, SQLite persistence, calendar aggregation, quality gaps, TuShare `60min`, authorized-US native 1h, Hyperliquid native 1h, and ingestion persistence of a derived 1h row with a transform receipt.
+- The 3+3 source preflight remains the authority for provider readiness: easy_tdx A-share data is technically available but entitlement is unverified; Yahoo US data is a technical partial; no source is promoted automatically.
+
+## Safety
+
+No provider purchase/renewal, credential logging, full-universe run, NAS migration, production cutover, trading path, or legacy data deletion is part of this change. A source without persistence/derived-use evidence remains `blocked_for_entitlement`/`unavailable` and cannot advance a watermark.

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -11,7 +11,7 @@ import json
 from typing import Any, Callable, Mapping, Sequence
 
 from kline.market_calendar import QualityResult, assess_quality
-from kline.models import AssetClass, Candle, Timeframe
+from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import MvpManifest, manifest_digest
 from kline.ports import FetchReceipt, MarketDataPort
 from kline.providers.base import EntitlementBlocked, ProviderError
@@ -266,10 +266,21 @@ class IngestionOrchestrator:
         raise ProviderError(str(last_error)) from last_error
 
     def _to_mvp_rows(
-        self, instrument: Any, timeframe: str, candles: Sequence[Candle], manifest: MvpManifest
+        self,
+        instrument: Any,
+        timeframe: str,
+        candles: Sequence[Candle],
+        manifest: MvpManifest,
+        *,
+        timeframe_transform: TimeframeTransform | None = None,
     ) -> list[MvpCandle]:
         key = self._key(instrument, timeframe, manifest)
         rows: list[MvpCandle] = []
+        is_derived = timeframe in {"4h", "1w"} or (
+            timeframe == "1h"
+            and timeframe_transform is not None
+            and timeframe_transform.timeframe_origin == "aggregated"
+        )
         for candle in candles:
             volume = None if instrument.volume_semantics == "not_applicable" else candle.volume
             rows.append(
@@ -283,7 +294,7 @@ class IngestionOrchestrator:
                     volume=volume,
                     amount=candle.amount,
                     volume_semantics=instrument.volume_semantics,
-                    is_derived=timeframe in {"4h", "1w"},
+                    is_derived=is_derived,
                 )
             )
         return rows
@@ -341,7 +352,7 @@ class IngestionOrchestrator:
         quality_counts = {"pass": 0, "partial": 0, "fail": 0}
 
         for instrument in manifest.instruments:
-            for timeframe in ("15m", "4h", "1d", "1w"):
+            for timeframe in ("15m", "1h", "4h", "1d", "1w"):
                 if timeframe in instrument.not_applicable_timeframes:
                     cells.append(
                         CellResult(
@@ -443,7 +454,13 @@ class IngestionOrchestrator:
                         plan=plan,
                     )
                     raw_rows = fetch_receipt.candles
-                    mvp_rows = self._to_mvp_rows(instrument, timeframe, raw_rows, manifest)
+                    mvp_rows = self._to_mvp_rows(
+                        instrument,
+                        timeframe,
+                        raw_rows,
+                        manifest,
+                        timeframe_transform=fetch_receipt.timeframe_transform,
+                    )
                     quality = assess_quality(
                         mvp_rows,
                         timeframe=timeframe,

--- a/src/kline/market_calendar.py
+++ b/src/kline/market_calendar.py
@@ -19,8 +19,9 @@ from kline.storage import CandleSeriesKey, MvpCandle, TransformReceiptWrite
 
 
 _FOUR_HOURS = timedelta(hours=4)
+_ONE_HOUR = timedelta(hours=1)
 _FIFTEEN_MINUTES = timedelta(minutes=15)
-_ALLOWED_TIMEFRAMES = frozenset({"15m", "4h", "1d", "1w"})
+_ALLOWED_TIMEFRAMES = frozenset({"15m", "1h", "4h", "1d", "1w"})
 
 
 class CalendarError(ValueError):
@@ -214,6 +215,8 @@ def _bar_end(candle: MvpCandle, *, timeframe: str, spec: CalendarSpec) -> dateti
         return start + _FIFTEEN_MINUTES
     if timeframe == "4h":
         return start + _FOUR_HOURS
+    if timeframe == "1h":
+        return start + _ONE_HOUR
     if timeframe == "1d":
         if spec.continuous:
             return start + timedelta(days=1)
@@ -431,6 +434,109 @@ def aggregate_15m_to_4h(
     )
 
 
+def aggregate_15m_to_1h(
+    candles: Sequence[MvpCandle],
+    *,
+    calendar_id: str,
+    cutoff: datetime | str,
+    run_id: str = "aggregation-preview",
+) -> AggregationResult:
+    """Aggregate closed 15m rows into complete, calendar-aware 1H buckets."""
+
+    if not candles:
+        return AggregationResult((), None, (), (), ())
+    if not all(isinstance(candle, MvpCandle) for candle in candles):
+        raise CalendarError("malformed candle input")
+    key = candles[0].key
+    if key.timeframe != "15m":
+        raise CalendarError("1H aggregation requires 15m input")
+    if any(candle.key != key for candle in candles):
+        raise CalendarError("mixed source/instrument identity in 1H input")
+    if len({candle.volume_semantics for candle in candles}) > 1:
+        raise CalendarError("mixed volume semantics in 1H input")
+    spec = calendar_spec(calendar_id)
+    cutoff_utc = _parse_cutoff(cutoff)
+    issues = _sequence_issues(candles)
+    if any(issue.status == "mixed_source" for issue in issues):
+        raise CalendarError("mixed source input cannot be aggregated")
+
+    grouped: dict[datetime, list[MvpCandle]] = {}
+    excluded_forming: list[str] = []
+    for candle in candles:
+        stamp = _parse_stamp(candle.timestamp)
+        local = stamp.astimezone(spec.zone)
+        if _bar_end(candle, timeframe="15m", spec=spec) > cutoff_utc:
+            excluded_forming.append(candle.timestamp)
+            issues.append(AggregationIssue("forming", "bar ends after cutoff", candle.timestamp))
+            continue
+        if not spec.continuous and not _inside_session(local, spec):
+            issues.append(
+                AggregationIssue(
+                    "out_of_session", "bar is outside regular session", candle.timestamp
+                )
+            )
+            continue
+        if not spec.continuous and not is_trading_session(calendar_id, local.date()):
+            issues.append(
+                AggregationIssue("holiday", "bar falls on a non-session date", candle.timestamp)
+            )
+            continue
+        if spec.calendar_id == "cn_a":
+            local_time = local.timetz().replace(tzinfo=None)
+            anchor_time = time(13, 0) if local_time >= time(13, 0) else time(9, 30)
+            anchor = datetime.combine(local.date(), anchor_time, tzinfo=spec.zone)
+            bucket = anchor + ((local - anchor) // _ONE_HOUR) * _ONE_HOUR
+        else:
+            anchor = datetime.combine(local.date(), spec.four_hour_anchor, tzinfo=spec.zone)
+            if local < anchor:
+                anchor -= timedelta(days=1)
+            bucket = anchor + ((local - anchor) // _ONE_HOUR) * _ONE_HOUR
+        grouped.setdefault(bucket.astimezone(timezone.utc), []).append(candle)
+
+    output_key = _output_key(key, "1h")
+    output: list[MvpCandle] = []
+    partial: list[str] = []
+    for bucket, rows in sorted(grouped.items()):
+        rows.sort(key=lambda item: _parse_stamp(item.timestamp))
+        local_bucket = bucket.astimezone(spec.zone)
+        expected_stamps = [
+            (local_bucket + timedelta(minutes=15 * offset)).astimezone(timezone.utc)
+            for offset in range(4)
+        ]
+        actual_stamps = [_parse_stamp(row.timestamp) for row in rows]
+        if len(rows) != len(expected_stamps) or actual_stamps != sorted(expected_stamps):
+            partial.append(bucket.isoformat())
+            issues.append(AggregationIssue("partial", "incomplete 1H bucket", bucket.isoformat()))
+            continue
+        output.append(_aggregate_rows(rows, output_key, bucket.isoformat(), derived=True))
+
+    receipt = None
+    if output:
+        receipt = TransformReceiptWrite(
+            run_id=run_id,
+            manifest_version=key.manifest_version,
+            instrument_id=key.instrument_id,
+            source_id=key.source_id,
+            output_timeframe="1h",
+            input_timeframe="15m",
+            aggregation_rule_version=(
+                "cn_a_session_1h_v1"
+                if spec.calendar_id == "cn_a"
+                else f"{spec.calendar_id}_fixed_1h_v1"
+            ),
+            input_start=min(candle.timestamp for candle in candles),
+            input_end=max(candle.timestamp for candle in candles),
+            input_hash=_hash_candles(candles),
+            output_hash=_hash_candles(output),
+            bucket_anchor=spec.four_hour_anchor.strftime("%H:%M"),
+            partial_bucket_policy="drop_and_record",
+            partial_bucket_count=len(partial),
+        )
+    return AggregationResult(
+        tuple(output), receipt, tuple(partial), tuple(excluded_forming), tuple(issues)
+    )
+
+
 def aggregate_daily_to_weekly(
     candles: Sequence[MvpCandle],
     *,
@@ -547,7 +653,11 @@ def assess_quality(
             continue
         local = _parse_stamp(candle.timestamp).astimezone(spec.zone)
         observed_dates.add(local.date())
-        if timeframe in {"15m", "4h"} and not spec.continuous and not _inside_session(local, spec):
+        if (
+            timeframe in {"15m", "1h", "4h"}
+            and not spec.continuous
+            and not _inside_session(local, spec)
+        ):
             issues.append(
                 AggregationIssue("malformed", "bar is outside regular session", candle.timestamp)
             )
@@ -561,6 +671,7 @@ def assess_quality(
             closed_stamps.append((_parse_stamp(candle.timestamp), end))
     interval = {
         "15m": _FIFTEEN_MINUTES,
+        "1h": _ONE_HOUR,
         "4h": _FOUR_HOURS,
         "1d": timedelta(days=1),
         "1w": timedelta(days=7),

--- a/src/kline/mvp_manifest.py
+++ b/src/kline/mvp_manifest.py
@@ -12,7 +12,7 @@ from typing import Any, Mapping
 
 
 MVP_MANIFEST_VERSION = "mvp_universe_v1"
-ALLOWED_TIMEFRAMES = ("15m", "4h", "1d", "1w")
+ALLOWED_TIMEFRAMES = ("15m", "1h", "4h", "1d", "1w")
 EXPECTED_COUNTS = {"a_share": 100, "us_stock": 100, "cross_market": 16}
 LEGACY_EXCLUSIONS = {
     "treasury_symbols": ["DGS2", "DGS10", "T10Y2Y"],

--- a/src/kline/mvp_worker.py
+++ b/src/kline/mvp_worker.py
@@ -291,7 +291,7 @@ def _source_states(manifest: MvpManifest) -> list[dict[str, Any]]:
         state["instruments"] += 1
         if item.source_status == "blocked_for_entitlement":
             state["status"] = "blocked_for_entitlement"
-            state["blocked_cells"] += len(item.blocked_timeframes) or 4
+            state["blocked_cells"] += len(item.blocked_timeframes) or 5
     return sorted(grouped.values(), key=lambda value: value["source_id"])
 
 
@@ -361,7 +361,7 @@ def build_mvp_serving_status(
     }
     cells: list[dict[str, Any]] = []
     for instrument in manifest.instruments:
-        for timeframe in ("15m", "4h", "1d", "1w"):
+        for timeframe in ("15m", "1h", "4h", "1d", "1w"):
             status = "ready"
             if timeframe in instrument.not_applicable_timeframes:
                 status = "not_applicable"
@@ -396,6 +396,7 @@ def build_mvp_serving_status(
                         ).total_seconds()
                         max_age = {
                             "15m": 45 * 60,
+                            "1h": 90 * 60,
                             "4h": 12 * 60 * 60,
                             "1d": 3 * 24 * 60 * 60,
                             "1w": 21 * 24 * 60 * 60,

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -324,6 +324,7 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
             "BTC": (
                 Timeframe.MIN_15,
                 Timeframe.MIN_30,
+                Timeframe.HOUR_1,
                 Timeframe.HOUR_4,
                 Timeframe.DAY,
                 Timeframe.WEEK,
@@ -331,6 +332,7 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
             "ETH": (
                 Timeframe.MIN_15,
                 Timeframe.MIN_30,
+                Timeframe.HOUR_1,
                 Timeframe.HOUR_4,
                 Timeframe.DAY,
                 Timeframe.WEEK,
@@ -338,6 +340,7 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
             "HYPE": (
                 Timeframe.MIN_15,
                 Timeframe.MIN_30,
+                Timeframe.HOUR_1,
                 Timeframe.HOUR_4,
                 Timeframe.DAY,
                 Timeframe.WEEK,

--- a/src/kline/providers/hyperliquid.py
+++ b/src/kline/providers/hyperliquid.py
@@ -17,6 +17,7 @@ HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info"
 _TF_MAP = {
     Timeframe.MIN_15: ("15m", 15 * 60 * 1000),
     Timeframe.MIN_30: ("30m", 30 * 60 * 1000),
+    Timeframe.HOUR_1: ("1h", 60 * 60 * 1000),
     Timeframe.HOUR_4: ("4h", 4 * 60 * 60 * 1000),
     Timeframe.DAY: ("1d", 24 * 60 * 60 * 1000),
 }
@@ -81,7 +82,14 @@ class HyperliquidPerpetualProvider:
         self.source_identity: dict[str, Any] = {}
 
     def supported_timeframes(self) -> list[Timeframe]:
-        return [Timeframe.MIN_15, Timeframe.MIN_30, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK]
+        return [
+            Timeframe.MIN_15,
+            Timeframe.MIN_30,
+            Timeframe.HOUR_1,
+            Timeframe.HOUR_4,
+            Timeframe.DAY,
+            Timeframe.WEEK,
+        ]
 
     async def fetch(
         self,
@@ -127,7 +135,7 @@ class HyperliquidPerpetualProvider:
         interval, interval_ms = _TF_MAP.get(timeframe, (None, None))
         if interval is None or interval_ms is None:
             raise ProviderError(
-                "Hyperliquid perpetual source supports only 15m, 30m, 4h, 1d, and 1w"
+                "Hyperliquid perpetual source supports only 15m, 30m, 1h, 4h, 1d, and 1w"
             )
         now = datetime.now(timezone.utc)
         start_ms = _parse_bound(start)

--- a/src/kline/providers/tushare_mvp.py
+++ b/src/kline/providers/tushare_mvp.py
@@ -18,7 +18,11 @@ from typing import Any, Callable, Mapping
 
 import tushare as ts
 
-from kline.market_calendar import aggregate_15m_to_4h, aggregate_daily_to_weekly
+from kline.market_calendar import (
+    aggregate_15m_to_1h,
+    aggregate_15m_to_4h,
+    aggregate_daily_to_weekly,
+)
 from kline.models import Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import MvpManifest, load_manifest
 from kline.providers.ashare import _to_tushare_code
@@ -149,11 +153,7 @@ class TuShareMvpProvider:
         return [
             timeframe
             for timeframe in MVP_TUSHARE_TIMEFRAMES
-            if self._entitlement.permits(timeframe, now=now)
-            and (
-                timeframe not in {Timeframe.HOUR_4, Timeframe.WEEK}
-                or self._entitlement.derived_allowed
-            )
+            if self._permission_allows(timeframe, now=now)
         ]
 
     def membership_report(self) -> dict[str, Any]:
@@ -176,6 +176,14 @@ class TuShareMvpProvider:
         limit: int = 500,
     ) -> list[Candle]:
         instrument = self._resolve_member(ticker)
+        if timeframe == Timeframe.HOUR_1 and not self._native_permission_allows(Timeframe.HOUR_1):
+            if self._derived_1h_permission_allows():
+                return await self._fetch_derived_1h(
+                    instrument,
+                    start=start,
+                    end=end,
+                    limit=limit,
+                )
         self._require_entitlement(timeframe)
         if timeframe in {Timeframe.HOUR_4, Timeframe.WEEK}:
             if self._entitlement is None or not self._entitlement.derived_allowed:
@@ -235,6 +243,82 @@ class TuShareMvpProvider:
             self.last_raw_response["requested_timeframe"] = timeframe.value
             return [self._from_mvp(row) for row in result.candles[-limit:]]
         return await self._fetch_native(instrument, timeframe, start=start, end=end, limit=limit)
+
+    async def _fetch_derived_1h(
+        self,
+        instrument: Any,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        raw = await self.fetch(
+            instrument.display_symbol,
+            Timeframe.MIN_15,
+            start=start,
+            end=end,
+            limit=max(limit * 4, 200),
+        )
+        key = self._key(instrument, Timeframe.MIN_15)
+        result = aggregate_15m_to_1h(
+            [self._to_mvp(key, candle) for candle in raw],
+            calendar_id=_A_SHARE_CALENDAR,
+            cutoff=self._clock(),
+            run_id=f"tushare-preview:{instrument.instrument_id}:1h",
+        )
+        if not result.candles:
+            raise ProviderError(
+                f"TuShare returned no complete 1h rows for {instrument.display_symbol}"
+            )
+        self.timeframe_transform = TimeframeTransform(
+            raw_timeframe=Timeframe.MIN_15,
+            timeframe_origin="aggregated",
+            aggregation={
+                "rule": "cn_a_session_1h_v1",
+                "bucket_anchor": "09:30",
+                "partial_bucket_policy": "drop_and_record",
+                "partial_bucket_count": len(result.partial_buckets),
+            },
+        )
+        self.last_raw_response = dict(self.last_raw_response or {})
+        self.last_raw_response["requested_timeframe"] = Timeframe.HOUR_1.value
+        return [self._from_mvp(row) for row in result.candles[-limit:]]
+
+    def _native_permission_allows(self, timeframe: Timeframe) -> bool:
+        return bool(
+            self._token
+            and self._entitlement is not None
+            and self._entitlement.permits(timeframe, now=self._clock())
+            and self._entitlement.persistence_allowed
+            and self._entitlement.non_display_allowed
+        )
+
+    def _derived_1h_permission_allows(self) -> bool:
+        return bool(
+            self._token
+            and self._entitlement is not None
+            and self._entitlement.permits(Timeframe.MIN_15, now=self._clock())
+            and self._entitlement.derived_allowed
+            and self._entitlement.persistence_allowed
+            and self._entitlement.non_display_allowed
+        )
+
+    def _permission_allows(self, timeframe: Timeframe, *, now: datetime) -> bool:
+        if (
+            self._entitlement is None
+            or not self._token
+            or not self._entitlement.persistence_allowed
+            or not self._entitlement.non_display_allowed
+        ):
+            return False
+        if timeframe == Timeframe.HOUR_1:
+            return self._entitlement.permits(timeframe, now=now) or (
+                self._entitlement.permits(Timeframe.MIN_15, now=now)
+                and self._entitlement.derived_allowed
+            )
+        return self._entitlement.permits(timeframe, now=now) and (
+            timeframe not in {Timeframe.HOUR_4, Timeframe.WEEK} or self._entitlement.derived_allowed
+        )
 
     async def _fetch_native(
         self,

--- a/src/kline/providers/tushare_mvp.py
+++ b/src/kline/providers/tushare_mvp.py
@@ -26,7 +26,13 @@ from kline.providers.base import EntitlementBlocked, ProviderError
 from kline.storage import CandleSeriesKey, EntitlementReceiptWrite, MvpCandle
 
 
-MVP_TUSHARE_TIMEFRAMES = (Timeframe.MIN_15, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK)
+MVP_TUSHARE_TIMEFRAMES = (
+    Timeframe.MIN_15,
+    Timeframe.HOUR_1,
+    Timeframe.HOUR_4,
+    Timeframe.DAY,
+    Timeframe.WEEK,
+)
 _A_SHARE_CALENDAR = "cn_a"
 _A_SHARE_ZONE = timezone(timedelta(hours=8))
 
@@ -37,7 +43,7 @@ class TuShareEntitlement:
 
     source_id: str = "tushare_pro"
     status: str = "active"
-    allowed_timeframes: tuple[str, ...] = ("15m", "4h", "1d", "1w")
+    allowed_timeframes: tuple[str, ...] = ("15m", "1h", "4h", "1d", "1w")
     persistence_allowed: bool = False
     derived_allowed: bool = False
     non_display_allowed: bool = False
@@ -246,7 +252,13 @@ class TuShareMvpProvider:
             "start_date": start,
             "end_date": end,
             "limit": limit,
-            "freq": "15min" if timeframe == Timeframe.MIN_15 else None,
+            "freq": (
+                "15min"
+                if timeframe == Timeframe.MIN_15
+                else "60min"
+                if timeframe == Timeframe.HOUR_1
+                else None
+            ),
         }
         self.last_raw_response = {
             "request_params": request_params,
@@ -255,13 +267,14 @@ class TuShareMvpProvider:
             "error": None,
         }
         try:
-            if timeframe == Timeframe.MIN_15:
+            if timeframe in {Timeframe.MIN_15, Timeframe.HOUR_1}:
+                freq = "15min" if timeframe == Timeframe.MIN_15 else "60min"
                 frame = await self._call(
                     lambda: client.stk_mins(
                         ts_code=ts_code,
                         start_date=start,
                         end_date=end,
-                        freq="15min",
+                        freq=freq,
                     )
                 )
             elif timeframe == Timeframe.DAY:
@@ -427,6 +440,8 @@ class TuShareMvpProvider:
                 close_boundary = (
                     stamp + timedelta(minutes=15)
                     if timeframe == Timeframe.MIN_15
+                    else stamp + timedelta(hours=1)
+                    if timeframe == Timeframe.HOUR_1
                     else self._daily_close(stamp)
                 )
                 if close_boundary > now:
@@ -481,7 +496,9 @@ class TuShareMvpProvider:
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
         if parsed.tzinfo is None:
             parsed = parsed.replace(
-                tzinfo=_A_SHARE_ZONE if timeframe == Timeframe.MIN_15 else timezone.utc
+                tzinfo=_A_SHARE_ZONE
+                if timeframe in {Timeframe.MIN_15, Timeframe.HOUR_1}
+                else timezone.utc
             )
         return parsed.astimezone(timezone.utc)
 

--- a/src/kline/providers/us_authorized.py
+++ b/src/kline/providers/us_authorized.py
@@ -25,7 +25,13 @@ from kline.providers.base import EntitlementBlocked, ProviderError
 from kline.storage import CandleSeriesKey, EntitlementReceiptWrite, MvpCandle
 
 
-MVP_US_TIMEFRAMES = (Timeframe.MIN_15, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK)
+MVP_US_TIMEFRAMES = (
+    Timeframe.MIN_15,
+    Timeframe.HOUR_1,
+    Timeframe.HOUR_4,
+    Timeframe.DAY,
+    Timeframe.WEEK,
+)
 _US_ZONE = ZoneInfo("America/New_York")
 
 
@@ -57,7 +63,7 @@ class USDataEntitlement:
 
     source_id: str = "us_authorized_pending"
     status: str = "active"
-    allowed_timeframes: tuple[str, ...] = ("15m", "4h", "1d", "1w")
+    allowed_timeframes: tuple[str, ...] = ("15m", "1h", "4h", "1d", "1w")
     persistence_allowed: bool = False
     derived_allowed: bool = False
     non_display_allowed: bool = False
@@ -290,7 +296,7 @@ class AuthorizedUSProvider:
         end: str | None,
         limit: int,
     ) -> list[Candle]:
-        if timeframe not in {Timeframe.MIN_15, Timeframe.DAY}:
+        if timeframe not in {Timeframe.MIN_15, Timeframe.HOUR_1, Timeframe.DAY}:
             raise ProviderError(f"US native timeframe {timeframe.value} is unsupported")
         client = self._get_client()
         request_params = {
@@ -505,8 +511,13 @@ class AuthorizedUSProvider:
                 timestamp = raw.get("timestamp", raw.get("t", raw.get("time")))
                 stamp = self._parse_timestamp(timestamp, timeframe)
                 local = stamp.astimezone(_US_ZONE)
-                if timeframe == Timeframe.MIN_15:
-                    if stamp + timedelta(minutes=15) > now:
+                if timeframe in {Timeframe.MIN_15, Timeframe.HOUR_1}:
+                    interval = (
+                        timedelta(minutes=15)
+                        if timeframe == Timeframe.MIN_15
+                        else timedelta(hours=1)
+                    )
+                    if stamp + interval > now:
                         continue
                 else:
                     close = datetime.combine(local.date(), time(16, 0), tzinfo=_US_ZONE).astimezone(
@@ -559,7 +570,9 @@ class AuthorizedUSProvider:
         parsed = datetime.fromisoformat(text)
         if parsed.tzinfo is None:
             parsed = parsed.replace(
-                tzinfo=_US_ZONE if timeframe == Timeframe.MIN_15 else timezone.utc
+                tzinfo=_US_ZONE
+                if timeframe in {Timeframe.MIN_15, Timeframe.HOUR_1}
+                else timezone.utc
             )
         return parsed.astimezone(timezone.utc)
 

--- a/src/kline/providers/us_authorized.py
+++ b/src/kline/providers/us_authorized.py
@@ -18,7 +18,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Protocol
 from zoneinfo import ZoneInfo
 
-from kline.market_calendar import aggregate_15m_to_4h, aggregate_daily_to_weekly
+from kline.market_calendar import (
+    aggregate_15m_to_1h,
+    aggregate_15m_to_4h,
+    aggregate_daily_to_weekly,
+)
 from kline.models import Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import MvpManifest, load_manifest
 from kline.providers.base import EntitlementBlocked, ProviderError
@@ -179,11 +183,7 @@ class AuthorizedUSProvider:
         return [
             timeframe
             for timeframe in MVP_US_TIMEFRAMES
-            if self._entitlement.permits(timeframe, now=now)
-            and (
-                timeframe not in {Timeframe.HOUR_4, Timeframe.WEEK}
-                or self._entitlement.derived_allowed
-            )
+            if self._permission_allows(timeframe, now=now)
         ]
 
     def membership_report(self) -> dict[str, Any]:
@@ -205,6 +205,15 @@ class AuthorizedUSProvider:
         limit: int = 500,
     ) -> list[Candle]:
         instrument, alias_used = self._resolve_member(ticker, start=start, end=end)
+        if timeframe == Timeframe.HOUR_1 and not self._native_permission_allows(Timeframe.HOUR_1):
+            if self._derived_1h_permission_allows():
+                return await self._fetch_derived_1h(
+                    instrument,
+                    alias_used=alias_used,
+                    start=start,
+                    end=end,
+                    limit=limit,
+                )
         self._require_entitlement(timeframe)
         if timeframe in {Timeframe.HOUR_4, Timeframe.WEEK}:
             if self._entitlement is None or not self._entitlement.derived_allowed:
@@ -262,6 +271,80 @@ class AuthorizedUSProvider:
         rows = await self._fetch_native(instrument, timeframe, start=start, end=end, limit=limit)
         self.source_identity["alias_used"] = alias_used
         return rows
+
+    async def _fetch_derived_1h(
+        self,
+        instrument: Any,
+        *,
+        alias_used: str | None,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        raw = await self.fetch(
+            instrument.display_symbol,
+            Timeframe.MIN_15,
+            start=start,
+            end=end,
+            limit=max(limit * 4, 200),
+        )
+        key = self._key(instrument, Timeframe.MIN_15)
+        result = aggregate_15m_to_1h(
+            [self._to_mvp(key, candle) for candle in raw],
+            calendar_id="us_equities",
+            cutoff=self._clock(),
+            run_id=f"us-preview:{instrument.instrument_id}:1h",
+        )
+        if not result.candles:
+            raise ProviderError(
+                f"authorized US returned no complete 1h rows for {instrument.display_symbol}"
+            )
+        self._set_transform(
+            Timeframe.MIN_15,
+            "us_regular_fixed_1h_v1",
+            len(result.partial_buckets),
+        )
+        self.source_identity["alias_used"] = alias_used
+        self.source_identity["timeframe_origin"] = "aggregated"
+        self.last_raw_response = dict(self.last_raw_response or {})
+        self.last_raw_response["requested_timeframe"] = Timeframe.HOUR_1.value
+        return [self._from_mvp(row) for row in result.candles[-limit:]]
+
+    def _native_permission_allows(self, timeframe: Timeframe) -> bool:
+        return bool(
+            self._token
+            and self._entitlement is not None
+            and self._entitlement.permits(timeframe, now=self._clock())
+            and self._entitlement.persistence_allowed
+            and self._entitlement.non_display_allowed
+        )
+
+    def _derived_1h_permission_allows(self) -> bool:
+        return bool(
+            self._token
+            and self._entitlement is not None
+            and self._entitlement.permits(Timeframe.MIN_15, now=self._clock())
+            and self._entitlement.derived_allowed
+            and self._entitlement.persistence_allowed
+            and self._entitlement.non_display_allowed
+        )
+
+    def _permission_allows(self, timeframe: Timeframe, *, now: datetime) -> bool:
+        if (
+            self._entitlement is None
+            or not self._token
+            or not self._entitlement.persistence_allowed
+            or not self._entitlement.non_display_allowed
+        ):
+            return False
+        if timeframe == Timeframe.HOUR_1:
+            return self._entitlement.permits(timeframe, now=now) or (
+                self._entitlement.permits(Timeframe.MIN_15, now=now)
+                and self._entitlement.derived_allowed
+            )
+        return self._entitlement.permits(timeframe, now=now) and (
+            timeframe not in {Timeframe.HOUR_4, Timeframe.WEEK} or self._entitlement.derived_allowed
+        )
 
     async def fetch_corporate_actions(
         self,

--- a/src/kline/storage.py
+++ b/src/kline/storage.py
@@ -13,7 +13,7 @@ import math
 from typing import Any, Mapping, Protocol, Sequence
 
 
-MVP_TIMEFRAMES = frozenset({"15m", "4h", "1d", "1w"})
+MVP_TIMEFRAMES = frozenset({"15m", "1h", "4h", "1d", "1w"})
 VOLUME_SEMANTICS = frozenset({"traded", "quote_derived", "not_applicable"})
 
 

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -596,6 +596,18 @@ class KlineStore:
             ):
                 raise StorageError("partial_bucket_count must be a non-negative integer")
 
+        derived_identities = {
+            (candle.key.instrument_id, candle.key.source_id, candle.key.timeframe)
+            for candle in write.candles
+            if candle.is_derived
+        }
+        receipt_identities = {
+            (instrument_id, source_id, output_timeframe)
+            for instrument_id, source_id, output_timeframe, _input_timeframe in transform_keys
+        }
+        if derived_identities - receipt_identities:
+            raise StorageError("derived candle requires a matching transform receipt")
+
         watermark_keys: set[tuple[Any, ...]] = set()
         for watermark in write.watermarks:
             if not isinstance(watermark, WatermarkWrite):
@@ -762,6 +774,7 @@ class KlineStore:
                             )
                         )
 
+                    transform_rows: dict[tuple[str, str, str], MvpTransformReceiptRow] = {}
                     for transform in write.transform_receipts:
                         row = MvpTransformReceiptRow(
                             run_id=transform.run_id,
@@ -780,9 +793,30 @@ class KlineStore:
                             partial_bucket_count=transform.partial_bucket_count,
                         )
                         session.add(row)
+                        transform_rows[
+                            (
+                                transform.instrument_id,
+                                transform.source_id,
+                                transform.output_timeframe,
+                            )
+                        ] = row
                     session.flush()
 
                     for candle in write.candles:
+                        transform_row = transform_rows.get(
+                            (
+                                candle.key.instrument_id,
+                                candle.key.source_id,
+                                candle.key.timeframe,
+                            )
+                        )
+                        transform_receipt_id = candle.transform_receipt_id
+                        if candle.is_derived:
+                            if transform_row is None:
+                                raise StorageError(
+                                    "derived candle requires a matching transform receipt"
+                                )
+                            transform_receipt_id = transform_row.id
                         values = {
                             "instrument_id": candle.key.instrument_id,
                             "display_symbol": candle.key.display_symbol,
@@ -801,7 +835,7 @@ class KlineStore:
                             "amount": candle.amount,
                             "volume_semantics": candle.volume_semantics,
                             "is_derived": candle.is_derived,
-                            "transform_receipt_id": candle.transform_receipt_id,
+                            "transform_receipt_id": transform_receipt_id,
                         }
                         stmt = sqlite_insert(MvpCandleRow).values(values)
                         stmt = stmt.on_conflict_do_update(

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -558,11 +558,13 @@ class KlineStore:
                 raise StorageError("transform receipt identity does not match run")
             if transform.output_timeframe not in {
                 "15m",
+                "1h",
                 "4h",
                 "1d",
                 "1w",
             } or transform.input_timeframe not in {
                 "15m",
+                "1h",
                 "4h",
                 "1d",
                 "1w",
@@ -625,7 +627,8 @@ class KlineStore:
             ):
                 raise StorageError("timeframe_permissions must be a sequence")
             if any(
-                item not in {"15m", "4h", "1d", "1w"} for item in entitlement.timeframe_permissions
+                item not in {"15m", "1h", "4h", "1d", "1w"}
+                for item in entitlement.timeframe_permissions
             ):
                 raise StorageError("timeframe_permissions contains unsupported timeframe")
             if not all(

--- a/tests/test_hyperliquid.py
+++ b/tests/test_hyperliquid.py
@@ -27,7 +27,7 @@ def _row(open_ms: int, close: str = "60.0") -> dict[str, object]:
 
 
 def _row_for_interval(open_ms: int, interval: str, close: str = "60.0") -> dict[str, object]:
-    minutes = {"15m": 15, "30m": 30, "4h": 240}[interval]
+    minutes = {"15m": 15, "30m": 30, "1h": 60, "4h": 240}[interval]
     return {
         **_row(open_ms, close),
         "T": open_ms + minutes * 60 * 1000 - 1,
@@ -73,6 +73,24 @@ async def test_hyperliquid_native_15m_is_available_for_mvp_crypto_source(symbol:
     assert len(candles) == 1
     assert provider.timeframe_transform is not None
     assert provider.timeframe_transform.raw_timeframe == Timeframe.MIN_15
+    assert provider.timeframe_transform.timeframe_origin == "native"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("symbol", ["BTC", "ETH", "HYPE"])
+async def test_hyperliquid_native_1h_is_available_for_mvp_crypto_source(symbol: str):
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["req"]["coin"] == symbol
+        assert payload["req"]["interval"] == "1h"
+        return httpx.Response(200, json=[_row_for_interval(1786838400000, "1h")])
+
+    provider = HyperliquidPerpetualProvider(transport=httpx.MockTransport(handler))
+    candles = await provider.fetch(symbol, Timeframe.HOUR_1, limit=1)
+
+    assert len(candles) == 1
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.HOUR_1
     assert provider.timeframe_transform.timeframe_origin == "native"
 
 

--- a/tests/test_mvp_manifest.py
+++ b/tests/test_mvp_manifest.py
@@ -448,7 +448,7 @@ def test_manifest_rejects_malformed_open_ended_dates_and_source_mismatch() -> No
     )
     capability_target["required_timeframes"] = ["15m"]
     capability_target["blocked_timeframes"] = []
-    capability_target["not_applicable_timeframes"] = ["4h", "1d", "1w"]
+    capability_target["not_applicable_timeframes"] = ["1h", "4h", "1d", "1w"]
     with pytest.raises(ManifestError, match="does not support"):
         validate_manifest(payload)
 

--- a/tests/test_timeframe_1h.py
+++ b/tests/test_timeframe_1h.py
@@ -277,6 +277,28 @@ async def test_ingestion_persists_derived_1h_with_transform_receipt(tmp_path: Pa
                         "partial_bucket_count": 0,
                     },
                 )
+            elif timeframe == Timeframe.HOUR_4:
+                transform = TimeframeTransform(
+                    raw_timeframe=Timeframe.HOUR_1,
+                    timeframe_origin="aggregated",
+                    aggregation={
+                        "rule": "utc_fixed_4h_v1",
+                        "bucket_anchor": "00:00",
+                        "partial_bucket_policy": "drop_and_record",
+                        "partial_bucket_count": 0,
+                    },
+                )
+            elif timeframe == Timeframe.WEEK:
+                transform = TimeframeTransform(
+                    raw_timeframe=Timeframe.DAY,
+                    timeframe_origin="aggregated",
+                    aggregation={
+                        "rule": "completed_local_calendar_week_v1",
+                        "bucket_anchor": "local_week",
+                        "partial_bucket_policy": "defer_until_closed",
+                        "partial_bucket_count": 0,
+                    },
+                )
             return FetchReceipt(
                 candles=[candle],
                 timeframe_transform=transform,
@@ -320,4 +342,5 @@ async def test_ingestion_persists_derived_1h_with_transform_receipt(tmp_path: Pa
     rows = store.query_mvp_candles(key)
     assert len(rows) == 1
     assert rows[0].is_derived is True
+    assert rows[0].transform_receipt_id is not None
     assert store.mvp_storage_health()["transform_receipts"] >= 1

--- a/tests/test_timeframe_1h.py
+++ b/tests/test_timeframe_1h.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from kline.ingestion import IngestionOrchestrator, IngestionPlan
+from kline.market_calendar import aggregate_15m_to_1h, assess_quality
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.mvp_manifest import ALLOWED_TIMEFRAMES, load_manifest
+from kline.providers.tushare_mvp import TuShareEntitlement, TuShareMvpProvider
+from kline.providers.us_authorized import AuthorizedUSProvider, USDataEntitlement
+from kline.storage import CandleSeriesKey, MvpCandle
+from kline.store import KlineStore
+from kline.ports import FetchReceipt
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def _key(timeframe: str = "15m") -> CandleSeriesKey:
+    return CandleSeriesKey(
+        instrument_id="CN.A.600519",
+        display_symbol="600519",
+        provider_symbol="600519.SS",
+        source_id="test-source",
+        asset_class="a_share",
+        timeframe=timeframe,
+        adjustment_basis="raw_unadjusted",
+        manifest_version="mvp_universe_v1",
+    )
+
+
+def _mvp_bar(key: CandleSeriesKey, stamp: datetime, index: int = 0) -> MvpCandle:
+    return MvpCandle(
+        key=key,
+        timestamp=stamp.isoformat(),
+        open=100 + index,
+        high=102 + index,
+        low=99 + index,
+        close=101 + index,
+        volume=10 + index,
+        amount=1000 + index,
+    )
+
+
+def test_mvp_timeframe_contract_includes_1h_and_excludes_30m() -> None:
+    assert ALLOWED_TIMEFRAMES == ("15m", "1h", "4h", "1d", "1w")
+    manifest = load_manifest(MANIFEST_PATH)
+    for instrument in manifest.instruments:
+        states = (
+            set(instrument.required_timeframes)
+            | set(instrument.not_applicable_timeframes)
+            | set(instrument.blocked_timeframes)
+        )
+        assert states == set(ALLOWED_TIMEFRAMES)
+        assert "30m" not in states
+
+
+def test_storage_accepts_1h_series_key_and_entitlement() -> None:
+    key = _key("1h")
+    candle = _mvp_bar(key, datetime(2026, 8, 31, 1, 30, tzinfo=timezone.utc))
+    store = KlineStore(":memory:")
+    from kline.storage import EntitlementReceiptWrite, MvpRunWrite
+
+    receipt = store.commit_mvp_run(
+        MvpRunWrite(
+            run_id="run-1h",
+            manifest_version=key.manifest_version,
+            manifest_hash="a" * 64,
+            started_at="2026-08-31T00:00:00+00:00",
+            window_start="2026-08-30T00:00:00+00:00",
+            window_end="2026-08-31T00:00:00+00:00",
+            policy={"timeframe": "1h"},
+            candles=(candle,),
+            entitlement_receipts=(
+                EntitlementReceiptWrite(
+                    receipt_id="ent-1h",
+                    source_id=key.source_id,
+                    status="active",
+                    allowed_history={"hours": 24},
+                    timeframe_permissions=("1h",),
+                    persistence_allowed=True,
+                    derived_allowed=True,
+                    non_display_allowed=True,
+                    valid_from="2026-08-01",
+                    valid_to=None,
+                    evidence_ref="operator://1h",
+                    receipt_hash="b" * 64,
+                ),
+            ),
+        )
+    )
+    assert receipt.candle_count == 1
+    assert store.query_mvp_candles(key)[0].key.timeframe == "1h"
+
+
+def test_cn_15m_to_1h_aggregation_is_calendar_aware_and_auditable() -> None:
+    key = _key()
+    local = datetime(2026, 8, 31, 9, 30, tzinfo=timezone(timedelta(hours=8)))
+    rows = [_mvp_bar(key, local + timedelta(minutes=15 * i), i) for i in range(4)]
+
+    result = aggregate_15m_to_1h(
+        rows,
+        calendar_id="cn_a",
+        cutoff=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        run_id="run-1h-transform",
+    )
+
+    assert len(result.candles) == 1
+    assert result.candles[0].key.timeframe == "1h"
+    assert result.candles[0].volume == 46
+    assert result.candles[0].is_derived is True
+    assert result.transform_receipt is not None
+    assert result.transform_receipt.input_timeframe == "15m"
+    assert result.transform_receipt.output_timeframe == "1h"
+    assert result.transform_receipt.aggregation_rule_version == "cn_a_session_1h_v1"
+    assert result.transform_receipt.input_hash
+    assert result.transform_receipt.output_hash
+
+
+def test_quality_accepts_1h_and_detects_same_session_gap() -> None:
+    key = _key("1h")
+    first = _mvp_bar(key, datetime(2026, 8, 31, 1, 30, tzinfo=timezone.utc))
+    second = _mvp_bar(key, datetime(2026, 8, 31, 3, 15, tzinfo=timezone.utc), 1)
+
+    quality = assess_quality(
+        [first, second],
+        timeframe="1h",
+        calendar_id="cn_a",
+        cutoff=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+
+    assert quality.status == "partial"
+    assert any(issue.status == "gap" for issue in quality.issues)
+
+
+class _FakeTuShareClient:
+    def __init__(self) -> None:
+        self.minute_calls: list[dict[str, object]] = []
+
+    def stk_mins(self, **kwargs: object) -> pd.DataFrame:
+        self.minute_calls.append(kwargs)
+        return pd.DataFrame(
+            [
+                {
+                    "trade_time": "2026-08-31 09:30:00",
+                    "open": 100,
+                    "high": 102,
+                    "low": 99,
+                    "close": 101,
+                    "vol": 1000,
+                    "amount": 100000,
+                }
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_tushare_native_1h_requests_60min_and_keeps_identity() -> None:
+    client = _FakeTuShareClient()
+    entitlement = TuShareEntitlement(
+        allowed_timeframes=("15m", "1h", "4h", "1d", "1w"),
+        persistence_allowed=True,
+        derived_allowed=True,
+        non_display_allowed=True,
+        evidence_ref="operator://tushare-1h",
+        receipt_hash="c" * 64,
+    )
+    provider = TuShareMvpProvider(
+        "secret-token",
+        entitlement=entitlement,
+        client=client,
+        clock=lambda: datetime(2026, 9, 1, 8, tzinfo=timezone.utc),
+    )
+
+    candles = await provider.fetch("600519", Timeframe.HOUR_1)
+
+    assert len(candles) == 1
+    assert client.minute_calls[0]["freq"] == "60min"
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.timeframe_origin == "native"
+
+
+class _FakeUSClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def fetch_bars(
+        self, provider_symbol: str, timeframe: str, **kwargs: object
+    ) -> list[dict[str, object]]:
+        self.calls.append({"provider_symbol": provider_symbol, "timeframe": timeframe, **kwargs})
+        return [
+            {
+                "timestamp": "2026-08-31T13:30:00Z",
+                "open": 100,
+                "high": 102,
+                "low": 99,
+                "close": 101,
+                "volume": 1000,
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_authorized_us_accepts_native_1h() -> None:
+    client = _FakeUSClient()
+    entitlement = USDataEntitlement(
+        allowed_timeframes=("15m", "1h", "4h", "1d", "1w"),
+        persistence_allowed=True,
+        derived_allowed=True,
+        non_display_allowed=True,
+        evidence_ref="operator://us-1h",
+        receipt_hash="d" * 64,
+    )
+    provider = AuthorizedUSProvider(
+        "secret-us-token",
+        entitlement=entitlement,
+        client=client,
+        manifest=MANIFEST_PATH,
+        clock=lambda: datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+    )
+
+    candles = await provider.fetch("AAPL", Timeframe.HOUR_1)
+
+    assert len(candles) == 1
+    assert client.calls[0]["timeframe"] == "1h"
+    assert provider.timeframe_transform == TimeframeTransform(
+        raw_timeframe=Timeframe.HOUR_1,
+        timeframe_origin="native",
+        aggregation={"kind": "none", "rule": "native_passthrough"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingestion_persists_derived_1h_with_transform_receipt(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "ingestion-1h.db"))
+
+    class DerivedHourAdapter:
+        async def fetch_candles_with_receipt(
+            self,
+            ticker: str,
+            timeframe: Timeframe,
+            *,
+            start: str | None,
+            end: str | None,
+            limit: int,
+        ) -> FetchReceipt:
+            del start, end, limit
+            timestamps = {
+                Timeframe.MIN_15: "2026-08-31T00:00:00+00:00",
+                Timeframe.HOUR_1: "2026-08-31T00:00:00+00:00",
+                Timeframe.HOUR_4: "2026-08-31T00:00:00+00:00",
+                Timeframe.DAY: "2026-08-31T00:00:00+00:00",
+                Timeframe.WEEK: "2026-08-28T00:00:00+00:00",
+            }
+            candle = Candle(
+                timestamp=timestamps[timeframe],
+                open=100.0,
+                high=102.0,
+                low=99.0,
+                close=101.0,
+                volume=10.0,
+            )
+            transform = None
+            if timeframe == Timeframe.HOUR_1:
+                transform = TimeframeTransform(
+                    raw_timeframe=Timeframe.MIN_15,
+                    timeframe_origin="aggregated",
+                    aggregation={
+                        "rule": "utc_fixed_1h_v1",
+                        "bucket_anchor": "00:00",
+                        "partial_bucket_policy": "drop_and_record",
+                        "partial_bucket_count": 0,
+                    },
+                )
+            return FetchReceipt(
+                candles=[candle],
+                timeframe_transform=transform,
+                source_identity={"provider_symbol": ticker},
+                raw_response={"row_count": 1, "timeframe": timeframe.value},
+            )
+
+    adapter = DerivedHourAdapter()
+    receipt = await IngestionOrchestrator(
+        store,
+        adapter_resolver=lambda instrument: (
+            adapter if instrument.instrument_id == "CRYPTO.PERP.BTC" else None
+        ),
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-derived-1h",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            history_start="2026-08-31T00:00:00+00:00",
+            fetch_limit=10,
+        )
+    )
+
+    assert receipt.status == "partial"
+    assert any(
+        cell.instrument_id == "CRYPTO.PERP.BTC"
+        and cell.timeframe == "1h"
+        and cell.status == "ready"
+        for cell in receipt.requested_cells
+    )
+    key = CandleSeriesKey(
+        instrument_id="CRYPTO.PERP.BTC",
+        display_symbol="BTC",
+        provider_symbol="BTC",
+        source_id="hyperliquid_perpetual_public",
+        asset_class="crypto",
+        timeframe="1h",
+        adjustment_basis="raw_unadjusted",
+        manifest_version=manifest.version,
+    )
+    rows = store.query_mvp_candles(key)
+    assert len(rows) == 1
+    assert rows[0].is_derived is True
+    assert store.mvp_storage_health()["transform_receipts"] >= 1

--- a/tests/test_timeframe_1h.py
+++ b/tests/test_timeframe_1h.py
@@ -184,6 +184,45 @@ async def test_tushare_native_1h_requests_60min_and_keeps_identity() -> None:
     assert provider.timeframe_transform.timeframe_origin == "native"
 
 
+@pytest.mark.asyncio
+async def test_tushare_derives_1h_from_15m_when_native_permission_is_absent() -> None:
+    from tests.test_tushare_mvp import FakeTuShareClient, _entitlement, _minute_frame
+
+    local_times = [
+        *[
+            (datetime(2026, 8, 31, 9, 30) + timedelta(minutes=15 * index)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            for index in range(8)
+        ],
+        *[
+            (datetime(2026, 8, 31, 13, 0) + timedelta(minutes=15 * index)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            for index in range(8)
+        ],
+    ]
+    client = FakeTuShareClient(mins=_minute_frame(*local_times))
+    entitlement = _entitlement(
+        allowed_timeframes=("15m", "4h", "1d", "1w"),
+        derived_allowed=True,
+    )
+    provider = TuShareMvpProvider(
+        "secret-token",
+        entitlement=entitlement,
+        client=client,
+        clock=lambda: datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+
+    candles = await provider.fetch("600519", Timeframe.HOUR_1)
+
+    assert len(candles) == 4
+    assert client.minute_calls[0]["freq"] == "15min"
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.MIN_15
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
+
+
 class _FakeUSClient:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
@@ -232,6 +271,36 @@ async def test_authorized_us_accepts_native_1h() -> None:
         timeframe_origin="native",
         aggregation={"kind": "none", "rule": "native_passthrough"},
     )
+
+
+@pytest.mark.asyncio
+async def test_authorized_us_derives_1h_from_15m_when_native_permission_is_absent() -> None:
+    from tests.test_us_authorized import FakeUSClient, _bar, _entitlement
+
+    zone = timezone(timedelta(hours=-4))
+    start = datetime(2026, 8, 31, 9, 30, tzinfo=zone)
+    client = FakeUSClient(
+        [_bar((start + timedelta(minutes=15 * index)).isoformat()) for index in range(16)]
+    )
+    entitlement = _entitlement(
+        allowed_timeframes=("15m", "4h", "1d", "1w"),
+        derived_allowed=True,
+    )
+    provider = AuthorizedUSProvider(
+        "secret-us-token",
+        entitlement=entitlement,
+        client=client,
+        manifest=MANIFEST_PATH,
+        clock=lambda: datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+
+    candles = await provider.fetch("AAPL", Timeframe.HOUR_1)
+
+    assert len(candles) == 4
+    assert client.calls[0]["timeframe"] == "15m"
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.raw_timeframe == Timeframe.MIN_15
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
- Add `1h` to the MVP manifest, storage, entitlement, worker, serving, and receipt contracts while keeping `30m` excluded.
- Add calendar-aware 15m→1h aggregation with transform receipts and native/derived provider paths.
- Persist the transform receipt ID on derived candles and reject derived writes without a matching receipt.
- Extend TuShare, authorized-US, and Hyperliquid capability seams; add a human-readable 1h contract receipt.

## Why
The approved Health Dashboard contract needs an independent health cell for 1h, and the data layer must distinguish native hourly observations from hourly bars derived from 15m.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 243 passed
- Ruff checks on all changed Python files → passed
- `git diff --check` → passed
- `gitleaks detect --no-banner --redact --source .` → no leaks
- New tests cover manifest state, SQLite 1h persistence/entitlement, calendar aggregation, quality gaps, TuShare native/derived 1h, authorized-US native/derived 1h, Hyperliquid native 1h, ingestion promotion, and transform receipt links.
- Two-axis code review: no hard standards issues; no remaining spec findings.

## Safety
Source entitlement is still explicit; unlicensed/unsupported cells remain blocked/unavailable. No Dashboard UI, provider purchase, public redistribution, NAS migration, trading path, or legacy data deletion.

Closes #68