### PR TITLE
feat: expand health matrix to full manifest

### DIFF
--- a/docs/verification/health-matrix-full-runtime-2026-09-01.md
+++ b/docs/verification/health-matrix-full-runtime-2026-09-01.md
@@ -1,0 +1,31 @@
+# 全量 Health Matrix 运行证据
+
+- 观察时间：2026-09-01T05:49:17+00:00
+- 运行地址：`http://127.0.0.1:18170/health-ui`
+- 运行方式：隔离临时 SQLite；未连接 resident database、NAS 或公网监听
+- API：`GET /api/mvp/health/matrix`
+- manifest：`mvp_universe_v1`
+- manifest hash：`bf276deacc6fc50606241d7d91ef1656725bc688ccfb3fec720865b510b49f25`
+- response SHA-256：`24006e5017ceaf0dd065bc3f3085f735a3f1dc9197a3a0c34014453fcdcb66cd`
+
+## API 实测
+
+- 返回 `scope=full_216`，资产数 216：A 股 100、美股 100、跨市场 16。
+- 返回 1,080 个 cell（216 × `15m/1h/4h/1d/1w`）；没有 `30m`。
+- 每个时间级别的 `applicable + not_applicable` 等于 216；适用 cell 的状态计数和等于 applicable。
+- 当前隔离库没有采集 run，且 manifest 中 A/美股 entitlement 仍为 blocked；因此当前总体状态为 `failed`，不是 verified/ready。
+- 五个级别的 blocked/applicable 计数分别为：`15m 208/208`、`1h 209/209`、`4h 208/208`、`1d 216/216`、`1w 216/216`；不适用分别为 8、7、8、0、0。
+- 数据库路径与 SSD volume 在响应中均为 redacted；NAS backup 为 pending，未伪造成功。
+
+## 浏览器实测
+
+- 页面标题为“资产 × 时间级别健康矩阵”，首屏顺序为覆盖概览 → 全量矩阵 → 最近一次运行 → 基础设施。
+- 真实页面 DOM 显示三组：A 股 100、美股 100、跨市场 16。
+- 搜索“Tesla”后只显示 Tesla 资产；市场筛选“跨市场”只显示跨市场分组。
+- 点击“收起 · 美股（100 个资产）”后矩阵只保留分组行，点击展开恢复资产行。
+- 点击真实 cell 后打开只读详情抽屉，显示来源标识等证据字段；没有交易控件、来源切换或系统通知。
+- 页面脚本包含 30 秒轮询、10 秒 AbortController 超时、`cache: no-store`、API 失联快照冻结和 900 秒过期处理。
+
+## 未解决事项
+
+本证据证明全量 API/UI 从真实隔离服务读取了运行时 manifest 和存储事实，不证明数据源已取得持久化授权，也不证明采集 worker 已完成 7 天可靠性。后续 #71 负责实际 worker/备份运行与 7 天门槛。

--- a/docs/verification/health-matrix-full-runtime-2026-09-01.md
+++ b/docs/verification/health-matrix-full-runtime-2026-09-01.md
@@ -1,12 +1,12 @@
 # 全量 Health Matrix 运行证据
 
-- 观察时间：2026-09-01T05:49:17+00:00
+- 观察时间：2026-09-01T05:51:59+00:00
 - 运行地址：`http://127.0.0.1:18170/health-ui`
 - 运行方式：隔离临时 SQLite；未连接 resident database、NAS 或公网监听
 - API：`GET /api/mvp/health/matrix`
 - manifest：`mvp_universe_v1`
 - manifest hash：`bf276deacc6fc50606241d7d91ef1656725bc688ccfb3fec720865b510b49f25`
-- response SHA-256：`24006e5017ceaf0dd065bc3f3085f735a3f1dc9197a3a0c34014453fcdcb66cd`
+- response SHA-256：`09d8392614eb5dac31978a763a1ed260eda3ee200ad05d2a87a47d77c522d0b0`
 
 ## API 实测
 

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -21,7 +21,12 @@ from kline.models import (
     TimeframeTransform,
     InstrumentDefinition,
 )
-from kline.health_matrix import build_mvp_health_matrix
+from kline.health_matrix import (
+    MATRIX_SCOPE_DEMO,
+    MATRIX_SCOPE_FULL,
+    MVP_DEMO_INSTRUMENT_IDS,
+    build_mvp_health_matrix,
+)
 from kline.mvp_manifest import load_manifest
 from kline.ports import MarketDataPort
 from kline.providers.base import ProviderError
@@ -36,6 +41,7 @@ from kline.quality import QualityReport, analyze_candles
 from kline.registry import get_adapter_for_source, get_store, provider_status, runtime_status
 
 router = APIRouter()
+_mvp_matrix_last_success_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1093,19 +1099,32 @@ async def health() -> dict:
 
 
 @router.get("/mvp/health/matrix")
-async def mvp_health_matrix() -> dict:
+async def mvp_health_matrix(scope: str = MATRIX_SCOPE_FULL) -> dict:
     """Return the source-aware MVP asset × timeframe health matrix."""
 
+    global _mvp_matrix_last_success_at
     manifest_path = Path(__file__).resolve().parents[2] / "configs" / "mvp_manifest.json"
+    if scope not in {MATRIX_SCOPE_FULL, MATRIX_SCOPE_DEMO}:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "unsupported_matrix_scope", "scope": scope},
+        )
     try:
         manifest = load_manifest(manifest_path)
-        return build_mvp_health_matrix(manifest, get_store())
+        payload = build_mvp_health_matrix(
+            manifest,
+            get_store(),
+            scope=scope,
+            instrument_ids=MVP_DEMO_INSTRUMENT_IDS if scope == MATRIX_SCOPE_DEMO else None,
+        )
+        _mvp_matrix_last_success_at = payload["refresh"]["last_success_at"]
+        return payload
     except Exception as error:
         raise HTTPException(
             status_code=503,
             detail={
                 "error": "dashboard_unavailable",
                 "detail": type(error).__name__,
-                "last_success_at": None,
+                "last_success_at": _mvp_matrix_last_success_at,
             },
         ) from error

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -7,6 +7,7 @@ import math
 from typing import Any, Mapping, Sequence
 
 from kline.market_calendar import calendar_spec, is_trading_session
+from kline.models import AssetClass
 from kline.mvp_manifest import MvpManifest, ManifestInstrument, manifest_digest
 from kline.storage import StoragePort
 
@@ -262,6 +263,19 @@ def _manifest_entitlement(
     }
 
 
