### PR TITLE
feat: ship Chinese 3+3 health matrix dashboard

### DIFF
--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -353,7 +353,10 @@ def _resolve_policy(
             source_meta(normalized_fallback, asset_class)
         except (KeyError, ValueError) as error:
             raise ValueError(f"Invalid fallback source: {fallback_source}") from error
-        if normalized_fallback != normalized_source and normalized_fallback not in normalized_fallbacks:
+        if (
+            normalized_fallback != normalized_source
+            and normalized_fallback not in normalized_fallbacks
+        ):
             normalized_fallbacks.append(normalized_fallback)
     if resolved_fallback_policy == FallbackPolicy.EXPLICIT and not normalized_fallbacks:
         raise ValueError("fallback sources must differ from the primary source")
@@ -447,9 +450,7 @@ async def _fetch_upstream_candles(
         last_provider_symbol = selected_ticker
         selected_manifest = source_manifest(selected_source, asset_class)
         if not selected_manifest.supports_timeframe(selected_ticker, timeframe):
-            detail = (
-                f"unsupported symbol/timeframe {selected_ticker}/{timeframe.value}"
-            )
+            detail = f"unsupported symbol/timeframe {selected_ticker}/{timeframe.value}"
             last_error = ProviderError(detail)
             last_error_source = selected_source
             last_error_symbol = selected_ticker
@@ -527,9 +528,7 @@ async def _fetch_upstream_candles(
                 served_from="upstream",
                 raw_response=raw_snapshot,
             )
-        report = analyze_candles(
-            candles, timeframe, selected_meta, strict=policy.strict_quality
-        )
+        report = analyze_candles(candles, timeframe, selected_meta, strict=policy.strict_quality)
         last_report = report
         if policy.cache_policy != CachePolicy.BYPASS:
             get_store().save_source_observation(
@@ -574,9 +573,9 @@ async def _fetch_upstream_candles(
             access_issues=failures if selected_source != policy.source else [],
             timeframe_transform=last_transform,
             source_identity=last_identity,
-            instrument_id=source_manifest(
-                selected_source, asset_class
-            ).canonical_instrument_id(ticker),
+            instrument_id=source_manifest(selected_source, asset_class).canonical_instrument_id(
+                ticker
+            ),
         )
 
     if last_error:
@@ -694,11 +693,11 @@ async def get_candles(
                 requested_source=source,
                 cache_policy=cache_policy,
                 quality_policy=quality,
-                    fallback_policy=fallback_policy,
-                    require_execution_venue=require_execution_venue,
-                    provider_symbol=ticker,
-                    source_identity={"requested_ticker": ticker, "timeframe": timeframe.value},
-                    reject_reason="invalid_policy",
+                fallback_policy=fallback_policy,
+                require_execution_venue=require_execution_venue,
+                provider_symbol=ticker,
+                source_identity={"requested_ticker": ticker, "timeframe": timeframe.value},
+                reject_reason="invalid_policy",
                 access_issues=[str(e)],
                 timeframe=timeframe,
             ).model_dump(),
@@ -786,9 +785,9 @@ async def get_candles(
                 meta,
                 served_from="cache",
                 policy=policy,
-                instrument_id=source_manifest(
-                    policy.source, asset_class
-                ).canonical_instrument_id(requested_ticker),
+                instrument_id=source_manifest(policy.source, asset_class).canonical_instrument_id(
+                    requested_ticker
+                ),
             )
         if policy.cache_policy == CachePolicy.REQUIRE:
             raise _error(
@@ -876,12 +875,15 @@ async def stream_candles(
         )
         await websocket.close(code=1011)
 
-
         return
 
     try:
         async for candle in adapter.stream_candles(ticker, timeframe):
-            if policy.cache_policy != CachePolicy.BYPASS and timeframe not in (Timeframe.DAY, Timeframe.HOUR_4, Timeframe.WEEK):
+            if policy.cache_policy != CachePolicy.BYPASS and timeframe not in (
+                Timeframe.DAY,
+                Timeframe.HOUR_4,
+                Timeframe.WEEK,
+            ):
                 get_store().save(
                     ticker,
                     asset_class,
@@ -987,7 +989,9 @@ async def compare_sources(
             normalized = normalize_source(source, asset_class)
             source_meta(normalized, asset_class)
         except (KeyError, ValueError) as error:
-            raise HTTPException(status_code=400, detail=f"Invalid comparison source: {source}") from error
+            raise HTTPException(
+                status_code=400, detail=f"Invalid comparison source: {source}"
+            ) from error
         if normalized not in normalized_sources:
             normalized_sources.append(normalized)
     if len(normalized_sources) < 2:
@@ -1103,5 +1107,9 @@ async def mvp_health_matrix() -> dict:
     except Exception as error:
         raise HTTPException(
             status_code=503,
-            detail={"error": "dashboard_unavailable", "detail": type(error).__name__},
+            detail={
+                "error": "dashboard_unavailable",
+                "detail": type(error).__name__,
+                "last_success_at": None,
+            },
         ) from error

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from time import monotonic
 from typing import Any, Mapping
 
@@ -20,6 +21,8 @@ from kline.models import (
     TimeframeTransform,
     InstrumentDefinition,
 )
+from kline.health_matrix import build_mvp_health_matrix
+from kline.mvp_manifest import load_manifest
 from kline.ports import MarketDataPort
 from kline.providers.base import ProviderError
 from kline.provenance import (
@@ -1087,3 +1090,18 @@ async def health() -> dict:
         "storage_coverage": coverage,
         "latest_observations": get_store().latest_source_observations(),
     }
+
+
+@router.get("/mvp/health/matrix")
+async def mvp_health_matrix() -> dict:
+    """Return the source-aware MVP asset × timeframe health matrix."""
+
+    manifest_path = Path(__file__).resolve().parents[2] / "configs" / "mvp_manifest.json"
+    try:
+        manifest = load_manifest(manifest_path)
+        return build_mvp_health_matrix(manifest, get_store())
+    except Exception as error:
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "dashboard_unavailable", "detail": type(error).__name__},
+        ) from error

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -353,10 +353,7 @@ def _resolve_policy(
             source_meta(normalized_fallback, asset_class)
         except (KeyError, ValueError) as error:
             raise ValueError(f"Invalid fallback source: {fallback_source}") from error
-        if (
-            normalized_fallback != normalized_source
-            and normalized_fallback not in normalized_fallbacks
-        ):
+        if normalized_fallback != normalized_source and normalized_fallback not in normalized_fallbacks:
             normalized_fallbacks.append(normalized_fallback)
     if resolved_fallback_policy == FallbackPolicy.EXPLICIT and not normalized_fallbacks:
         raise ValueError("fallback sources must differ from the primary source")
@@ -450,7 +447,9 @@ async def _fetch_upstream_candles(
         last_provider_symbol = selected_ticker
         selected_manifest = source_manifest(selected_source, asset_class)
         if not selected_manifest.supports_timeframe(selected_ticker, timeframe):
-            detail = f"unsupported symbol/timeframe {selected_ticker}/{timeframe.value}"
+            detail = (
+                f"unsupported symbol/timeframe {selected_ticker}/{timeframe.value}"
+            )
             last_error = ProviderError(detail)
             last_error_source = selected_source
             last_error_symbol = selected_ticker
@@ -528,7 +527,9 @@ async def _fetch_upstream_candles(
                 served_from="upstream",
                 raw_response=raw_snapshot,
             )
-        report = analyze_candles(candles, timeframe, selected_meta, strict=policy.strict_quality)
+        report = analyze_candles(
+            candles, timeframe, selected_meta, strict=policy.strict_quality
+        )
         last_report = report
         if policy.cache_policy != CachePolicy.BYPASS:
             get_store().save_source_observation(
@@ -573,9 +574,9 @@ async def _fetch_upstream_candles(
             access_issues=failures if selected_source != policy.source else [],
             timeframe_transform=last_transform,
             source_identity=last_identity,
-            instrument_id=source_manifest(selected_source, asset_class).canonical_instrument_id(
-                ticker
-            ),
+            instrument_id=source_manifest(
+                selected_source, asset_class
+            ).canonical_instrument_id(ticker),
         )
 
     if last_error:
@@ -693,11 +694,11 @@ async def get_candles(
                 requested_source=source,
                 cache_policy=cache_policy,
                 quality_policy=quality,
-                fallback_policy=fallback_policy,
-                require_execution_venue=require_execution_venue,
-                provider_symbol=ticker,
-                source_identity={"requested_ticker": ticker, "timeframe": timeframe.value},
-                reject_reason="invalid_policy",
+                    fallback_policy=fallback_policy,
+                    require_execution_venue=require_execution_venue,
+                    provider_symbol=ticker,
+                    source_identity={"requested_ticker": ticker, "timeframe": timeframe.value},
+                    reject_reason="invalid_policy",
                 access_issues=[str(e)],
                 timeframe=timeframe,
             ).model_dump(),
@@ -785,9 +786,9 @@ async def get_candles(
                 meta,
                 served_from="cache",
                 policy=policy,
-                instrument_id=source_manifest(policy.source, asset_class).canonical_instrument_id(
-                    requested_ticker
-                ),
+                instrument_id=source_manifest(
+                    policy.source, asset_class
+                ).canonical_instrument_id(requested_ticker),
             )
         if policy.cache_policy == CachePolicy.REQUIRE:
             raise _error(
@@ -875,15 +876,12 @@ async def stream_candles(
         )
         await websocket.close(code=1011)
 
+
         return
 
     try:
         async for candle in adapter.stream_candles(ticker, timeframe):
-            if policy.cache_policy != CachePolicy.BYPASS and timeframe not in (
-                Timeframe.DAY,
-                Timeframe.HOUR_4,
-                Timeframe.WEEK,
-            ):
+            if policy.cache_policy != CachePolicy.BYPASS and timeframe not in (Timeframe.DAY, Timeframe.HOUR_4, Timeframe.WEEK):
                 get_store().save(
                     ticker,
                     asset_class,
@@ -989,9 +987,7 @@ async def compare_sources(
             normalized = normalize_source(source, asset_class)
             source_meta(normalized, asset_class)
         except (KeyError, ValueError) as error:
-            raise HTTPException(
-                status_code=400, detail=f"Invalid comparison source: {source}"
-            ) from error
+            raise HTTPException(status_code=400, detail=f"Invalid comparison source: {source}") from error
         if normalized not in normalized_sources:
             normalized_sources.append(normalized)
     if len(normalized_sources) < 2:

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -140,6 +140,13 @@ def _redacted_value(value: Any) -> Any:
     return value
 
 
+def _safe_run(run: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(run)
+    if payload.get("error"):
+        payload["error"] = _redacted_error(str(payload["error"]), code="run_error")
+    return payload
+
+
 def _manifest_entitlement(instrument: ManifestInstrument) -> dict[str, Any]:
     blocked = instrument.source_status == "blocked_for_entitlement"
     return {
@@ -207,7 +214,7 @@ def _cell(
         "duplicates": int(quality.get("duplicates", 0)) if quality else 0,
         "invalid_rows": int(quality.get("invalid_rows", 0)) if quality else 0,
         "blocked_cells": int(quality.get("blocked_cells", 0)) if quality else 0,
-        "details": quality.get("details", {}) if quality else {},
+        "details": _redacted_value(quality.get("details", {})) if quality else {},
     }
     if quality is None:
         quality_payload["status"] = "missing"
@@ -440,11 +447,14 @@ def build_mvp_health_matrix(
     coverage = _status_counts(cells)
     statuses = {str(cell["status"]) for cell in cells if cell["applicability"] == "applicable"}
     latest_runs = storage.latest_mvp_runs(limit=6) if hasattr(storage, "latest_mvp_runs") else []
+    latest_runs = [_safe_run(run) for run in latest_runs]
     latest_run = (
         latest_runs[0]
         if latest_runs
         else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
     )
+    if latest_run is not None:
+        latest_run = _safe_run(latest_run)
     storage_health = storage.mvp_storage_health() if hasattr(storage, "mvp_storage_health") else {}
     backup = storage.latest_mvp_backup() if hasattr(storage, "latest_mvp_backup") else None
     infrastructure_status = "ready" if storage_health.get("status") in {"ok", "ready"} else "failed"

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -279,11 +279,11 @@ def _worker_payload(
     )
     last_activity = (latest.get("completed_at") or latest.get("started_at")) if latest else None
     parsed_activity = _parse_timestamp(last_activity)
-    next_due = (
-        _iso(parsed_activity + timedelta(seconds=interval_seconds))
-        if parsed_activity is not None
-        else None
-    )
+    next_due = None
+    if parsed_activity is not None:
+        due = parsed_activity + timedelta(seconds=interval_seconds)
+        reference = now.astimezone(timezone.utc)
+        next_due = _iso(max(due, reference))
     return {
         "status": "idle" if latest is None else "last_run",
         "last_attempt_at": latest.get("started_at") if latest else None,

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -1,0 +1,495 @@
+"""Read-only asset × timeframe health read model for the MVP dashboard."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from kline.mvp_manifest import MvpManifest, ManifestInstrument, manifest_digest
+from kline.storage import StoragePort
+
+
+MATRIX_TIMEFRAMES = ("15m", "1h", "4h", "1d", "1w")
+MATRIX_STATUSES = ("ready", "partial", "stale", "failed", "blocked", "unavailable")
+POLL_INTERVAL_SECONDS = 30
+REQUEST_TIMEOUT_SECONDS = 10
+SNAPSHOT_MAX_AGE_SECONDS = 900
+# These six identities are the approved #69 vertical slice.  The runtime
+# manifest remains the authority for their fields; #70 will widen this scope
+# to every manifest instrument without changing the cell schema.
+MVP_DEMO_INSTRUMENT_IDS = (
+    "CN.A.600519",
+    "CN.A.300750",
+    "CN.A.688981",
+    "US.EQ.AAPL",
+    "US.EQ.NVDA",
+    "US.EQ.TSLA",
+)
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _status_counts(cells: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    coverage: dict[str, dict[str, Any]] = {}
+    for timeframe in MATRIX_TIMEFRAMES:
+        states = {"applicable": 0, "not_applicable": 0, **{status: 0 for status in MATRIX_STATUSES}}
+        for cell in cells:
+            if cell["timeframe"] != timeframe:
+                continue
+            if cell["applicability"] == "not_applicable":
+                states["not_applicable"] += 1
+            else:
+                states["applicable"] += 1
+                states[cell["status"]] += 1
+        states["ratio"] = (
+            round(states["ready"] / states["applicable"], 4) if states["applicable"] else None
+        )
+        coverage[timeframe] = states
+    return coverage
+
+
+def _key(row: Mapping[str, Any]) -> tuple[str, str, str, str, str]:
+    return (
+        str(row.get("source_id") or ""),
+        str(row.get("instrument_id") or ""),
+        str(row.get("timeframe") or ""),
+        str(row.get("adjustment_basis") or "raw_unadjusted"),
+        str(row.get("manifest_version") or ""),
+    )
+
+
+def _freshness_stale(
+    instrument: ManifestInstrument,
+    timeframe: str,
+    latest_timestamp: str | None,
+    *,
+    now: datetime,
+) -> bool:
+    """Apply a conservative SLA for continuous/futures cells.
+
+    Session markets are not marked stale solely because they are closed; their
+    next run is determined by the worker/calendar contract. Continuous assets
+    use the same grace values as the approved dashboard spec.
+    """
+
+    if instrument.calendar_id not in {"crypto_24x7", "us_futures"}:
+        return False
+    latest = _parse_timestamp(latest_timestamp)
+    if latest is None:
+        return False
+    grace = {
+        "15m": timedelta(minutes=45),
+        "1h": timedelta(minutes=90),
+        "4h": timedelta(hours=5),
+        "1d": timedelta(hours=26),
+        "1w": timedelta(days=8),
+    }[timeframe]
+    return latest + grace < now.astimezone(timezone.utc)
+
+
+def _redacted_error(error: str | None, *, code: str = "source_error") -> dict[str, Any] | None:
+    if not error:
+        return None
+    text = str(error)
+    lower = text.lower()
+    for marker in ("token", "api_key", "apikey", "secret", "password"):
+        start = lower.find(marker)
+        if start >= 0:
+            end = text.find(" ", start)
+            text = f"{text[:start]}{marker}=<redacted>{text[end:] if end >= 0 else ''}"
+            lower = text.lower()
+    return {
+        "code": code,
+        "message": text[:500],
+        "redacted_raw": text[:500],
+        "next_step": "inspect the run receipt",
+    }
+
+
+def _redacted_value(value: Any) -> Any:
+    """Keep persisted policy details useful without exposing credentials."""
+
+    sensitive = ("token", "api_key", "apikey", "secret", "password", "authorization")
+    if isinstance(value, Mapping):
+        return {
+            str(key): "<redacted>"
+            if any(marker in str(key).lower() for marker in sensitive)
+            else _redacted_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redacted_value(item) for item in value]
+    if isinstance(value, str) and any(marker in value.lower() for marker in sensitive):
+        return "<redacted>"
+    return value
+
+
+def _manifest_entitlement(instrument: ManifestInstrument) -> dict[str, Any]:
+    blocked = instrument.source_status == "blocked_for_entitlement"
+    return {
+        "status": "blocked" if blocked else "unverified",
+        "persistence_allowed": False if blocked else None,
+        "derived_allowed": False if blocked else None,
+        "non_display_allowed": False if blocked else None,
+        "evidence_ref": "manifest://blocked" if blocked else "operator_review_required",
+    }
+
+
+def _cell(
+    instrument: ManifestInstrument,
+    timeframe: str,
+    *,
+    status: str,
+    reason: str,
+    latest: Mapping[str, Any] | None,
+    observation: Mapping[str, Any] | None,
+    quality: Mapping[str, Any] | None,
+    transform: Mapping[str, Any] | None,
+    watermark: Mapping[str, Any] | None,
+    now: datetime,
+) -> dict[str, Any]:
+    applicable = (
+        timeframe in instrument.required_timeframes
+        or timeframe in instrument.blocked_timeframes
+        or instrument.source_status == "blocked_for_entitlement"
+    ) and timeframe not in instrument.not_applicable_timeframes
+    if not applicable:
+        return {
+            "instrument_id": instrument.instrument_id,
+            "display_symbol": instrument.display_symbol,
+            "display_name": instrument.display_name,
+            "provider_symbol": None,
+            "asset_class": instrument.asset_class,
+            "source_id": None,
+            "source_mode": None,
+            "entitlement": None,
+            "timeframe": timeframe,
+            "applicability": "not_applicable",
+            "status": "not_applicable",
+            "status_reason": "timeframe_not_required",
+            "latest_closed_timestamp": None,
+            "row_count": 0,
+            "is_derived": None,
+            "transform": None,
+            "last_attempt_at": None,
+            "last_success_at": None,
+            "run_id": None,
+            "policy": None,
+            "coverage": None,
+            "quality": None,
+            "watermark": None,
+            "error": None,
+        }
+
+    latest_timestamp = latest.get("latest_timestamp") if latest else None
+    last_attempt = observation.get("observed_at") if observation else None
+    last_success = last_attempt if observation and observation.get("success") else None
+    policy = _redacted_value(observation.get("policy")) if observation else None
+    quality_payload = {
+        "status": quality.get("status") if quality else None,
+        "gaps": int(quality.get("gaps", 0)) if quality else 0,
+        "duplicates": int(quality.get("duplicates", 0)) if quality else 0,
+        "invalid_rows": int(quality.get("invalid_rows", 0)) if quality else 0,
+        "blocked_cells": int(quality.get("blocked_cells", 0)) if quality else 0,
+        "details": quality.get("details", {}) if quality else {},
+    }
+    if quality is None:
+        quality_payload["status"] = "missing"
+    error = _redacted_error(
+        (observation or {}).get("error"),
+        code="source_error" if observation and not observation.get("success") else "quality_error",
+    )
+    if error is None and status in {"failed", "blocked"}:
+        error = {
+            "code": reason,
+            "message": reason,
+            "redacted_raw": reason,
+            "next_step": "inspect the source entitlement or run receipt",
+        }
+    derived = bool(transform) or timeframe in {"4h", "1w"}
+    run_id = (
+        (observation or {}).get("run_id")
+        or (quality or {}).get("run_id")
+        or (watermark or {}).get("run_id")
+        or (transform or {}).get("run_id")
+    )
+    return {
+        "instrument_id": instrument.instrument_id,
+        "display_symbol": instrument.display_symbol,
+        "display_name": instrument.display_name,
+        "provider_symbol": instrument.provider_symbol,
+        "asset_class": instrument.asset_class,
+        "source_id": instrument.source_id,
+        "source_mode": instrument.source_id,
+        "entitlement": _manifest_entitlement(instrument),
+        "timeframe": timeframe,
+        "applicability": "applicable",
+        "status": status,
+        "status_reason": reason,
+        "latest_closed_timestamp": latest_timestamp,
+        "row_count": int(latest.get("row_count", 0)) if latest else 0,
+        "is_derived": derived,
+        "transform": dict(transform) if transform else None,
+        "last_attempt_at": last_attempt,
+        "last_success_at": last_success,
+        "run_id": run_id,
+        "policy": policy,
+        "coverage": {
+            "expected_bars": None,
+            "stored_bars": int(latest.get("row_count", 0)) if latest else 0,
+            "ratio": None,
+        },
+        "quality": quality_payload,
+        "watermark": dict(watermark) if watermark else None,
+        "error": error,
+    }
+
+
+def _worker_payload(
+    storage: StoragePort, *, now: datetime, interval_seconds: int
+) -> dict[str, Any]:
+    runs = storage.latest_mvp_runs(limit=6) if hasattr(storage, "latest_mvp_runs") else []
+    latest = (
+        runs[0]
+        if runs
+        else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
+    )
+    last_activity = (latest.get("completed_at") or latest.get("started_at")) if latest else None
+    parsed_activity = _parse_timestamp(last_activity)
+    next_due = (
+        _iso(parsed_activity + timedelta(seconds=interval_seconds))
+        if parsed_activity is not None
+        else None
+    )
+    return {
+        "status": "idle" if latest is None else "last_run",
+        "last_attempt_at": latest.get("started_at") if latest else None,
+        "last_success_at": latest.get("completed_at")
+        if latest and latest.get("status") == "success"
+        else None,
+        "last_run_id": latest.get("run_id") if latest else None,
+        "next_due_at": next_due,
+        "interval_seconds": interval_seconds,
+    }
+
+
+def build_mvp_health_matrix(
+    manifest: MvpManifest,
+    storage: StoragePort,
+    *,
+    now: datetime | None = None,
+    interval_seconds: int = 4 * 60 * 60,
+    instrument_ids: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Build the bounded source-aware matrix from persisted facts only.
+
+    The default is the approved #69 3+3 slice.  Callers may pass an explicit
+    manifest identity list for deterministic tests or the later full-manifest
+    expansion; unknown identities fail closed instead of silently shrinking
+    the requested matrix.
+    """
+
+    observed_at = now or datetime.now(timezone.utc)
+    selected_ids = tuple(instrument_ids or MVP_DEMO_INSTRUMENT_IDS)
+    by_id = {instrument.instrument_id: instrument for instrument in manifest.instruments}
+    missing_ids = [instrument_id for instrument_id in selected_ids if instrument_id not in by_id]
+    if missing_ids:
+        raise ValueError(f"matrix instruments missing from manifest: {', '.join(missing_ids)}")
+    selected_instruments = [by_id[instrument_id] for instrument_id in selected_ids]
+    latest_rows = (
+        storage.mvp_latest_closed_bars() if hasattr(storage, "mvp_latest_closed_bars") else []
+    )
+    observations = (
+        storage.latest_mvp_source_observations()
+        if hasattr(storage, "latest_mvp_source_observations")
+        else []
+    )
+    qualities = (
+        storage.latest_mvp_quality_receipts()
+        if hasattr(storage, "latest_mvp_quality_receipts")
+        else []
+    )
+    transforms = (
+        storage.latest_mvp_transform_receipts()
+        if hasattr(storage, "latest_mvp_transform_receipts")
+        else []
+    )
+    watermarks = (
+        storage.latest_mvp_watermarks() if hasattr(storage, "latest_mvp_watermarks") else []
+    )
+    latest_map = {_key(row): row for row in latest_rows}
+    observation_map = {_key(row): row for row in observations}
+    quality_map = {_key(row): row for row in qualities}
+    transform_map = {
+        (
+            str(row.get("source_id") or ""),
+            str(row.get("instrument_id") or ""),
+            str(row.get("output_timeframe") or ""),
+            "raw_unadjusted",
+            str(row.get("manifest_version") or ""),
+        ): row
+        for row in transforms
+    }
+    watermark_map = {_key(row): row for row in watermarks}
+
+    cells: list[dict[str, Any]] = []
+    for instrument in selected_instruments:
+        for timeframe in MATRIX_TIMEFRAMES:
+            key = (
+                instrument.source_id,
+                instrument.instrument_id,
+                timeframe,
+                instrument.adjustment_basis,
+                manifest.version,
+            )
+            latest = latest_map.get(key)
+            observation = observation_map.get(key)
+            quality = quality_map.get(key)
+            transform = transform_map.get(key)
+            watermark = watermark_map.get(key)
+            if timeframe in instrument.not_applicable_timeframes:
+                cells.append(
+                    _cell(
+                        instrument,
+                        timeframe,
+                        status="not_applicable",
+                        reason="timeframe_not_required",
+                        latest=None,
+                        observation=None,
+                        quality=None,
+                        transform=None,
+                        watermark=None,
+                        now=observed_at,
+                    )
+                )
+                continue
+            if (
+                instrument.source_status == "blocked_for_entitlement"
+                or timeframe in instrument.blocked_timeframes
+            ):
+                status, reason = "blocked", "entitlement_blocked"
+            elif timeframe not in instrument.required_timeframes:
+                cells.append(
+                    _cell(
+                        instrument,
+                        timeframe,
+                        status="not_applicable",
+                        reason="timeframe_not_required",
+                        latest=None,
+                        observation=None,
+                        quality=None,
+                        transform=None,
+                        watermark=None,
+                        now=observed_at,
+                    )
+                )
+                continue
+            elif observation and not observation.get("success"):
+                status, reason = "failed", "source_observation_failed"
+            elif quality and quality.get("status") == "blocked":
+                status, reason = "blocked", "quality_blocked"
+            elif quality and quality.get("status") == "fail":
+                status, reason = "failed", "quality_failed"
+            elif latest is None:
+                status, reason = "unavailable", "no_persisted_closed_bar"
+            elif timeframe in {"4h", "1w"} and transform is None:
+                status, reason = "partial", "transform_receipt_missing"
+            elif quality is None:
+                status, reason = "partial", "quality_receipt_missing"
+            elif _freshness_stale(
+                instrument, timeframe, latest.get("latest_timestamp"), now=observed_at
+            ):
+                status, reason = "stale", "freshness_sla_exceeded"
+            elif quality.get("status") == "partial":
+                status, reason = "partial", "quality_partial"
+            elif watermark is None:
+                status, reason = "partial", "watermark_missing"
+            else:
+                status, reason = "ready", "closed_bar_quality_passed"
+            cells.append(
+                _cell(
+                    instrument,
+                    timeframe,
+                    status=status,
+                    reason=reason,
+                    latest=latest,
+                    observation=observation,
+                    quality=quality,
+                    transform=transform,
+                    watermark=watermark,
+                    now=observed_at,
+                )
+            )
+
+    coverage = _status_counts(cells)
+    statuses = {str(cell["status"]) for cell in cells if cell["applicability"] == "applicable"}
+    latest_runs = storage.latest_mvp_runs(limit=6) if hasattr(storage, "latest_mvp_runs") else []
+    latest_run = (
+        latest_runs[0]
+        if latest_runs
+        else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
+    )
+    storage_health = storage.mvp_storage_health() if hasattr(storage, "mvp_storage_health") else {}
+    backup = storage.latest_mvp_backup() if hasattr(storage, "latest_mvp_backup") else None
+    infrastructure_status = "ready" if storage_health.get("status") in {"ok", "ready"} else "failed"
+    if infrastructure_status == "failed" or statuses.intersection({"failed", "blocked"}):
+        overall = "failed"
+    elif statuses.intersection({"partial", "stale", "unavailable"}):
+        overall = "partial"
+    else:
+        overall = "ready"
+    universes: dict[str, int] = {}
+    for instrument in selected_instruments:
+        universes[instrument.universe] = universes.get(instrument.universe, 0) + 1
+    return {
+        "status": overall,
+        "as_of": _iso(observed_at),
+        "manifest_version": manifest.version,
+        "manifest_hash": manifest_digest(manifest),
+        "scope": {
+            "name": "demo_3x3",
+            "instrument_count": len(selected_instruments),
+            "universes": universes,
+        },
+        "refresh": {
+            "poll_interval_seconds": 30,
+            "request_timeout_seconds": 10,
+            "last_success_at": _iso(observed_at),
+            "snapshot_age_seconds": 0,
+            "snapshot_max_age_seconds": 900,
+        },
+        "worker": _worker_payload(storage, now=observed_at, interval_seconds=interval_seconds),
+        "runs": latest_runs or ([latest_run] if latest_run else []),
+        "infrastructure": {
+            "worker": _worker_payload(storage, now=observed_at, interval_seconds=interval_seconds),
+            "database": {
+                "status": infrastructure_status,
+                "path": "redacted",
+                "filesystem": "local",
+            },
+            "ssd_mount_guard": {"status": "not_observed", "volume_id": "redacted"},
+            "nas_backup": {
+                "status": backup.get("status", "pending") if backup else "pending",
+                "last_backup_at": backup.get("created_at") if backup else None,
+                "restore_verified": bool(backup and backup.get("restore_verified")),
+            },
+        },
+        "coverage": coverage,
+        "cells": cells,
+    }

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -1,4 +1,4 @@
-"""Small browser-visible source health and provenance surface."""
+"""Chinese, read-only browser surface for the MVP health matrix."""
 
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
@@ -8,67 +8,270 @@ router = APIRouter()
 
 @router.get("/health-ui", response_class=HTMLResponse, include_in_schema=False)
 async def health_ui() -> str:
+    """Serve the dashboard shell; all facts are fetched from the matrix API."""
+
     return """<!doctype html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Datafeed Source Health</title>
+  <title>市场数据健康监控</title>
   <style>
-    :root { color-scheme: dark; --bg:#091019; --panel:#101a26; --line:#253447;
-      --text:#e8f0f7; --muted:#8ea2b7; --ok:#39d98a; --bad:#ff6b6b; --accent:#58a6ff; }
-    * { box-sizing:border-box } body { margin:0; background:var(--bg); color:var(--text);
-      font:14px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif; }
-    main { max-width:1180px; margin:0 auto; padding:32px 24px 48px; }
-    header { display:flex; justify-content:space-between; gap:24px; align-items:end; margin-bottom:24px; }
-    h1 { font-size:27px; margin:0 0 6px } p { margin:0; color:var(--muted) }
-    .stamp { text-align:right; color:var(--muted) } .grid { display:grid;
-      grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:12px; margin-bottom:28px; }
-    .card { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:16px; }
-    .row { display:flex; justify-content:space-between; gap:12px; align-items:center; }
-    .source { font-weight:700; font-size:15px } .pill { border-radius:999px; padding:3px 8px;
-      font-size:12px; background:#1b2938; color:var(--muted) }
-    .pill.ok { color:var(--ok); background:#0e2b22 } .pill.bad { color:var(--bad); background:#341b20 }
-    dl { display:grid; grid-template-columns:1fr auto; gap:7px 12px; margin:14px 0 0 }
-    dt { color:var(--muted) } dd { margin:0; text-align:right; max-width:190px; overflow:hidden;
-      text-overflow:ellipsis; white-space:nowrap }
-    h2 { font-size:17px; margin:0 0 12px } table { width:100%; border-collapse:collapse;
-      background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
-    th,td { padding:11px 12px; border-bottom:1px solid var(--line); text-align:left }
-    th { color:var(--muted); font-size:12px; font-weight:600 } tr:last-child td { border:0 }
-    .empty { color:var(--muted); padding:20px } .error { color:var(--bad) }
+    :root {
+      color-scheme: dark;
+      --bg:#08111b; --panel:#101d2a; --panel-2:#0d1824; --line:#24364a;
+      --text:#e8f1f8; --muted:#8da3b8; --accent:#67b7ff; --accent-2:#9a8cff;
+      --ok:#42d392; --partial:#ffc857; --stale:#f4a261; --bad:#ff6b78;
+    }
+    * { box-sizing:border-box }
+    body { margin:0; background:radial-gradient(circle at 10% 0%,#13263a 0,#08111b 40%);
+      color:var(--text); font:14px/1.5 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif; }
+    main { max-width:1500px; margin:0 auto; padding:28px 24px 54px }
+    header { display:flex; justify-content:space-between; gap:20px; align-items:flex-start; margin-bottom:18px }
+    .eyebrow { color:var(--accent); font-size:12px; letter-spacing:.08em; text-transform:uppercase; margin-bottom:6px }
+    h1 { margin:0 0 6px; font-size:30px; letter-spacing:-.02em }
+    h2 { margin:0 0 12px; font-size:17px }
+    p { margin:0; color:var(--muted) }
+    .header-meta { min-width:230px; text-align:right; color:var(--muted); font-size:12px }
+    .header-meta strong { display:block; color:var(--text); font-size:14px; margin-bottom:4px }
+    .banner { position:sticky; top:10px; z-index:5; display:none; margin:0 0 18px;
+      padding:12px 14px; border:1px solid #71404a; border-radius:10px; background:#321b25; color:#ffdce1; }
+    .banner.warn { border-color:#80652d; background:#332c18; color:#ffe5a5; }
+    .banner.show { display:flex; align-items:center; gap:10px }
+    .banner .dot { width:9px; height:9px; flex:none; border-radius:50%; background:var(--bad); box-shadow:0 0 14px var(--bad) }
+    .banner.warn .dot { background:var(--partial); box-shadow:0 0 14px var(--partial) }
+    .toolbar { display:flex; flex-wrap:wrap; justify-content:space-between; gap:12px; align-items:center;
+      margin-bottom:18px; padding:11px 14px; background:rgba(16,29,42,.8); border:1px solid var(--line); border-radius:10px; }
+    .toolbar span { color:var(--muted); font-size:12px }
+    .toolbar select { border:1px solid var(--line); border-radius:7px; padding:7px 10px; background:var(--panel-2); color:var(--text) }
+    .coverage-grid { display:grid; grid-template-columns:repeat(5,minmax(155px,1fr)); gap:10px; margin-bottom:26px }
+    .card { background:linear-gradient(145deg,rgba(16,29,42,.98),rgba(12,23,34,.98)); border:1px solid var(--line); border-radius:12px; padding:14px }
+    .coverage-card { min-height:116px }
+    .coverage-card .label { color:var(--muted); font-size:12px }
+    .coverage-card .ratio { display:flex; align-items:baseline; gap:7px; margin:8px 0 4px }
+    .coverage-card .ratio strong { font-size:26px; letter-spacing:-.03em }
+    .coverage-card .ratio span { color:var(--muted); font-size:12px }
+    .coverage-card .counts { color:var(--muted); font-size:12px }
+    .progress { height:4px; border-radius:99px; background:#1b2b3b; overflow:hidden; margin-top:11px }
+    .progress i { display:block; height:100%; border-radius:inherit; background:linear-gradient(90deg,var(--accent),var(--accent-2)); }
+    .section { margin-top:24px }
+    .section-head { display:flex; justify-content:space-between; align-items:baseline; gap:12px; margin-bottom:12px }
+    .section-head small { color:var(--muted); font-size:12px }
+    .matrix-wrap { overflow:auto; border:1px solid var(--line); border-radius:12px; background:var(--panel-2) }
+    table { width:100%; min-width:940px; border-collapse:collapse }
+    th,td { padding:10px 11px; border-bottom:1px solid rgba(36,54,74,.7); text-align:left; vertical-align:middle }
+    th { position:sticky; top:0; z-index:2; background:#152639; color:var(--muted); font-size:12px; font-weight:600; white-space:nowrap }
+    tr:last-child td { border-bottom:0 }
+    .asset { min-width:185px }
+    .asset strong { display:block; font-size:13px }
+    .asset small { display:block; color:var(--muted); margin-top:2px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+    .cell { width:100%; min-width:118px; border:1px solid transparent; border-radius:8px; padding:7px 8px; text-align:left;
+      background:#152335; color:var(--text); cursor:pointer; transition:border-color .15s,transform .15s; }
+    .cell:hover { border-color:var(--accent); transform:translateY(-1px) }
+    .cell .cell-top { display:flex; justify-content:space-between; gap:6px; align-items:center }
+    .cell .state { font-weight:700; font-size:12px }
+    .cell .age { color:var(--muted); font-size:11px; margin-top:3px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+    .cell.ready { background:#103126; color:#bff4d9 }
+    .cell.partial { background:#332c18; color:#ffe5a5 }
+    .cell.stale { background:#332718; color:#ffd0a0 }
+    .cell.failed, .cell.blocked, .cell.unavailable { background:#351c25; color:#ffd0d6 }
+    .cell.not_applicable { background:#17202a; color:#8ea1b1; cursor:default }
+    .empty { color:var(--muted); padding:22px; text-align:center }
+    .lower-grid { display:grid; grid-template-columns:minmax(0,1.45fr) minmax(300px,.85fr); gap:14px; }
+    .run-table { min-width:700px }
+    .run-table td, .run-table th { white-space:nowrap }
+    .run-status { font-weight:700 }
+    .infra-grid { display:grid; gap:10px }
+    .infra-item { display:flex; justify-content:space-between; gap:12px; padding-bottom:10px; border-bottom:1px solid rgba(36,54,74,.7) }
+    .infra-item:last-child { border-bottom:0; padding-bottom:0 }
+    .infra-item span { color:var(--muted) }
+    .infra-item strong { text-align:right }
+    .drawer-backdrop { position:fixed; inset:0; display:none; z-index:10; background:rgba(1,6,12,.68) }
+    .drawer-backdrop.open { display:block }
+    .drawer { position:absolute; top:0; right:0; height:100%; width:min(480px,94vw); overflow:auto; padding:22px;
+      background:#0e1a27; border-left:1px solid var(--line); box-shadow:-18px 0 50px rgba(0,0,0,.35) }
+    .drawer-head { display:flex; justify-content:space-between; gap:10px; align-items:flex-start; margin-bottom:18px }
+    .drawer-head h2 { margin:0 }
+    .close { border:1px solid var(--line); border-radius:7px; background:transparent; color:var(--muted); padding:5px 9px; cursor:pointer }
+    .detail-list { display:grid; grid-template-columns:140px minmax(0,1fr); gap:9px 12px; margin:0 }
+    .detail-list dt { color:var(--muted) }
+    .detail-list dd { margin:0; overflow-wrap:anywhere; color:var(--text) }
+    .detail-list code { color:#c8d9e8; white-space:pre-wrap; font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace }
+    @media (max-width:900px) { header { flex-direction:column } .header-meta { min-width:0; text-align:left }
+      .coverage-grid { grid-template-columns:repeat(2,minmax(145px,1fr)) } .lower-grid { grid-template-columns:1fr } }
+    @media (max-width:520px) { main { padding:22px 14px 42px } h1 { font-size:25px } .coverage-grid { grid-template-columns:1fr 1fr } }
   </style>
 </head>
-<body><main>
-  <header><div><h1>Datafeed Source Health</h1><p>Availability, provenance and source-scoped storage coverage.</p></div>
-    <div class="stamp" id="stamp">Loading…</div></header>
-  <div class="grid" id="sources"></div>
-  <h2>Stored source coverage</h2>
-  <div id="coverage"></div>
-  <h2 style="margin-top:28px">GOLD 5m source comparison</h2>
-  <div id="comparison" class="card empty">Waiting for two stored GOLD sources…</div>
-</main><script>
-const esc = value => String(value ?? '—').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[c]));
-fetch('/api/health').then(r => r.json()).then(data => {
-  document.getElementById('stamp').textContent = `${data.service} ${data.version} · ${new Date().toLocaleString()}`;
-  const observations = Object.fromEntries((data.latest_observations || []).map(x => [x.source_id, x]));
-  const sources = data.providers?.sources || {};
-  document.getElementById('sources').innerHTML = Object.entries(sources).map(([id, src]) => {
-    const obs = observations[id]; const state = !src.available ? 'unavailable' : !obs ? 'registered' : obs.success ? 'healthy' : 'failed';
-    const klass = state === 'healthy' ? 'ok' : state === 'failed' || state === 'unavailable' ? 'bad' : '';
-    return `<section class="card"><div class="row"><span class="source">${esc(id)}</span><span class="pill ${klass}">${esc(state)}</span></div>
-      <dl><dt>Provider</dt><dd>${esc(src.provider)}</dd><dt>Asset / market</dt><dd>${esc(src.asset_class)} · ${esc(src.market_type)}</dd>
-      <dt>Execution venue</dt><dd>${src.execution_venue ? 'yes' : 'no'}</dd><dt>Realtime</dt><dd>${src.realtime_supported ? 'yes' : 'no'}</dd>
-      <dt>Last instrument</dt><dd>${esc(obs?.ticker)}</dd><dt>Latest candle</dt><dd>${esc(obs?.latest_timestamp)}</dd>
-      <dt>Latency</dt><dd>${obs?.latency_ms == null ? '—' : Math.round(obs.latency_ms) + ' ms'}</dd><dt>Last error</dt><dd title="${esc(obs?.error)}">${esc(obs?.error)}</dd></dl></section>`;
-  }).join('');
-  const rows = data.storage_coverage || [];
-  document.getElementById('coverage').innerHTML = rows.length ? `<table><thead><tr><th>Source</th><th>Asset</th><th>Symbol</th><th>TF</th><th>Bars</th><th>Latest</th></tr></thead><tbody>${rows.map(x => `<tr><td>${esc(x.source_id)}</td><td>${esc(x.asset_class)}</td><td>${esc(x.ticker)}</td><td>${esc(x.timeframe)}</td><td>${esc(x.count)}</td><td>${esc(x.latest_timestamp)}</td></tr>`).join('')}</tbody></table>` : '<div class="card empty">No source-scoped candles stored yet.</div>';
-  const ids = new Set(rows.filter(x => x.asset_class === 'commodity' && x.timeframe === '5m').map(x => x.source_id));
-  if (ids.has('binance_usdm_futures') && ids.has('yahoo_finance_futures')) {
-    fetch('/api/compare/commodity/GOLD?timeframe=5m&sources=binance_usdm_futures&sources=yahoo_finance_futures&limit=500').then(r => r.json()).then(c => {
-      document.getElementById('comparison').innerHTML = `<div class="row"><span class="source">${esc(c.instrument_id)} · ${esc(c.primary_source)} vs ${esc(c.sources[1])}</span><span class="pill">never blended</span></div><dl><dt>Overlapping candles</dt><dd>${esc(c.overlap_count)}</dd><dt>Max close deviation</dt><dd>${Number(c.max_close_deviation_pct || 0).toFixed(4)}%</dd><dt>Provider symbols</dt><dd>${esc(Object.values(c.provider_symbols).join(' / '))}</dd></dl>`;
-    });
+<body>
+<main>
+  <header>
+    <div><div class="eyebrow">市场数据管线 / 运行监控</div><h1>资产 × 时间级别健康矩阵</h1>
+      <p>只读查看最近一次持久化运行、数据质量和覆盖情况。页面每 30 秒自动读取。</p></div>
+    <div class="header-meta"><strong id="overall">等待首次读取</strong><span id="last-success">尚未取得成功快照</span></div>
+  </header>
+  <div id="banner" class="banner" role="status"><i class="dot"></i><span id="banner-text"></span></div>
+  <div class="toolbar"><span id="snapshot-meta">正在连接健康矩阵…</span>
+    <label><span>矩阵筛选：</span><select id="filter"><option value="all">显示全部</option><option value="attention">仅显示需关注</option></select></label></div>
+
+  <section><div class="section-head"><h2>覆盖概览</h2><small id="coverage-meta">—</small></div><div id="coverage" class="coverage-grid"></div></section>
+
+  <section class="section"><div class="section-head"><h2>资产 × 时间级别明细</h2><small>点击单元格查看来源、质量和水位证据</small></div>
+    <div class="matrix-wrap"><table id="matrix"><thead><tr><th class="asset">资产</th><th>15 分钟</th><th>1 小时</th><th>4 小时</th><th>日线</th><th>周线</th></tr></thead><tbody id="matrix-body"><tr><td colspan="6" class="empty">正在读取数据…</td></tr></tbody></table></div></section>
+
+  <section class="section lower-grid"><div><div class="section-head"><h2>最近一次运行</h2><small>按时间倒序展示</small></div>
+      <div class="matrix-wrap"><table class="run-table"><thead><tr><th>运行编号</th><th>状态</th><th>开始</th><th>结束</th><th>蜡烛数</th><th>质量数</th></tr></thead><tbody id="runs-body"><tr><td colspan="6" class="empty">暂无运行记录</td></tr></tbody></table></div></div>
+    <div><div class="section-head"><h2>基础设施</h2><small>不包含密钥和原始路径</small></div><div id="infrastructure" class="card infra-grid"><div class="empty">暂无基础设施事实</div></div></div></section>
+</main>
+
+<div id="drawer-backdrop" class="drawer-backdrop" aria-hidden="true"><aside class="drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title">
+  <div class="drawer-head"><h2 id="drawer-title">单元格详情</h2><button class="close" id="close-drawer" type="button">关闭</button></div><dl id="detail-list" class="detail-list"></dl>
+</aside></div>
+
+<script>
+(() => {
+  const API = '/api/mvp/health/matrix';
+  const POLL_MS = 30000;
+  const TIMEOUT_MS = 10000;
+  const MAX_SNAPSHOT_MS = 900000;
+  const timeframes = ['15m','1h','4h','1d','1w'];
+  const timeframeLabels = {'15m':'15 分钟','1h':'1 小时','4h':'4 小时','1d':'日线','1w':'周线'};
+  const statusLabels = {ready:'正常',partial:'部分',stale:'过期',failed:'失败',blocked:'阻塞',unavailable:'不可用',not_applicable:'不适用'};
+  const attention = new Set(['partial','stale','failed','blocked','unavailable']);
+  let latestSnapshot = null;
+  let latestReceivedAt = 0;
+  let loading = false;
+
+  const esc = value => String(value ?? '—').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[c]));
+  const fmtTime = value => { if (!value) return '—'; const date = new Date(value); return Number.isNaN(date.getTime()) ? esc(value) : date.toLocaleString('zh-CN',{hour12:false}); };
+  const fmtCount = value => value == null ? '—' : Number(value).toLocaleString('zh-CN');
+  const statusText = status => statusLabels[status] || status || '未知';
+  const validSnapshot = data => data && Array.isArray(data.cells) && data.coverage && typeof data.coverage === 'object' && data.refresh;
+  const showBanner = (text, severity = 'error') => {
+    const banner = document.getElementById('banner');
+    document.getElementById('banner-text').textContent = text;
+    banner.classList.toggle('warn', severity === 'warn');
+    banner.classList.add('show');
+  };
+  const hideBanner = () => document.getElementById('banner').classList.remove('show');
+
+  function renderCoverage(snapshot) {
+    const host = document.getElementById('coverage');
+    host.innerHTML = timeframes.map(tf => {
+      const item = snapshot.coverage[tf] || {};
+      const applicable = Number(item.applicable || 0);
+      const ready = Number(item.ready || 0);
+      const ratio = applicable ? Math.round(ready / applicable * 100) : 0;
+      const problem = ['failed','blocked','stale','partial','unavailable'].reduce((sum, key) => sum + Number(item[key] || 0), 0);
+      return `<article class="card coverage-card"><div class="label">${timeframeLabels[tf]}</div><div class="ratio"><strong>${ratio}%</strong><span>${ready}/${applicable} 正常</span></div><div class="counts">${problem ? `需关注 ${problem} 个` : '没有异常单元格'} · 不适用 ${Number(item.not_applicable || 0)} 个</div><div class="progress"><i style="width:${ratio}%"></i></div></article>`;
+    }).join('');
+    document.getElementById('coverage-meta').textContent = `共 ${fmtCount(snapshot.cells.length)} 个单元格 · 清单 ${esc(snapshot.manifest_version)}`;
   }
-}).catch(error => { document.getElementById('sources').innerHTML = `<div class="card error">Health request failed: ${esc(error)}</div>`; });
-</script></body></html>"""
+
+  function renderMatrix(snapshot) {
+    const filter = document.getElementById('filter').value;
+    const grouped = new Map();
+    snapshot.cells.forEach(cell => {
+      if (filter === 'attention' && !attention.has(cell.status)) return;
+      const key = cell.instrument_id || cell.display_symbol;
+      if (!grouped.has(key)) grouped.set(key, {symbol:cell.display_symbol, name:cell.display_name, cells:{}});
+      grouped.get(key).cells[cell.timeframe] = cell;
+    });
+    const rows = Array.from(grouped.values());
+    document.getElementById('matrix-body').innerHTML = rows.length ? rows.map(row => `<tr><td class="asset"><strong>${esc(row.symbol)}</strong><small>${esc(row.name)}</small></td>${timeframes.map(tf => {
+      const cell = row.cells[tf];
+      if (!cell) return '<td><div class="empty">—</div></td>';
+      const latest = cell.latest_closed_timestamp ? fmtTime(cell.latest_closed_timestamp) : '暂无收盘数据';
+      return `<td><button class="cell ${esc(cell.status)}" type="button" data-cell="${esc(JSON.stringify(cell))}"><span class="cell-top"><span class="state">${esc(statusText(cell.status))}</span><span>${esc(timeframeLabels[tf])}</span></span><span class="age">${esc(latest)}</span></button></td>`;
+    }).join('')}</tr>`).join('') : '<tr><td colspan="6" class="empty">当前筛选没有需要展示的资产</td></tr>';
+    document.querySelectorAll('[data-cell]').forEach(button => button.addEventListener('click', () => openDetail(JSON.parse(button.dataset.cell))));
+  }
+
+  function renderRuns(snapshot) {
+    const rows = snapshot.runs || [];
+    document.getElementById('runs-body').innerHTML = rows.length ? rows.map(run => `<tr><td title="${esc(run.run_id)}">${esc(String(run.run_id || '—').slice(0,18))}</td><td class="run-status">${esc(statusText(run.status === 'success' ? 'ready' : run.status))}</td><td>${esc(fmtTime(run.started_at))}</td><td>${esc(fmtTime(run.completed_at))}</td><td>${esc(fmtCount(run.candle_count))}</td><td>${esc(fmtCount(run.quality_count))}</td></tr>`).join('') : '<tr><td colspan="6" class="empty">暂无运行记录</td></tr>';
+  }
+
+  function renderInfrastructure(snapshot) {
+    const infra = snapshot.infrastructure || {};
+    const worker = infra.worker || snapshot.worker || {};
+    const database = infra.database || {};
+    const backup = infra.nas_backup || {};
+    const label = value => value === 'ready' || value === 'ok' || value === 'last_run' ? '正常' : statusText(value || 'unavailable');
+    document.getElementById('infrastructure').innerHTML = [
+      ['采集任务', label(worker.status), worker.last_success_at ? `上次成功 ${fmtTime(worker.last_success_at)}` : '尚无成功运行'],
+      ['本地数据库', label(database.status), database.filesystem === 'local' ? '本地 SQLite（路径已隐藏）' : '路径已隐藏'],
+      ['SSD 挂载保护', label((infra.ssd_mount_guard || {}).status), '仅展示保护状态'],
+      ['NAS 备份', label(backup.status), backup.last_backup_at ? `上次备份 ${fmtTime(backup.last_backup_at)}` : '尚无备份证据']
+    ].map(item => `<div class="infra-item"><span>${esc(item[0])}<br><small>${esc(item[2])}</small></span><strong>${esc(item[1])}</strong></div>`).join('');
+  }
+
+  function render(snapshot) {
+    latestSnapshot = snapshot;
+    renderCoverage(snapshot); renderMatrix(snapshot); renderRuns(snapshot); renderInfrastructure(snapshot);
+    document.getElementById('overall').textContent = `总体状态：${statusText(snapshot.status)}`;
+    document.getElementById('snapshot-meta').textContent = `数据时间 ${fmtTime(snapshot.as_of)} · 自动读取间隔 30 秒 · 请求上限 10 秒`;
+    if (snapshot.status === 'failed') {
+      showBanner('数据源或存储存在失败、阻塞单元格，请查看矩阵详情', 'error');
+    } else if (snapshot.status === 'partial') {
+      showBanner('数据源存在过期、部分或不可用单元格，请查看覆盖概览', 'warn');
+    } else {
+      hideBanner();
+    }
+  }
+
+  function openDetail(cell) {
+    const rows = [
+      ['状态', statusText(cell.status)], ['状态原因', cell.status_reason], ['资产', `${cell.display_symbol || '—'} · ${cell.display_name || '—'}`],
+      ['时间级别', timeframeLabels[cell.timeframe] || cell.timeframe], ['适用性', cell.applicability === 'not_applicable' ? '不适用' : '适用'],
+      ['来源标识', cell.source_id], ['供应商代码', cell.provider_symbol], ['来源模式', cell.source_mode],
+      ['最近收盘', cell.latest_closed_timestamp ? fmtTime(cell.latest_closed_timestamp) : null], ['存储行数', fmtCount(cell.row_count)],
+      ['是否聚合', cell.is_derived == null ? null : (cell.is_derived ? '是' : '否')], ['最近尝试', fmtTime(cell.last_attempt_at)],
+      ['最近成功', fmtTime(cell.last_success_at)], ['质量', cell.quality], ['水位', cell.watermark], ['转换凭证', cell.transform], ['错误', cell.error]
+    ];
+    document.getElementById('drawer-title').textContent = `${cell.display_symbol || '资产'} · ${timeframeLabels[cell.timeframe] || cell.timeframe}`;
+    document.getElementById('detail-list').innerHTML = rows.map(([key,value]) => `<dt>${esc(key)}</dt><dd>${value && typeof value === 'object' ? `<code>${esc(JSON.stringify(value,null,2))}</code>` : esc(value)}</dd>`).join('');
+    const drawer = document.getElementById('drawer-backdrop'); drawer.classList.add('open'); drawer.setAttribute('aria-hidden','false');
+  }
+  const closeDetail = () => { const drawer = document.getElementById('drawer-backdrop'); drawer.classList.remove('open'); drawer.setAttribute('aria-hidden','true'); };
+
+  async function fetchHealth() {
+    if (loading) return; loading = true;
+    const controller = new AbortController(); const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+      const response = await fetch(`${API}?_=${Date.now()}`, {cache:'no-store', signal:controller.signal, headers:{'Accept':'application/json'}});
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json(); if (!validSnapshot(data)) throw new Error('响应结构不完整');
+      latestReceivedAt = Date.now(); render(data);
+      document.getElementById('last-success').textContent = `最近成功读取 ${new Date(latestReceivedAt).toLocaleString('zh-CN',{hour12:false})}`;
+    } catch (error) {
+      const message = error.name === 'AbortError' ? '健康矩阵读取超过 10 秒' : `健康矩阵读取失败：${error.message || error}`;
+      if (!latestSnapshot) {
+        document.getElementById('overall').textContent = '监控服务不可用';
+        document.getElementById('snapshot-meta').textContent = '尚未取得可展示的健康快照';
+        document.getElementById('coverage').innerHTML = '<div class="card empty">暂无可验证的矩阵数据</div>';
+        document.getElementById('matrix-body').innerHTML = '<tr><td colspan="6" class="empty">监控服务不可用，暂不展示推测数据</td></tr>';
+      } else {
+        const age = Date.now() - latestReceivedAt;
+        if (age > MAX_SNAPSHOT_MS) {
+          latestSnapshot = null;
+          document.getElementById('overall').textContent = '快照已过期';
+          document.getElementById('snapshot-meta').textContent = '最近成功快照已超过 15 分钟，暂不继续展示';
+          document.getElementById('coverage').innerHTML = '<div class="card empty">快照已过期，等待新的可验证数据</div>';
+          document.getElementById('matrix-body').innerHTML = '<tr><td colspan="6" class="empty">快照已过期</td></tr>';
+        } else {
+          document.getElementById('snapshot-meta').textContent = `读取失败，保留最近快照 · 已过 ${Math.round(age / 1000)} 秒`;
+        }
+      }
+      showBanner(message);
+    } finally { clearTimeout(timeout); loading = false; }
+  }
+
+  document.getElementById('filter').addEventListener('change', () => { if (latestSnapshot) renderMatrix(latestSnapshot); });
+  document.getElementById('close-drawer').addEventListener('click', closeDetail);
+  document.getElementById('drawer-backdrop').addEventListener('click', event => { if (event.target.id === 'drawer-backdrop') closeDetail(); });
+  document.addEventListener('keydown', event => { if (event.key === 'Escape') closeDetail(); });
+  fetchHealth(); setInterval(fetchHealth, POLL_MS);
+})();
+</script>
+</body>
+</html>"""

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -1111,6 +1111,171 @@ class KlineStore:
             "error": row.error,
         }
 
+    def latest_mvp_runs(self, *, limit: int = 6) -> list[dict[str, Any]]:
+        """Return recent MVP run receipts for the health matrix timeline."""
+
+        bounded_limit = max(1, min(int(limit), 100))
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(MvpRunRow)
+                .order_by(MvpRunRow.created_at.desc(), MvpRunRow.run_id.desc())
+                .limit(bounded_limit)
+            ).scalars()
+            return [
+                {
+                    "run_id": row.run_id,
+                    "status": row.status,
+                    "manifest_version": row.manifest_version,
+                    "manifest_hash": row.manifest_hash,
+                    "started_at": row.started_at,
+                    "completed_at": row.completed_at,
+                    "window_start": row.window_start,
+                    "window_end": row.window_end,
+                    "candle_count": row.candle_count,
+                    "observation_count": row.observation_count,
+                    "quality_count": row.quality_count,
+                    "transform_count": row.transform_count,
+                    "watermark_count": row.watermark_count,
+                    "receipt_hash": row.receipt_hash,
+                    "error": row.error,
+                }
+                for row in rows
+            ]
+
+    def latest_mvp_source_observations(self) -> list[dict[str, Any]]:
+        """Return the latest source observation for every exact MVP cell."""
+
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(MvpSourceObservationRow).order_by(MvpSourceObservationRow.id.desc())
+            ).scalars()
+            seen: set[tuple[str, str, str, str]] = set()
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                identity = (row.source_id, row.instrument_id, row.timeframe, row.manifest_version)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                result.append(
+                    {
+                        "run_id": row.run_id,
+                        "manifest_version": row.manifest_version,
+                        "instrument_id": row.instrument_id,
+                        "display_symbol": row.display_symbol,
+                        "provider_symbol": row.provider_symbol,
+                        "source_id": row.source_id,
+                        "asset_class": row.asset_class,
+                        "timeframe": row.timeframe,
+                        "success": row.success,
+                        "served_from": row.served_from,
+                        "request_start": row.request_start,
+                        "request_end": row.request_end,
+                        "response_hash": row.response_hash,
+                        "candle_count": row.candle_count,
+                        "latest_timestamp": row.latest_timestamp,
+                        "latency_ms": row.latency_ms,
+                        "error": row.error,
+                        "observed_at": row.observed_at,
+                        "policy": json.loads(row.policy_json or "{}"),
+                    }
+                )
+            return result
+
+    def latest_mvp_quality_receipts(self) -> list[dict[str, Any]]:
+        """Return the latest quality receipt for every exact MVP cell."""
+
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(MvpQualityReceiptRow).order_by(MvpQualityReceiptRow.id.desc())
+            ).scalars()
+            seen: set[tuple[str, str, str, str]] = set()
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                identity = (row.source_id, row.instrument_id, row.timeframe, row.manifest_version)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                result.append(
+                    {
+                        "run_id": row.run_id,
+                        "manifest_version": row.manifest_version,
+                        "instrument_id": row.instrument_id,
+                        "source_id": row.source_id,
+                        "timeframe": row.timeframe,
+                        "status": row.status,
+                        "gaps": row.gaps,
+                        "duplicates": row.duplicates,
+                        "invalid_rows": row.invalid_rows,
+                        "blocked_cells": row.blocked_cells,
+                        "details": json.loads(row.details_json or "{}"),
+                        "receipt_hash": row.receipt_hash,
+                    }
+                )
+            return result
+
+    def latest_mvp_transform_receipts(self) -> list[dict[str, Any]]:
+        """Return the latest transform receipt for every derived cell."""
+
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(MvpTransformReceiptRow).order_by(MvpTransformReceiptRow.id.desc())
+            ).scalars()
+            seen: set[tuple[str, str, str, str]] = set()
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                identity = (
+                    row.source_id,
+                    row.instrument_id,
+                    row.output_timeframe,
+                    row.manifest_version,
+                )
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                result.append(
+                    {
+                        "id": row.id,
+                        "receipt_id": row.id,
+                        "run_id": row.run_id,
+                        "manifest_version": row.manifest_version,
+                        "instrument_id": row.instrument_id,
+                        "source_id": row.source_id,
+                        "output_timeframe": row.output_timeframe,
+                        "input_timeframe": row.input_timeframe,
+                        "aggregation_rule_version": row.aggregation_rule_version,
+                        "input_start": row.input_start,
+                        "input_end": row.input_end,
+                        "input_hash": row.input_hash,
+                        "output_hash": row.output_hash,
+                        "bucket_anchor": row.bucket_anchor,
+                        "partial_bucket_policy": row.partial_bucket_policy,
+                        "partial_bucket_count": row.partial_bucket_count,
+                    }
+                )
+            return result
+
+    def latest_mvp_watermarks(self) -> list[dict[str, Any]]:
+        """Return the latest watermark for every exact MVP cell."""
+
+        with self._session_factory() as session:
+            rows = session.execute(select(MvpWatermarkRow)).scalars()
+            return [
+                {
+                    "instrument_id": row.instrument_id,
+                    "display_symbol": row.display_symbol,
+                    "provider_symbol": row.provider_symbol,
+                    "source_id": row.source_id,
+                    "asset_class": row.asset_class,
+                    "timeframe": row.timeframe,
+                    "adjustment_basis": row.adjustment_basis,
+                    "manifest_version": row.manifest_version,
+                    "last_closed_timestamp": row.last_closed_timestamp,
+                    "cursor": row.cursor,
+                    "run_id": row.run_id,
+                }
+                for row in rows
+            ]
+
     def mvp_latest_closed_bars(self) -> list[dict[str, Any]]:
         """Return latest timestamp/row count for each source-aware MVP series."""
 

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from kline.app import create_app
+from kline.health_matrix import MVP_DEMO_INSTRUMENT_IDS, build_mvp_health_matrix
+from kline.mvp_manifest import load_manifest
+from kline.storage import (
+    CandleSeriesKey,
+    MvpCandle,
+    MvpRunWrite,
+    QualityReceiptWrite,
+    SourceObservationWrite,
+    WatermarkWrite,
+)
+from kline.store import KlineStore
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def _btc_key(timeframe: str) -> CandleSeriesKey:
+    return CandleSeriesKey(
+        instrument_id="CRYPTO.PERP.BTC",
+        display_symbol="BTC",
+        provider_symbol="BTC",
+        source_id="hyperliquid_perpetual_public",
+        asset_class="crypto",
+        timeframe=timeframe,
+        adjustment_basis="raw_unadjusted",
+        manifest_version="mvp_universe_v1",
+    )
+
+
+def _btc_candle(key: CandleSeriesKey) -> MvpCandle:
+    return MvpCandle(
+        key=key,
+        timestamp="2026-08-31T00:00:00+00:00",
+        open=100,
+        high=102,
+        low=99,
+        close=101,
+        volume=10,
+    )
+
+
+def test_matrix_returns_every_manifest_timeframe_cell_and_explicit_statuses(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix.db"))
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(snapshot["cells"]) == 6 * 5
+    assert {cell["timeframe"] for cell in snapshot["cells"]} == {"15m", "1h", "4h", "1d", "1w"}
+    assert {cell["instrument_id"] for cell in snapshot["cells"]} == set(MVP_DEMO_INSTRUMENT_IDS)
+    aapl_1h = next(
+        cell
+        for cell in snapshot["cells"]
+        if cell["display_symbol"] == "AAPL" and cell["timeframe"] == "1h"
+    )
+    assert aapl_1h["status"] == "blocked"
+    assert aapl_1h["status_reason"] == "entitlement_blocked"
+    assert aapl_1h["applicability"] == "applicable"
+    assert aapl_1h["error"]["code"] == "entitlement_blocked"
+
+
+def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-ready.db"))
+    key = _btc_key("1h")
+    run_id = "matrix-run-1"
+    candle = _btc_candle(key)
+    store.commit_mvp_run(
+        MvpRunWrite(
+            run_id=run_id,
+            manifest_version=manifest.version,
+            manifest_hash="a" * 64,
+            started_at="2026-08-31T00:00:00+00:00",
+            window_start="2026-08-30T00:00:00+00:00",
+            window_end="2026-09-01T00:00:00+00:00",
+            policy={"overlap_bars": 2},
+            candles=(candle,),
+            source_observations=(
+                SourceObservationWrite(
+                    run_id=run_id,
+                    key=key,
+                    success=True,
+                    request_start="2026-08-30T00:00:00+00:00",
+                    request_end="2026-09-01T00:00:00+00:00",
+                    response_hash="b" * 64,
+                    candle_count=1,
+                    latest_timestamp=candle.timestamp,
+                    observed_at="2026-09-01T00:00:00+00:00",
+                ),
+            ),
+            quality_receipts=(QualityReceiptWrite(run_id=run_id, key=key, status="pass"),),
+            watermarks=(
+                WatermarkWrite(
+                    key=key,
+                    last_closed_timestamp=candle.timestamp,
+                    cursor=None,
+                    run_id=run_id,
+                ),
+            ),
+        )
+    )
+
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 8, 31, 1, tzinfo=timezone.utc),
+        instrument_ids=("CRYPTO.PERP.BTC",),
+    )
+    btc_1h = next(
+        cell
+        for cell in snapshot["cells"]
+        if cell["display_symbol"] == "BTC" and cell["timeframe"] == "1h"
+    )
+    assert btc_1h["status"] == "ready"
+    assert btc_1h["latest_closed_timestamp"] == candle.timestamp
+    assert btc_1h["watermark"]["run_id"] == run_id
+    assert snapshot["coverage"]["1h"]["ready"] == 1
+    assert snapshot["coverage"]["1h"]["applicable"] == 1
+    assert (
+        snapshot["coverage"]["1h"]["ready"]
+        + snapshot["coverage"]["1h"]["partial"]
+        + snapshot["coverage"]["1h"]["stale"]
+        + snapshot["coverage"]["1h"]["failed"]
+        + snapshot["coverage"]["1h"]["blocked"]
+        + snapshot["coverage"]["1h"]["unavailable"]
+        == snapshot["coverage"]["1h"]["applicable"]
+    )
+
+
+def test_health_matrix_api_and_ui_are_chinese_and_read_only(
+    tmp_path: Path,
+) -> None:
+    from kline.config import Settings
+    from kline.registry import init
+
+    init(Settings(db_path=str(tmp_path / "api.db"), load_entrypoint_adapters=False))
+    with TestClient(create_app()) as client:
+        response = client.get("/api/mvp/health/matrix")
+        page = client.get("/health-ui")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["cells"]) == 6 * 5
+    assert payload["scope"] == {
+        "name": "demo_3x3",
+        "instrument_count": 6,
+        "universes": {"a_share": 3, "us_stock": 3},
+    }
+    assert payload["refresh"]["poll_interval_seconds"] == 30
+    assert payload["refresh"]["request_timeout_seconds"] == 10
+    assert page.status_code == 200
+    assert "资产 × 时间级别健康矩阵" in page.text
+    assert "最近一次运行" in page.text
+    assert "system notification" not in page.text.lower()
+    assert "重试" not in page.text

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -94,9 +95,11 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
                     request_start="2026-08-30T00:00:00+00:00",
                     request_end="2026-09-01T00:00:00+00:00",
                     response_hash="b" * 64,
+                    policy={"api_key": "supersecret", "safe": "keep"},
                     candle_count=1,
                     latest_timestamp=candle.timestamp,
                     observed_at="2026-09-01T00:00:00+00:00",
+                    error="token=abc secretvalue",
                 ),
             ),
             quality_receipts=(QualityReceiptWrite(run_id=run_id, key=key, status="pass"),),
@@ -126,6 +129,10 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
     assert btc_1h["latest_closed_timestamp"] == candle.timestamp
     assert btc_1h["watermark"]["run_id"] == run_id
     assert snapshot["coverage"]["1h"]["ready"] == 1
+    assert btc_1h["run_id"] == run_id
+    serialized = json.dumps(btc_1h, ensure_ascii=False)
+    assert "supersecret" not in serialized
+    assert "abc" not in serialized
     assert snapshot["coverage"]["1h"]["applicable"] == 1
     assert (
         snapshot["coverage"]["1h"]["ready"]
@@ -136,6 +143,41 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
         + snapshot["coverage"]["1h"]["unavailable"]
         == snapshot["coverage"]["1h"]["applicable"]
     )
+
+
+def test_not_applicable_cell_keeps_the_full_null_payload_shape(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-not-applicable.db"))
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        instrument_ids=("US.ETF.UUP",),
+        now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+    )
+
+    intraday = next(cell for cell in snapshot["cells"] if cell["timeframe"] == "15m")
+    daily = next(cell for cell in snapshot["cells"] if cell["timeframe"] == "1d")
+    assert intraday["applicability"] == "not_applicable"
+    assert intraday["status"] == "not_applicable"
+    for field in (
+        "provider_symbol",
+        "source_id",
+        "source_mode",
+        "entitlement",
+        "latest_closed_timestamp",
+        "transform",
+        "last_attempt_at",
+        "last_success_at",
+        "run_id",
+        "policy",
+        "coverage",
+        "quality",
+        "watermark",
+        "error",
+    ):
+        assert intraday[field] is None
+    assert daily["applicability"] == "applicable"
+    assert daily["status"] == "unavailable"
 
 
 def test_health_matrix_api_and_ui_are_chinese_and_read_only(

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -7,5 +7,7 @@ def test_health_ui_is_browser_visible():
     with TestClient(create_app()) as client:
         response = client.get("/health-ui")
     assert response.status_code == 200
-    assert "Datafeed Source Health" in response.text
-    assert "fetch('/api/health')" in response.text
+    assert "资产 × 时间级别健康矩阵" in response.text
+    assert "fetch(`${API}?_=${Date.now()}`" in response.text
+    assert "最近一次运行" in response.text
+    assert "重试" not in response.text


### PR DESCRIPTION
## What
- add read-only `/api/mvp/health/matrix` for the approved six-instrument, five-timeframe slice
- add Chinese coverage-first `/health-ui` with 30-second polling, API-loss snapshot freeze/expiry, fixed in-page banner, run timeline, infrastructure facts, and cell detail drawer
- persist/read source, quality, transform, watermark, run facts with redacted policy/error details

## Why
- provide the first demoable end-to-end Health Dashboard without expanding to the full 216-instrument universe
- keep source/entitlement failures explicit and avoid inventing readiness or data

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (247 passed)
- `python3 -m ruff check ...` (changed files clean)
- `git diff --check`
- `gitleaks detect --no-banner --redact --source .` (no leaks)
- six manifest identities × five timeframe cells; 30m absent; no system notifications/retry/source-switch/trading controls

Closes #69