+def _source_mode(instrument: ManifestInstrument) -> str:
+    """Resolve the provider's declared mode without conflating it with identity."""
+
+    try:
+        from kline.provenance import source_manifest
+
+        return source_manifest(
+            instrument.source_id, AssetClass(instrument.asset_class)
+        ).meta.source_mode
+    except (KeyError, ValueError, TypeError):
+        return instrument.source_id
+
+
 def _entitlement_block_reason(
     instrument: ManifestInstrument,
     timeframe: str,
@@ -377,7 +391,7 @@ def _cell(
         "provider_symbol": instrument.provider_symbol,
         "asset_class": instrument.asset_class,
         "source_id": instrument.source_id,
-        "source_mode": instrument.source_id,
+        "source_mode": _source_mode(instrument),
         "entitlement": _manifest_entitlement(instrument, entitlement),
         "timeframe": timeframe,
         "applicability": "applicable",
@@ -606,17 +620,19 @@ def build_mvp_health_matrix(
 
     coverage = _status_counts(cells)
     statuses = {str(cell["status"]) for cell in cells if cell["applicability"] == "applicable"}
-    latest_runs = storage.latest_mvp_runs(limit=24) if hasattr(storage, "latest_mvp_runs") else []
-    latest_runs = [_safe_run(run) for run in latest_runs]
+    persisted_runs = (
+        storage.latest_mvp_runs(limit=24) if hasattr(storage, "latest_mvp_runs") else []
+    )
+    persisted_runs = [_safe_run(run) for run in persisted_runs]
     run_cutoff = observed_at.astimezone(timezone.utc) - timedelta(hours=24)
-    latest_runs = [
+    recent_runs = [
         run
-        for run in latest_runs
+        for run in persisted_runs
         if (started := _parse_timestamp(run.get("started_at"))) is None or started >= run_cutoff
     ]
     latest_run = (
-        latest_runs[0]
-        if latest_runs
+        persisted_runs[0]
+        if persisted_runs
         else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
     )
     if latest_run is not None:
@@ -651,7 +667,7 @@ def build_mvp_health_matrix(
             "snapshot_max_age_seconds": 900,
         },
         "worker": _worker_payload(storage, now=observed_at, interval_seconds=interval_seconds),
-        "runs": latest_runs or ([latest_run] if latest_run else []),
+        "runs": recent_runs,
         "infrastructure": {
             "worker": _worker_payload(storage, now=observed_at, interval_seconds=interval_seconds),
             "database": {

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import math
 from typing import Any, Mapping, Sequence
 
+from kline.market_calendar import calendar_spec, is_trading_session
 from kline.mvp_manifest import MvpManifest, ManifestInstrument, manifest_digest
 from kline.storage import StoragePort
 
 
 MATRIX_TIMEFRAMES = ("15m", "1h", "4h", "1d", "1w")
 MATRIX_STATUSES = ("ready", "partial", "stale", "failed", "blocked", "unavailable")
+MATRIX_SCOPE_DEMO = "demo_3x3"
+MATRIX_SCOPE_FULL = "full_216"
 POLL_INTERVAL_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 10
 SNAPSHOT_MAX_AGE_SECONDS = 900
@@ -81,26 +85,122 @@ def _freshness_stale(
     *,
     now: datetime,
 ) -> bool:
-    """Apply a conservative SLA for continuous/futures cells.
+    """Apply calendar-aware freshness without treating a closed session as stale."""
 
-    Session markets are not marked stale solely because they are closed; their
-    next run is determined by the worker/calendar contract. Continuous assets
-    use the same grace values as the approved dashboard spec.
-    """
-
-    if instrument.calendar_id not in {"crypto_24x7", "us_futures"}:
-        return False
     latest = _parse_timestamp(latest_timestamp)
     if latest is None:
         return False
+    expected = _expected_latest_closed_start(instrument, timeframe, now)
+    if expected is None:
+        return False
     grace = {
-        "15m": timedelta(minutes=45),
-        "1h": timedelta(minutes=90),
-        "4h": timedelta(hours=5),
-        "1d": timedelta(hours=26),
-        "1w": timedelta(days=8),
-    }[timeframe]
-    return latest + grace < now.astimezone(timezone.utc)
+        "cn_a": {
+            "15m": timedelta(minutes=45),
+            "1h": timedelta(minutes=90),
+            "4h": timedelta(hours=5),
+            "1d": timedelta(hours=26),
+            "1w": timedelta(days=8),
+        },
+        "us_equities": {
+            "15m": timedelta(minutes=45),
+            "1h": timedelta(minutes=90),
+            "4h": timedelta(hours=5),
+            "1d": timedelta(hours=30),
+            "1w": timedelta(days=8),
+        },
+        "crypto_24x7": {
+            "15m": timedelta(minutes=45),
+            "1h": timedelta(minutes=90),
+            "4h": timedelta(hours=5),
+            "1d": timedelta(hours=26),
+            "1w": timedelta(days=8),
+        },
+        "us_futures": {
+            "15m": timedelta(minutes=45),
+            "1h": timedelta(minutes=90),
+            "4h": timedelta(hours=5),
+            "1d": timedelta(hours=30),
+            "1w": timedelta(days=8),
+        },
+    }.get(instrument.calendar_id, {})
+    return latest + grace.get(timeframe, timedelta(0)) < expected
+
+
+def _expected_latest_closed_start(
+    instrument: ManifestInstrument, timeframe: str, now: datetime
+) -> datetime | None:
+    """Return the latest expected closed bar start for a manifest calendar."""
+
+    try:
+        spec = calendar_spec(instrument.calendar_id)
+    except (KeyError, ValueError):
+        return None
+    try:
+        zone = spec.zone
+    except Exception:
+        return None
+    local_now = now.astimezone(zone)
+    interval = {
+        "15m": timedelta(minutes=15),
+        "1h": timedelta(hours=1),
+        "4h": timedelta(hours=4),
+    }.get(timeframe)
+    if spec.continuous:
+        if timeframe == "1w":
+            monday = local_now.date() - timedelta(days=local_now.weekday())
+            return datetime.combine(monday, datetime.min.time(), tzinfo=zone)
+        if timeframe == "1d":
+            return datetime.combine(local_now.date(), datetime.min.time(), tzinfo=zone)
+        if interval is None:
+            return None
+        elapsed_seconds = local_now.hour * 3600 + local_now.minute * 60 + local_now.second
+        bucket_seconds = int(interval.total_seconds())
+        start_seconds = math.floor(elapsed_seconds / bucket_seconds) * bucket_seconds
+        current_bucket = datetime.combine(local_now.date(), datetime.min.time(), tzinfo=zone)
+        return current_bucket + timedelta(seconds=start_seconds) - interval
+
+    if timeframe == "1w":
+        for offset in range(0, 15):
+            candidate = local_now.date() - timedelta(days=offset)
+            if candidate.weekday() != 4 or not is_trading_session(
+                instrument.calendar_id, candidate
+            ):
+                continue
+            close = spec.sessions[-1].close_time
+            close_at = datetime.combine(candidate, close, tzinfo=zone)
+            if close_at <= local_now:
+                return datetime.combine(
+                    candidate - timedelta(days=4), datetime.min.time(), tzinfo=zone
+                )
+        return None
+    for offset in range(0, 15):
+        candidate = local_now.date() - timedelta(days=offset)
+        if not is_trading_session(instrument.calendar_id, candidate):
+            continue
+        if timeframe == "1d":
+            close = datetime.combine(candidate, spec.sessions[-1].close_time, tzinfo=zone)
+            if close <= local_now:
+                return datetime.combine(candidate, datetime.min.time(), tzinfo=zone)
+            continue
+        if interval is None:
+            continue
+        latest_start: datetime | None = None
+        for window in spec.sessions:
+            open_at = datetime.combine(candidate, window.open_time, tzinfo=zone)
+            close_at = datetime.combine(candidate, window.close_time, tzinfo=zone)
+            if local_now < open_at:
+                continue
+            effective_now = min(local_now, close_at)
+            completed = math.floor(
+                (effective_now - open_at).total_seconds() / interval.total_seconds()
+            )
+            if completed <= 0:
+                continue
+            candidate_start = open_at + interval * (completed - 1)
+            latest_start = max(latest_start, candidate_start) if latest_start else candidate_start
+        if latest_start is not None:
+            return latest_start
+    return None
 
 
 def _redacted_error(error: str | None, *, code: str = "source_error") -> dict[str, Any] | None:
@@ -147,8 +247,12 @@ def _safe_run(run: Mapping[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _manifest_entitlement(instrument: ManifestInstrument) -> dict[str, Any]:
+def _manifest_entitlement(
+    instrument: ManifestInstrument, receipt: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
     blocked = instrument.source_status == "blocked_for_entitlement"
+    if receipt is not None:
+        return _redacted_value(dict(receipt))
     return {
         "status": "blocked" if blocked else "unverified",
         "persistence_allowed": False if blocked else None,
@@ -156,6 +260,35 @@ def _manifest_entitlement(instrument: ManifestInstrument) -> dict[str, Any]:
         "non_display_allowed": False if blocked else None,
         "evidence_ref": "manifest://blocked" if blocked else "operator_review_required",
     }
+
+
+def _entitlement_block_reason(
+    instrument: ManifestInstrument,
+    timeframe: str,
+    receipt: Mapping[str, Any] | None,
+    *,
+    derived: bool,
+) -> str | None:
+    if instrument.source_status == "blocked_for_entitlement":
+        return "entitlement_blocked"
+    if receipt is None:
+        return "entitlement_unverified"
+    status = str(receipt.get("status") or "unverified").casefold()
+    if status in {"blocked", "missing", "unverified"}:
+        return f"entitlement_{status}"
+    if status == "expired":
+        return "entitlement_expired"
+    if receipt.get("persistence_allowed") is False:
+        return "persistence_not_allowed"
+    if derived and receipt.get("derived_allowed") is False:
+        return "derived_not_allowed"
+    permissions = receipt.get("timeframe_permissions")
+    if isinstance(permissions, Sequence) and not isinstance(permissions, (str, bytes)):
+        if timeframe not in {str(item) for item in permissions}:
+            return "timeframe_not_permitted"
+    else:
+        return "timeframe_permission_unverified"
+    return None
 
 
 def _cell(
@@ -169,6 +302,7 @@ def _cell(
     quality: Mapping[str, Any] | None,
     transform: Mapping[str, Any] | None,
     watermark: Mapping[str, Any] | None,
+    entitlement: Mapping[str, Any] | None,
     now: datetime,
 ) -> dict[str, Any]:
     applicable = (
@@ -244,7 +378,7 @@ def _cell(
         "asset_class": instrument.asset_class,
         "source_id": instrument.source_id,
         "source_mode": instrument.source_id,
-        "entitlement": _manifest_entitlement(instrument),
+        "entitlement": _manifest_entitlement(instrument, entitlement),
         "timeframe": timeframe,
         "applicability": "applicable",
         "status": status,
@@ -302,19 +436,30 @@ def build_mvp_health_matrix(
     *,
     now: datetime | None = None,
     interval_seconds: int = 4 * 60 * 60,
+    scope: str = MATRIX_SCOPE_FULL,
     instrument_ids: Sequence[str] | None = None,
 ) -> dict[str, Any]:
-    """Build the bounded source-aware matrix from persisted facts only.
+    """Build the source-aware matrix from persisted facts only.
 
-    The default is the approved #69 3+3 slice.  Callers may pass an explicit
-    manifest identity list for deterministic tests or the later full-manifest
-    expansion; unknown identities fail closed instead of silently shrinking
-    the requested matrix.
+    The API defaults to the full runtime manifest for #70.  The approved #69
+    slice remains available through ``scope="demo_3x3"`` or an explicit
+    identity list. Unknown identities fail closed instead of silently
+    shrinking the requested matrix.
     """
 
     observed_at = now or datetime.now(timezone.utc)
-    selected_ids = tuple(instrument_ids or MVP_DEMO_INSTRUMENT_IDS)
     by_id = {instrument.instrument_id: instrument for instrument in manifest.instruments}
+    if instrument_ids is not None:
+        selected_ids = tuple(instrument_ids)
+        scope_name = MATRIX_SCOPE_DEMO if selected_ids == MVP_DEMO_INSTRUMENT_IDS else "custom"
+    elif scope == MATRIX_SCOPE_DEMO:
+        selected_ids = MVP_DEMO_INSTRUMENT_IDS
+        scope_name = MATRIX_SCOPE_DEMO
+    elif scope == MATRIX_SCOPE_FULL:
+        selected_ids = tuple(instrument.instrument_id for instrument in manifest.instruments)
+        scope_name = MATRIX_SCOPE_FULL
+    else:
+        raise ValueError(f"unsupported matrix scope: {scope}")
     missing_ids = [instrument_id for instrument_id in selected_ids if instrument_id not in by_id]
     if missing_ids:
         raise ValueError(f"matrix instruments missing from manifest: {', '.join(missing_ids)}")
@@ -340,6 +485,11 @@ def build_mvp_health_matrix(
     watermarks = (
         storage.latest_mvp_watermarks() if hasattr(storage, "latest_mvp_watermarks") else []
     )
+    entitlements = (
+        storage.latest_mvp_entitlement_receipts()
+        if hasattr(storage, "latest_mvp_entitlement_receipts")
+        else []
+    )
     latest_map = {_key(row): row for row in latest_rows}
     observation_map = {_key(row): row for row in observations}
     quality_map = {_key(row): row for row in qualities}
@@ -354,6 +504,9 @@ def build_mvp_health_matrix(
         for row in transforms
     }
     watermark_map = {_key(row): row for row in watermarks}
+    entitlement_map = {
+        str(row.get("source_id") or ""): row for row in entitlements if row.get("source_id")
+    }
 
     cells: list[dict[str, Any]] = []
     for instrument in selected_instruments:
@@ -370,6 +523,7 @@ def build_mvp_health_matrix(
             quality = quality_map.get(key)
             transform = transform_map.get(key)
             watermark = watermark_map.get(key)
+            entitlement = entitlement_map.get(instrument.source_id)
             if timeframe in instrument.not_applicable_timeframes:
                 cells.append(
                     _cell(
@@ -382,15 +536,19 @@ def build_mvp_health_matrix(
                         quality=None,
                         transform=None,
                         watermark=None,
+                        entitlement=None,
                         now=observed_at,
                     )
                 )
                 continue
-            if (
-                instrument.source_status == "blocked_for_entitlement"
-                or timeframe in instrument.blocked_timeframes
-            ):
-                status, reason = "blocked", "entitlement_blocked"
+            entitlement_reason = _entitlement_block_reason(
+                instrument,
+                timeframe,
+                entitlement,
+                derived=bool(transform) or timeframe in {"4h", "1w"},
+            )
+            if entitlement_reason or timeframe in instrument.blocked_timeframes:
+                status, reason = "blocked", entitlement_reason or "timeframe_blocked"
             elif timeframe not in instrument.required_timeframes:
                 cells.append(
                     _cell(
@@ -403,6 +561,7 @@ def build_mvp_health_matrix(
                         quality=None,
                         transform=None,
                         watermark=None,
+                        entitlement=None,
                         now=observed_at,
                     )
                 )
@@ -440,14 +599,21 @@ def build_mvp_health_matrix(
                     quality=quality,
                     transform=transform,
                     watermark=watermark,
+                    entitlement=entitlement,
                     now=observed_at,
                 )
             )
 
     coverage = _status_counts(cells)
     statuses = {str(cell["status"]) for cell in cells if cell["applicability"] == "applicable"}
-    latest_runs = storage.latest_mvp_runs(limit=6) if hasattr(storage, "latest_mvp_runs") else []
+    latest_runs = storage.latest_mvp_runs(limit=24) if hasattr(storage, "latest_mvp_runs") else []
     latest_runs = [_safe_run(run) for run in latest_runs]
+    run_cutoff = observed_at.astimezone(timezone.utc) - timedelta(hours=24)
+    latest_runs = [
+        run
+        for run in latest_runs
+        if (started := _parse_timestamp(run.get("started_at"))) is None or started >= run_cutoff
+    ]
     latest_run = (
         latest_runs[0]
         if latest_runs
@@ -473,7 +639,7 @@ def build_mvp_health_matrix(
         "manifest_version": manifest.version,
         "manifest_hash": manifest_digest(manifest),
         "scope": {
-            "name": "demo_3x3",
+            "name": scope_name,
             "instrument_count": len(selected_instruments),
             "universes": universes,
         },

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -630,13 +630,6 @@ def build_mvp_health_matrix(
         for run in persisted_runs
         if (started := _parse_timestamp(run.get("started_at"))) is None or started >= run_cutoff
     ]
-    latest_run = (
-        persisted_runs[0]
-        if persisted_runs
-        else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
-    )
-    if latest_run is not None:
-        latest_run = _safe_run(latest_run)
     storage_health = storage.mvp_storage_health() if hasattr(storage, "mvp_storage_health") else {}
     backup = storage.latest_mvp_backup() if hasattr(storage, "latest_mvp_backup") else None
     infrastructure_status = "ready" if storage_health.get("status") in {"ok", "ready"} else "failed"

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -43,7 +43,9 @@ async def health_ui() -> str:
     .toolbar { display:flex; flex-wrap:wrap; justify-content:space-between; gap:12px; align-items:center;
       margin-bottom:18px; padding:11px 14px; background:rgba(16,29,42,.8); border:1px solid var(--line); border-radius:10px; }
     .toolbar span { color:var(--muted); font-size:12px }
-    .toolbar select { border:1px solid var(--line); border-radius:7px; padding:7px 10px; background:var(--panel-2); color:var(--text) }
+    .toolbar label { display:flex; align-items:center; gap:6px }
+    .toolbar input, .toolbar select { border:1px solid var(--line); border-radius:7px; padding:7px 10px; background:var(--panel-2); color:var(--text) }
+    .toolbar input { width:150px }
     .coverage-grid { display:grid; grid-template-columns:repeat(5,minmax(155px,1fr)); gap:10px; margin-bottom:26px }
     .card { background:linear-gradient(145deg,rgba(16,29,42,.98),rgba(12,23,34,.98)); border:1px solid var(--line); border-radius:12px; padding:14px }
     .coverage-card { min-height:116px }
@@ -65,6 +67,8 @@ async def health_ui() -> str:
     .asset { min-width:185px }
     .asset strong { display:block; font-size:13px }
     .asset small { display:block; color:var(--muted); margin-top:2px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+    .group-row td { padding:8px 11px; background:#111f2e; color:var(--accent); font-weight:700 }
+    .group-toggle { border:0; padding:0; background:transparent; color:inherit; font:inherit; cursor:pointer }
     .cell { width:100%; min-width:118px; border:1px solid transparent; border-radius:8px; padding:7px 8px; text-align:left;
       background:#152335; color:var(--text); cursor:pointer; transition:border-color .15s,transform .15s; }
     .cell:hover { border-color:var(--accent); transform:translateY(-1px) }
@@ -111,15 +115,18 @@ async def health_ui() -> str:
   </header>
   <div id="banner" class="banner" role="status"><i class="dot"></i><span id="banner-text"></span></div>
   <div class="toolbar"><span id="snapshot-meta">正在连接健康矩阵…</span>
-    <label><span>矩阵筛选：</span><select id="filter"><option value="all">显示全部</option><option value="attention">仅显示需关注</option></select></label></div>
+    <label><span>搜索：</span><input id="search" aria-label="搜索" type="search" placeholder="代码或名称" autocomplete="off"></label>
+    <label><span>市场：</span><select id="market-filter" aria-label="市场"><option value="all">全部市场</option><option value="a_share">A 股</option><option value="us_stock">美股</option><option value="cross_market">跨市场</option></select></label>
+    <label><span>时间级别：</span><select id="timeframe-filter" aria-label="时间级别"><option value="all">全部级别</option><option value="15m">15 分钟</option><option value="1h">1 小时</option><option value="4h">4 小时</option><option value="1d">日线</option><option value="1w">周线</option></select></label>
+    <label><span>状态：</span><select id="filter" aria-label="状态"><option value="all">全部状态</option><option value="ready">正常</option><option value="partial">部分</option><option value="stale">过期</option><option value="failed">失败</option><option value="blocked">阻塞</option><option value="unavailable">不可用</option><option value="not_applicable">不适用</option></select></label></div>
 
   <section><div class="section-head"><h2>覆盖概览</h2><small id="coverage-meta">—</small></div><div id="coverage" class="coverage-grid"></div></section>
 
   <section class="section"><div class="section-head"><h2>资产 × 时间级别明细</h2><small>点击单元格查看来源、质量和水位证据</small></div>
     <div class="matrix-wrap"><table id="matrix"><thead><tr><th class="asset">资产</th><th>15 分钟</th><th>1 小时</th><th>4 小时</th><th>日线</th><th>周线</th></tr></thead><tbody id="matrix-body"><tr><td colspan="6" class="empty">正在读取数据…</td></tr></tbody></table></div></section>
 
-  <section class="section lower-grid"><div><div class="section-head"><h2>最近一次运行</h2><small>按时间倒序展示</small></div>
-      <div class="matrix-wrap"><table class="run-table"><thead><tr><th>运行编号</th><th>状态</th><th>开始</th><th>结束</th><th>蜡烛数</th><th>质量数</th></tr></thead><tbody id="runs-body"><tr><td colspan="6" class="empty">暂无运行记录</td></tr></tbody></table></div></div>
+  <section class="section lower-grid"><div><div class="section-head"><h2>最近一次运行</h2><small id="next-run-meta">按时间倒序展示</small></div>
+      <div class="matrix-wrap"><table class="run-table"><thead><tr><th>运行编号</th><th>状态</th><th>开始</th><th>结束</th><th>覆盖/尝试</th><th>水位推进</th><th>失败原因</th></tr></thead><tbody id="runs-body"><tr><td colspan="7" class="empty">暂无运行记录</td></tr></tbody></table></div></div>
     <div><div class="section-head"><h2>基础设施</h2><small>不包含密钥和原始路径</small></div><div id="infrastructure" class="card infra-grid"><div class="empty">暂无基础设施事实</div></div></div></section>
 </main>
 
@@ -136,16 +143,21 @@ async def health_ui() -> str:
   const timeframes = ['15m','1h','4h','1d','1w'];
   const timeframeLabels = {'15m':'15 分钟','1h':'1 小时','4h':'4 小时','1d':'日线','1w':'周线'};
   const statusLabels = {ready:'正常',partial:'部分',stale:'过期',failed:'失败',blocked:'阻塞',unavailable:'不可用',not_applicable:'不适用'};
-  const attention = new Set(['partial','stale','failed','blocked','unavailable']);
+  const universeLabels = {a_share:'A 股',us_stock:'美股',cross_market:'跨市场'};
   let latestSnapshot = null;
   let latestReceivedAt = 0;
   let loading = false;
+  const collapsedGroups = new Set();
 
   const esc = value => String(value ?? '—').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[c]));
   const fmtTime = value => { if (!value) return '—'; const date = new Date(value); return Number.isNaN(date.getTime()) ? esc(value) : date.toLocaleString('zh-CN',{hour12:false}); };
   const fmtCount = value => value == null ? '—' : Number(value).toLocaleString('zh-CN');
   const statusText = status => statusLabels[status] || status || '未知';
-  const validSnapshot = data => data && Array.isArray(data.cells) && data.coverage && typeof data.coverage === 'object' && data.refresh;
+  const validSnapshot = data => {
+    if (!data || !Array.isArray(data.cells) || !data.coverage || typeof data.coverage !== 'object' || !data.refresh || !Object.prototype.hasOwnProperty.call(statusLabels, data.status)) return false;
+    if (!timeframes.every(tf => data.coverage[tf] && Number.isFinite(Number(data.coverage[tf].applicable)) && Number.isFinite(Number(data.coverage[tf].not_applicable)))) return false;
+    return data.cells.every(cell => timeframes.includes(cell.timeframe) && ['applicable','not_applicable'].includes(cell.applicability) && Object.prototype.hasOwnProperty.call(statusLabels, cell.status));
+  };
   const showBanner = (text, severity = 'error') => {
     const banner = document.getElementById('banner');
     document.getElementById('banner-text').textContent = text;
@@ -167,28 +179,51 @@ async def health_ui() -> str:
     document.getElementById('coverage-meta').textContent = `共 ${fmtCount(snapshot.cells.length)} 个单元格 · 清单 ${esc(snapshot.manifest_version)}`;
   }
 
+  const universeFor = cell => cell.asset_class === 'a_share' ? 'a_share' : cell.asset_class === 'us_stock' ? 'us_stock' : 'cross_market';
+
   function renderMatrix(snapshot) {
-    const filter = document.getElementById('filter').value;
+    const query = document.getElementById('search').value.trim().toLowerCase();
+    const market = document.getElementById('market-filter').value;
+    const timeframeFilter = document.getElementById('timeframe-filter').value;
+    const statusFilter = document.getElementById('filter').value;
     const grouped = new Map();
     snapshot.cells.forEach(cell => {
-      if (filter === 'attention' && !attention.has(cell.status)) return;
+      const universe = universeFor(cell);
+      const matchesText = !query || `${cell.display_symbol || ''} ${cell.display_name || ''}`.toLowerCase().includes(query);
+      if (!matchesText || (market !== 'all' && universe !== market) || (statusFilter !== 'all' && cell.status !== statusFilter)) return;
       const key = cell.instrument_id || cell.display_symbol;
-      if (!grouped.has(key)) grouped.set(key, {symbol:cell.display_symbol, name:cell.display_name, cells:{}});
-      grouped.get(key).cells[cell.timeframe] = cell;
+      if (!grouped.has(universe)) grouped.set(universe, new Map());
+      if (!grouped.get(universe).has(key)) grouped.get(universe).set(key, {symbol:cell.display_symbol, name:cell.display_name, cells:{}});
+      grouped.get(universe).get(key).cells[cell.timeframe] = cell;
     });
-    const rows = Array.from(grouped.values());
-    document.getElementById('matrix-body').innerHTML = rows.length ? rows.map(row => `<tr><td class="asset"><strong>${esc(row.symbol)}</strong><small>${esc(row.name)}</small></td>${timeframes.map(tf => {
-      const cell = row.cells[tf];
-      if (!cell) return '<td><div class="empty">—</div></td>';
-      const latest = cell.latest_closed_timestamp ? fmtTime(cell.latest_closed_timestamp) : '暂无收盘数据';
-      return `<td><button class="cell ${esc(cell.status)}" type="button" data-cell="${esc(JSON.stringify(cell))}"><span class="cell-top"><span class="state">${esc(statusText(cell.status))}</span><span>${esc(timeframeLabels[tf])}</span></span><span class="age">${esc(latest)}</span></button></td>`;
-    }).join('')}</tr>`).join('') : '<tr><td colspan="6" class="empty">当前筛选没有需要展示的资产</td></tr>';
+    const sections = Array.from(grouped.entries()).filter(([, rows]) => Array.from(rows.values()).some(row => timeframeFilter === 'all' || row.cells[timeframeFilter]));
+    const html = sections.map(([universe, rows]) => {
+      const collapsed = collapsedGroups.has(universe);
+      const rowHtml = collapsed ? '' : Array.from(rows.values()).filter(row => timeframeFilter === 'all' || row.cells[timeframeFilter]).map(row => `<tr><td class="asset"><strong>${esc(row.symbol)}</strong><small>${esc(row.name)}</small></td>${timeframes.map(tf => {
+        const cell = row.cells[tf];
+        if (!cell) return '<td><div class="empty">—</div></td>';
+        const latest = cell.latest_closed_timestamp ? fmtTime(cell.latest_closed_timestamp) : '暂无收盘数据';
+        return `<td><button class="cell ${esc(cell.status)}" type="button" data-cell="${esc(JSON.stringify(cell))}"><span class="cell-top"><span class="state">${esc(statusText(cell.status))}</span><span>${esc(timeframeLabels[tf])}</span></span><span class="age">${esc(latest)}</span></button></td>`;
+      }).join('')}</tr>`).join('');
+      return `<tr class="group-row"><td colspan="6"><button class="group-toggle" type="button" data-group-toggle="${esc(universe)}">${collapsed ? '展开' : '收起'} · ${esc(universeLabels[universe])}（${rows.size} 个资产）</button></td></tr>${rowHtml}`;
+    }).join('');
+    document.getElementById('matrix-body').innerHTML = html || '<tr><td colspan="6" class="empty">当前筛选没有需要展示的资产</td></tr>';
     document.querySelectorAll('[data-cell]').forEach(button => button.addEventListener('click', () => openDetail(JSON.parse(button.dataset.cell))));
+    document.querySelectorAll('[data-group-toggle]').forEach(button => button.addEventListener('click', () => {
+      const key = button.dataset.groupToggle;
+      if (collapsedGroups.has(key)) collapsedGroups.delete(key); else collapsedGroups.add(key);
+      renderMatrix(snapshot);
+    }));
   }
 
   function renderRuns(snapshot) {
     const rows = snapshot.runs || [];
-    document.getElementById('runs-body').innerHTML = rows.length ? rows.map(run => `<tr><td title="${esc(run.run_id)}">${esc(String(run.run_id || '—').slice(0,18))}</td><td class="run-status">${esc(statusText(run.status === 'success' ? 'ready' : run.status))}</td><td>${esc(fmtTime(run.started_at))}</td><td>${esc(fmtTime(run.completed_at))}</td><td>${esc(fmtCount(run.candle_count))}</td><td>${esc(fmtCount(run.quality_count))}</td></tr>`).join('') : '<tr><td colspan="6" class="empty">暂无运行记录</td></tr>';
+    const nextDue = (snapshot.worker || {}).next_due_at;
+    document.getElementById('next-run-meta').textContent = nextDue ? `下一次运行 ${fmtTime(nextDue)}` : '最近 24 小时 · 按时间倒序展示';
+    document.getElementById('runs-body').innerHTML = rows.length ? rows.map(run => {
+      const failure = run.error && typeof run.error === 'object' ? run.error.message : run.error;
+      return `<tr><td title="${esc(run.run_id)}">${esc(String(run.run_id || '—').slice(0,18))}</td><td class="run-status">${esc(statusText(run.status === 'success' ? 'ready' : run.status))}</td><td>${esc(fmtTime(run.started_at))}</td><td>${esc(fmtTime(run.completed_at))}</td><td>${esc(fmtCount(run.observation_count))}</td><td>${esc(fmtCount(run.watermark_count))}</td><td title="${esc(failure)}">${esc(failure || '—')}</td></tr>`;
+    }).join('') : `<tr><td colspan="7" class="empty">暂无最近 24 小时运行记录${nextDue ? ` · 下一次 ${esc(fmtTime(nextDue))}` : ''}</td></tr>`;
   }
 
   function renderInfrastructure(snapshot) {
@@ -226,7 +261,7 @@ async def health_ui() -> str:
       ['来源标识', cell.source_id], ['供应商代码', cell.provider_symbol], ['来源模式', cell.source_mode],
       ['最近收盘', cell.latest_closed_timestamp ? fmtTime(cell.latest_closed_timestamp) : null], ['存储行数', fmtCount(cell.row_count)],
       ['是否聚合', cell.is_derived == null ? null : (cell.is_derived ? '是' : '否')], ['最近尝试', fmtTime(cell.last_attempt_at)],
-      ['最近成功', fmtTime(cell.last_success_at)], ['质量', cell.quality], ['水位', cell.watermark], ['转换凭证', cell.transform], ['错误', cell.error]
+      ['最近成功', fmtTime(cell.last_success_at)], ['质量', cell.quality], ['水位', cell.watermark], ['转换凭证', cell.transform], ['策略信息', cell.policy], ['错误', cell.error]
     ];
     document.getElementById('drawer-title').textContent = `${cell.display_symbol || '资产'} · ${timeframeLabels[cell.timeframe] || cell.timeframe}`;
     document.getElementById('detail-list').innerHTML = rows.map(([key,value]) => `<dt>${esc(key)}</dt><dd>${value && typeof value === 'object' ? `<code>${esc(JSON.stringify(value,null,2))}</code>` : esc(value)}</dd>`).join('');
@@ -266,7 +301,9 @@ async def health_ui() -> str:
     } finally { clearTimeout(timeout); loading = false; }
   }
 
-  document.getElementById('filter').addEventListener('change', () => { if (latestSnapshot) renderMatrix(latestSnapshot); });
+  ['search','market-filter','timeframe-filter','filter'].forEach(id => {
+    document.getElementById(id).addEventListener(id === 'search' ? 'input' : 'change', () => { if (latestSnapshot) renderMatrix(latestSnapshot); });
+  });
   document.getElementById('close-drawer').addEventListener('click', closeDetail);
   document.getElementById('drawer-backdrop').addEventListener('click', event => { if (event.target.id === 'drawer-backdrop') closeDetail(); });
   document.addEventListener('keydown', event => { if (event.key === 'Escape') closeDetail(); });

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -154,7 +154,7 @@ async def health_ui() -> str:
   const fmtCount = value => value == null ? '—' : Number(value).toLocaleString('zh-CN');
   const statusText = status => statusLabels[status] || status || '未知';
   const validSnapshot = data => {
-    if (!data || !Array.isArray(data.cells) || !data.coverage || typeof data.coverage !== 'object' || !data.refresh || !Object.prototype.hasOwnProperty.call(statusLabels, data.status)) return false;
+    if (!data || !Array.isArray(data.cells) || !data.coverage || typeof data.coverage !== 'object' || !data.refresh || !data.worker || typeof data.worker !== 'object' || !Array.isArray(data.runs) || !data.infrastructure || typeof data.infrastructure !== 'object' || !Object.prototype.hasOwnProperty.call(statusLabels, data.status)) return false;
     if (!timeframes.every(tf => data.coverage[tf] && Number.isFinite(Number(data.coverage[tf].applicable)) && Number.isFinite(Number(data.coverage[tf].not_applicable)))) return false;
     return data.cells.every(cell => timeframes.includes(cell.timeframe) && ['applicable','not_applicable'].includes(cell.applicability) && Object.prototype.hasOwnProperty.call(statusLabels, cell.status));
   };

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -1118,7 +1118,7 @@ class KlineStore:
         with self._session_factory() as session:
             rows = session.execute(
                 select(MvpRunRow)
-                .order_by(MvpRunRow.created_at.desc(), MvpRunRow.run_id.desc())
+                .order_by(MvpRunRow.started_at.desc(), MvpRunRow.run_id.desc())
                 .limit(bounded_limit)
             ).scalars()
             return [
@@ -1208,6 +1208,39 @@ class KlineStore:
                         "invalid_rows": row.invalid_rows,
                         "blocked_cells": row.blocked_cells,
                         "details": json.loads(row.details_json or "{}"),
+                        "receipt_hash": row.receipt_hash,
+                    }
+                )
+            return result
+
+    def latest_mvp_entitlement_receipts(self) -> list[dict[str, Any]]:
+        """Return the newest entitlement receipt for each source."""
+
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(MvpEntitlementReceiptRow).order_by(
+                    MvpEntitlementReceiptRow.created_at.desc()
+                )
+            ).scalars()
+            seen: set[str] = set()
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                if row.source_id in seen:
+                    continue
+                seen.add(row.source_id)
+                result.append(
+                    {
+                        "receipt_id": row.receipt_id,
+                        "source_id": row.source_id,
+                        "status": row.status,
+                        "allowed_history": json.loads(row.allowed_history_json or "{}"),
+                        "timeframe_permissions": json.loads(row.timeframe_permissions_json or "[]"),
+                        "persistence_allowed": row.persistence_allowed,
+                        "derived_allowed": row.derived_allowed,
+                        "non_display_allowed": row.non_display_allowed,
+                        "valid_from": row.valid_from,
+                        "valid_to": row.valid_to,
+                        "evidence_ref": row.evidence_ref,
                         "receipt_hash": row.receipt_hash,
                     }
                 )

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -256,6 +256,30 @@ def test_derived_entitlement_does_not_block_native_one_hour_cells() -> None:
     assert _entitlement_block_reason(btc, "1h", receipt, derived=True) == "derived_not_allowed"
 
 
+def test_run_timeline_does_not_fallback_to_older_than_24_hours(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-runs.db"))
+    store.commit_mvp_run(
+        MvpRunWrite(
+            run_id="old-run",
+            manifest_version=manifest.version,
+            manifest_hash="a" * 64,
+            started_at="2026-08-01T00:00:00+00:00",
+            window_start=None,
+            window_end=None,
+            policy={},
+            completed_at="2026-08-01T00:01:00+00:00",
+        )
+    )
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        scope="demo_3x3",
+        now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+    )
+    assert snapshot["runs"] == []
+
+
 def test_health_matrix_api_and_ui_are_chinese_and_read_only(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from dataclasses import replace
 import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 from kline.app import create_app
-from kline.health_matrix import MVP_DEMO_INSTRUMENT_IDS, build_mvp_health_matrix
+from kline.health_matrix import (
+    MVP_DEMO_INSTRUMENT_IDS,
+    _entitlement_block_reason,
+    _freshness_stale,
+    build_mvp_health_matrix,
+)
 from kline.mvp_manifest import load_manifest
 from kline.storage import (
     CandleSeriesKey,
+    EntitlementReceiptWrite,
     MvpCandle,
     MvpRunWrite,
     QualityReceiptWrite,
@@ -54,6 +61,7 @@ def test_matrix_returns_every_manifest_timeframe_cell_and_explicit_statuses(tmp_
     snapshot = build_mvp_health_matrix(
         manifest,
         store,
+        scope="demo_3x3",
         now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
     )
 
@@ -111,6 +119,22 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
                     run_id=run_id,
                 ),
             ),
+            entitlement_receipts=(
+                EntitlementReceiptWrite(
+                    receipt_id="matrix-entitlement-1",
+                    source_id="hyperliquid_perpetual_public",
+                    status="active",
+                    allowed_history={"days": 365},
+                    timeframe_permissions=("15m", "1h", "4h", "1d", "1w"),
+                    persistence_allowed=True,
+                    derived_allowed=True,
+                    non_display_allowed=True,
+                    valid_from="2026-01-01",
+                    valid_to=None,
+                    evidence_ref="operator://matrix-test",
+                    receipt_hash="c" * 64,
+                ),
+            ),
         )
     )
 
@@ -128,6 +152,7 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
     assert btc_1h["status"] == "ready"
     assert btc_1h["latest_closed_timestamp"] == candle.timestamp
     assert btc_1h["watermark"]["run_id"] == run_id
+    assert btc_1h["entitlement"]["status"] == "active"
     assert snapshot["coverage"]["1h"]["ready"] == 1
     assert btc_1h["run_id"] == run_id
     serialized = json.dumps(btc_1h, ensure_ascii=False)
@@ -177,7 +202,58 @@ def test_not_applicable_cell_keeps_the_full_null_payload_shape(tmp_path: Path) -
     ):
         assert intraday[field] is None
     assert daily["applicability"] == "applicable"
-    assert daily["status"] == "unavailable"
+    assert daily["status"] == "blocked"
+    assert daily["status_reason"] == "entitlement_unverified"
+
+
+def test_full_scope_preserves_manifest_cartesian_product_and_coverage_invariants(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-full.db"))
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(snapshot["cells"]) == 216 * 5
+    assert all(cell["timeframe"] != "30m" for cell in snapshot["cells"])
+    assert snapshot["scope"]["name"] == "full_216"
+    for timeframe, counts in snapshot["coverage"].items():
+        total = sum(1 for cell in snapshot["cells"] if cell["timeframe"] == timeframe)
+        assert counts["applicable"] + counts["not_applicable"] == total
+        assert (
+            sum(
+                counts[state]
+                for state in ("ready", "partial", "stale", "failed", "blocked", "unavailable")
+            )
+            == counts["applicable"]
+        )
+
+
+def test_freshness_uses_session_and_continuous_calendar_slas() -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    aapl = next(item for item in manifest.instruments if item.display_symbol == "AAPL")
+    aapl = replace(aapl, source_status="configured")
+    now = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
+    assert _freshness_stale(aapl, "1d", "2026-08-25T00:00:00+00:00", now=now)
+
+    btc = next(item for item in manifest.instruments if item.display_symbol == "BTC")
+    assert _freshness_stale(btc, "1h", "2026-08-31T00:00:00+00:00", now=now)
+
+
+def test_derived_entitlement_does_not_block_native_one_hour_cells() -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    btc = next(item for item in manifest.instruments if item.display_symbol == "BTC")
+    receipt = {
+        "status": "active",
+        "persistence_allowed": True,
+        "derived_allowed": False,
+        "timeframe_permissions": ("15m", "1h", "4h", "1d", "1w"),
+    }
+    assert _entitlement_block_reason(btc, "1h", receipt, derived=False) is None
+    assert _entitlement_block_reason(btc, "1h", receipt, derived=True) == "derived_not_allowed"
 
 
 def test_health_matrix_api_and_ui_are_chinese_and_read_only(
@@ -193,11 +269,11 @@ def test_health_matrix_api_and_ui_are_chinese_and_read_only(
 
     assert response.status_code == 200
     payload = response.json()
-    assert len(payload["cells"]) == 6 * 5
+    assert len(payload["cells"]) == 216 * 5
     assert payload["scope"] == {
-        "name": "demo_3x3",
-        "instrument_count": 6,
-        "universes": {"a_share": 3, "us_stock": 3},
+        "name": "full_216",
+        "instrument_count": 216,
+        "universes": {"a_share": 100, "us_stock": 100, "cross_market": 16},
     }
     assert payload["refresh"]["poll_interval_seconds"] == 30
     assert payload["refresh"]["request_timeout_seconds"] == 10
@@ -206,3 +282,41 @@ def test_health_matrix_api_and_ui_are_chinese_and_read_only(
     assert "最近一次运行" in page.text
     assert "system notification" not in page.text.lower()
     assert "重试" not in page.text
+
+
+def test_matrix_api_failure_preserves_last_success_timestamp(monkeypatch, tmp_path: Path) -> None:
+    import kline.api as api_module
+    from kline.config import Settings
+    from kline.registry import init
+
+    init(Settings(db_path=str(tmp_path / "api-loss.db"), load_entrypoint_adapters=False))
+
+    with TestClient(create_app()) as client:
+        assert client.get("/api/mvp/health/matrix").status_code == 200
+
+        def fail_manifest(_path: Path):
+            raise RuntimeError("token=should-not-leak")
+
+        monkeypatch.setattr(api_module, "load_manifest", fail_manifest)
+        response = client.get("/api/mvp/health/matrix")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["error"] == "dashboard_unavailable"
+    assert detail["last_success_at"]
+    assert "should-not-leak" not in response.text
+
+
+def test_matrix_api_exposes_demo_scope_only_when_explicit(tmp_path: Path) -> None:
+    from kline.config import Settings
+    from kline.registry import init
+
+    init(Settings(db_path=str(tmp_path / "api-scope.db"), load_entrypoint_adapters=False))
+    with TestClient(create_app()) as client:
+        demo = client.get("/api/mvp/health/matrix?scope=demo_3x3")
+        invalid = client.get("/api/mvp/health/matrix?scope=source_switch")
+
+    assert demo.status_code == 200
+    assert demo.json()["scope"]["name"] == "demo_3x3"
+    assert len(demo.json()["cells"]) == 30
+    assert invalid.status_code == 400

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -10,4 +10,10 @@ def test_health_ui_is_browser_visible():
     assert "资产 × 时间级别健康矩阵" in response.text
     assert "fetch(`${API}?_=${Date.now()}`" in response.text
     assert "最近一次运行" in response.text
+    assert "market-filter" in response.text
+    assert "timeframe-filter" in response.text
+    assert "data-group-toggle" in response.text
+    assert "MAX_SNAPSHOT_MS = 900000" in response.text
+    assert "AbortController" in response.text
+    assert "cache:'no-store'" in response.text
     assert "重试" not in response.text


### PR DESCRIPTION
## What
- expand `/api/mvp/health/matrix` and Chinese `/health-ui` to the runtime manifest: 216 instruments × 5 timeframes
- add calendar-aware freshness for session and continuous markets, entitlement/transform/watermark-aware statuses, and 24-hour run timeline
- add manifest-derived source mode, full schema validation, search/market/timeframe/status filters, grouping and collapse, and redacted receipt details
- add full-manifest runtime verification receipt

## Why
- graduate the verified 3+3 slice into the complete bounded MVP matrix without hiding blocked, partial, stale, unavailable, or not-applicable cells

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (253 passed)
- `python3 -m ruff check ...` (changed files clean)
- `git diff --check`
- `gitleaks detect --no-banner --redact --source .` (no leaks)
- live isolated HTTP endpoint returned 1,080 cells and coverage invariants; browser verified search, market filter, group collapse, and detail drawer
- unresolved provider entitlement remains explicit as blocked; no NAS migration or public exposure

Closes #70