### PR TITLE
feat: start MVP seven-day reliability observation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .venv/
 data/*.db
 data/*.db-*
+data/*.lock
 .env
 .env.local
 *.egg-info/

--- a/docs/verification/health-matrix-reliability-2026-09-01.md
+++ b/docs/verification/health-matrix-reliability-2026-09-01.md
@@ -1,0 +1,38 @@
+# 3+3 Health Matrix 可靠性观察启动证据
+
+- 观察时间：2026-09-01T06:03:27+00:00
+- 持续 API：`http://127.0.0.1:18171/health-ui`
+- 持续矩阵：`GET /api/mvp/health/matrix?scope=demo_3x3`
+- launchd：`com.wendy.datafeed.mvp-api` 与 `com.wendy.datafeed.mvp-worker` 均为 running / KeepAlive
+- 隔离数据库：`/Users/wendy/datafeed-runtime-issue-71/data/kline.db`（本地 SQLite；不触碰 resident DB、SSD 或 NAS）
+- worker 间隔：14,400 秒（4 小时）
+- manifest：`mvp_universe_v1`
+- manifest hash：`bf276deacc6fc50606241d7d91ef1656725bc688ccfb3fec720865b510b49f25`
+- 本次矩阵 response SHA-256：`1fbc2af6026dfb158ea693b78e72c33ac306727fd6cf46cfb4e8d9e9d25ff3f6`
+
+## 首次真实运行
+
+- run_id：`mvp-20260901T060237Z`
+- terminal status：`partial`
+- API 返回 30 个 cell（3 个 A 股 × 3 个美股 × 5 个时间级别）。
+- 每个适用 cell 都是 `blocked`，原因 `entitlement_blocked`；没有任何 blocked/unavailable 被计入 ready。
+- 五个时间级别的 coverage 均为 `applicable=6, ready=0, blocked=6`。
+- worker 已计算下一次运行：`2026-09-01T10:02:37+00:00`。
+- 数据源/持久化授权仍未核实，因此总体状态保持 `failed`，没有宣称 verified。
+
+## 审计器首次观察
+
+以 `2026-09-01T06:00:00+00:00` 到 `2026-09-01T06:10:00+00:00` 的短窗口运行审计：
+
+- 总体 `blocked`，因为窗口远未满七个自然日。
+- terminal receipt：`1/1`，当前短窗口为 100%。
+- 最大静默间隔：`0.123` 小时；canonical duplicate keys：`0`；失败 run 推进 watermark：`0`。
+- 七天门槛仍为 `blocked`；必须让 launchd 真实运行七天后再审计，不能用合成时间或回放数据代替。
+
+## 浏览器证据
+
+真实浏览器已打开持续页面并验证：中文标题、三组资产、30 个 cell、固定页内失败横幅；搜索、市场筛选、分组折叠和只读详情抽屉均可操作。截图已在本次运行的浏览器证据中采集；页面没有系统通知、重试按钮、来源切换或交易动作。
+
+## 当前结论
+
+可靠性观察已经开始，但 #71 尚未完成。满足七天窗口、95% terminal receipt、无八小时静默和故障/恢复/快照过期浏览器证据后，才可更新为 ready；任何 A/US 授权限制继续保持 blocked/partial。

--- a/ops/com.wendy.datafeed.mvp-api.plist.example
+++ b/ops/com.wendy.datafeed.mvp-api.plist.example
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wendy.datafeed.mvp-api</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/python3</string>
+        <string>-m</string>
+        <string>uvicorn</string>
+        <string>kline.app:create_app</string>
+        <string>--factory</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>18171</string>
+        <string>--log-level</string>
+        <string>info</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/wendy/datafeed-runtime</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>/Users/wendy/datafeed-runtime/src</string>
+        <key>KLINE_DB_PATH</key>
+        <string>/Users/wendy/datafeed-runtime/data/kline.db</string>
+        <key>KLINE_LOAD_ENTRYPOINT_ADAPTERS</key>
+        <string>false</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/mvp-api.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/mvp-api.stderr.log</string>
+</dict>
+</plist>

--- a/ops/com.wendy.datafeed.mvp-worker.plist.example
+++ b/ops/com.wendy.datafeed.mvp-worker.plist.example
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wendy.datafeed.mvp-worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/python3</string>
+        <string>-m</string>
+        <string>ops.mvp_reliability</string>
+        <string>--manifest</string>
+        <string>/Users/wendy/datafeed-runtime/configs/mvp_manifest.json</string>
+        <string>--db</string>
+        <string>/Users/wendy/datafeed-runtime/data/kline.db</string>
+        <string>--lock</string>
+        <string>/Users/wendy/datafeed-runtime/data/mvp-worker.lock</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/wendy/datafeed-runtime</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>/Users/wendy/datafeed-runtime/src</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/mvp-worker.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/mvp-worker.stderr.log</string>
+</dict>
+</plist>

--- a/ops/mvp_reliability.py
+++ b/ops/mvp_reliability.py
@@ -20,6 +20,7 @@ from typing import Any, Mapping, Sequence
 from kline.config import Settings
 from kline.health_matrix import (
     MVP_DEMO_INSTRUMENT_IDS,
+    _safe_run,
     build_mvp_health_matrix,
 )
 from kline.mvp_manifest import MvpManifest, load_manifest, manifest_digest
@@ -116,7 +117,7 @@ def _run_times(store: KlineStore, start: datetime, end: datetime) -> list[dict[s
         except (TypeError, ValueError):
             continue
         if start <= parsed <= end:
-            result.append(dict(row))
+            result.append(_safe_run(row))
     result.sort(key=lambda row: _parse_time(row["started_at"]))
     return result
 

--- a/ops/mvp_reliability.py
+++ b/ops/mvp_reliability.py
@@ -1,0 +1,352 @@
+"""Run and audit the bounded 3+3 MVP reliability window.
+
+The worker path is intentionally the same atomic ``MvpWorker`` used by the
+application.  This module only selects the approved pilot identities, records
+terminal receipts, and evaluates a seven-day gate; it never turns missing
+provider rights into successful data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import signal
+from typing import Any, Mapping, Sequence
+
+from kline.config import Settings
+from kline.health_matrix import (
+    MVP_DEMO_INSTRUMENT_IDS,
+    build_mvp_health_matrix,
+)
+from kline.mvp_manifest import MvpManifest, load_manifest, manifest_digest
+from kline.mvp_worker import MAX_INTERVAL_SECONDS, MvpWorker
+from kline.registry import init
+from kline.store import KlineStore
+
+
+DEMO_INSTRUMENT_IDS = MVP_DEMO_INSTRUMENT_IDS
+RELIABILITY_DAYS = 7
+MAX_SILENT_HOURS = 8
+TERMINAL_STATUSES = {"success", "partial", "failed"}
+
+
+def _parse_time(value: str | datetime) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return _parse_time(value).replace(microsecond=0).isoformat()
+
+
+def demo_manifest(manifest: MvpManifest) -> MvpManifest:
+    """Return a manifest view containing exactly the approved 3+3 identities."""
+
+    by_id = {item.instrument_id: item for item in manifest.instruments}
+    missing = [instrument_id for instrument_id in DEMO_INSTRUMENT_IDS if instrument_id not in by_id]
+    if missing:
+        raise ValueError(f"reliability identities missing from manifest: {', '.join(missing)}")
+    return replace(
+        manifest,
+        instruments=tuple(by_id[instrument_id] for instrument_id in DEMO_INSTRUMENT_IDS),
+    )
+
+
+async def run_demo_once(
+    *,
+    db_path: str | Path,
+    manifest_path: str | Path,
+    now: datetime | None = None,
+    interval_seconds: int = MAX_INTERVAL_SECONDS,
+    lock_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Execute one real 3+3 worker attempt and return its read-only snapshot."""
+
+    observed_at = _parse_time(now or datetime.now(timezone.utc))
+    manifest = load_manifest(manifest_path)
+    demo_manifest(manifest)
+    database = Path(db_path).expanduser()
+    init(Settings(db_path=str(database), load_entrypoint_adapters=False))
+    store = KlineStore(str(database))
+    worker = MvpWorker(
+        manifest,
+        store,
+        interval_seconds=interval_seconds,
+        lock_path=lock_path or database.with_suffix(".worker.lock"),
+        instrument_ids=DEMO_INSTRUMENT_IDS,
+        clock=lambda: observed_at,
+    )
+    result = await worker.run_once()
+    health = build_mvp_health_matrix(
+        manifest,
+        store,
+        scope="demo_3x3",
+        now=observed_at,
+    )
+    return {
+        "observed_at": _iso(observed_at),
+        "manifest_version": manifest.version,
+        "manifest_hash": manifest_digest(manifest),
+        "status": result.status,
+        "run_id": result.run_id,
+        "reason": result.reason,
+        "health": health,
+        "receipt": result.receipt.to_dict() if result.receipt is not None else None,
+    }
+
+
+def _run_times(store: KlineStore, start: datetime, end: datetime) -> list[dict[str, Any]]:
+    rows = store.latest_mvp_runs(limit=1000) if hasattr(store, "latest_mvp_runs") else []
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        stamp = row.get("started_at")
+        if not stamp:
+            continue
+        try:
+            parsed = _parse_time(stamp)
+        except (TypeError, ValueError):
+            continue
+        if start <= parsed <= end:
+            result.append(dict(row))
+    result.sort(key=lambda row: _parse_time(row["started_at"]))
+    return result
+
+
+def _terminal_gate(
+    runs: Sequence[Mapping[str, Any]], *, start: datetime, end: datetime, interval_seconds: int
+) -> dict[str, Any]:
+    duration = end - start
+    planned = max(1, int(duration.total_seconds() // interval_seconds) + 1)
+    terminal = sum(str(row.get("status")) in TERMINAL_STATUSES for row in runs)
+    rate = terminal / planned
+    return {
+        "status": "ready" if rate >= 0.95 else "failed",
+        "planned_opportunities": planned,
+        "terminal_receipts": terminal,
+        "rate": round(rate, 4),
+    }
+
+
+def _silence_gate(
+    runs: Sequence[Mapping[str, Any]], *, start: datetime, end: datetime
+) -> dict[str, Any]:
+    times = [_parse_time(row["started_at"]) for row in runs if row.get("started_at")]
+    gaps = [(later - earlier).total_seconds() / 3600 for earlier, later in zip(times, times[1:])]
+    if times:
+        gaps.extend(
+            [
+                max(0.0, (times[0] - start).total_seconds() / 3600),
+                max(0.0, (end - times[-1]).total_seconds() / 3600),
+            ]
+        )
+    else:
+        gaps = [(end - start).total_seconds() / 3600]
+    maximum = max(gaps, default=0.0)
+    return {
+        "status": "ready" if maximum <= MAX_SILENT_HOURS else "failed",
+        "max_silent_hours": round(maximum, 3),
+        "run_count": len(times),
+    }
+
+
+def audit_reliability(
+    manifest: MvpManifest,
+    store: KlineStore,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    interval_seconds: int = MAX_INTERVAL_SECONDS,
+) -> dict[str, Any]:
+    """Evaluate the seven-day gate from persisted facts only."""
+
+    start = _parse_time(window_start)
+    end = _parse_time(window_end)
+    runs = _run_times(store, start, end)
+    terminal = _terminal_gate(runs, start=start, end=end, interval_seconds=interval_seconds)
+    silence = _silence_gate(runs, start=start, end=end)
+    span_days = (end - start).total_seconds() / 86_400
+    seven_days = {
+        "status": "ready" if span_days >= RELIABILITY_DAYS else "blocked",
+        "observed_days": round(span_days, 4),
+        "required_days": RELIABILITY_DAYS,
+    }
+    health = build_mvp_health_matrix(
+        manifest,
+        store,
+        scope="demo_3x3",
+        now=end,
+    )
+    applicable = [cell for cell in health["cells"] if cell["applicability"] == "applicable"]
+    invalid_cells = [
+        cell
+        for cell in applicable
+        if cell["status"] not in {"blocked", "unavailable"}
+        and not cell.get("latest_closed_timestamp")
+    ]
+    cell_gate = {
+        "status": "ready" if not invalid_cells else "failed",
+        "applicable_cells": len(applicable),
+        "evidenced_cells": len(applicable) - len(invalid_cells),
+        "invalid_cells": [
+            {
+                "instrument_id": cell["instrument_id"],
+                "timeframe": cell["timeframe"],
+                "status": cell["status"],
+            }
+            for cell in invalid_cells
+        ],
+    }
+    storage_health = store.mvp_storage_health()
+    duplicate_count = (
+        store.mvp_duplicate_key_count() if hasattr(store, "mvp_duplicate_key_count") else None
+    )
+    duplicate_gate = {
+        "status": "ready" if duplicate_count == 0 else "blocked",
+        "duplicate_keys": duplicate_count,
+    }
+    failed_run_ids = {row["run_id"] for row in runs if row.get("status") == "failed"}
+    advanced_failed = (
+        store.mvp_watermark_count_for_runs(failed_run_ids)
+        if hasattr(store, "mvp_watermark_count_for_runs")
+        else None
+    )
+    watermark_gate = {
+        "status": "ready" if advanced_failed == 0 else "blocked",
+        "failed_run_ids": sorted(failed_run_ids),
+        "watermarks_advanced_for_failed_runs": advanced_failed,
+    }
+    gates = {
+        "seven_calendar_days": seven_days,
+        "terminal_receipt": terminal,
+        "no_eight_hour_silence": silence,
+        "cell_coverage": cell_gate,
+        "canonical_idempotency": duplicate_gate,
+        "failed_run_watermarks": watermark_gate,
+    }
+    if seven_days["status"] == "blocked":
+        overall = "blocked"
+    elif any(item["status"] == "failed" for item in gates.values()):
+        overall = "failed"
+    elif any(item["status"] == "blocked" for item in gates.values()):
+        overall = "blocked"
+    else:
+        overall = "ready"
+    return {
+        "status": overall,
+        "window_start": _iso(start),
+        "window_end": _iso(end),
+        "manifest_version": manifest.version,
+        "manifest_hash": manifest_digest(manifest),
+        "run_count": len(runs),
+        "runs": runs,
+        "coverage": health["coverage"],
+        "health": health,
+        "storage": storage_health,
+        "gates": gates,
+        "unresolved": {
+            "source_entitlement": "A/US pilot source entitlement remains blocked",
+            "nas_cutover": "not in #71 scope",
+        },
+    }
+
+
+def _write_receipt(path: Path, payload: Mapping[str, Any]) -> None:
+    path.expanduser().parent.mkdir(parents=True, exist_ok=True)
+    path.expanduser().write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+async def _run_forever(args: argparse.Namespace) -> None:
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(signum, stop_event.set)
+        except NotImplementedError:  # pragma: no cover - platform fallback
+            signal.signal(signum, lambda *_: stop_event.set())
+    while not stop_event.is_set():
+        result = await run_demo_once(
+            db_path=args.db,
+            manifest_path=args.manifest,
+            interval_seconds=args.interval,
+            lock_path=args.lock,
+        )
+        print(
+            json.dumps(
+                {
+                    "observed_at": result["observed_at"],
+                    "status": result["status"],
+                    "run_id": result["run_id"],
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=args.interval)
+        except TimeoutError:
+            continue
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the bounded 3+3 MVP reliability worker")
+    parser.add_argument("--manifest", default="configs/mvp_manifest.json")
+    parser.add_argument("--db", default="data/kline.db")
+    parser.add_argument("--lock", default=None)
+    parser.add_argument("--interval", type=int, default=MAX_INTERVAL_SECONDS)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--audit", action="store_true")
+    parser.add_argument("--window-start", default=None)
+    parser.add_argument("--window-end", default=None)
+    parser.add_argument("--receipt", default=None)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.interval <= 0 or args.interval > MAX_INTERVAL_SECONDS:
+        raise SystemExit("--interval must be positive and no greater than four hours")
+    if args.audit:
+        end = _parse_time(args.window_end or datetime.now(timezone.utc))
+        start = _parse_time(args.window_start or (end - timedelta(days=RELIABILITY_DAYS)))
+        manifest = load_manifest(args.manifest)
+        store = KlineStore(str(Path(args.db).expanduser()))
+        report = audit_reliability(
+            manifest,
+            store,
+            window_start=start,
+            window_end=end,
+            interval_seconds=args.interval,
+        )
+        if args.receipt:
+            _write_receipt(Path(args.receipt), report)
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if report["status"] == "ready" else 2
+    if args.once:
+        result = asyncio.run(
+            run_demo_once(
+                db_path=args.db,
+                manifest_path=args.manifest,
+                interval_seconds=args.interval,
+                lock_path=args.lock,
+            )
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+    asyncio.run(_run_forever(args))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -45,6 +45,7 @@ class IngestionPlan:
     retry_backoff_seconds: float = 0.0
     rate_budget: int | None = None
     policy: Mapping[str, Any] = field(default_factory=dict)
+    instrument_ids: Sequence[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -174,6 +175,7 @@ class IngestionOrchestrator:
     def _interval(timeframe: str) -> timedelta:
         return {
             "15m": timedelta(minutes=15),
+            "1h": timedelta(hours=1),
             "4h": timedelta(hours=4),
             "1d": timedelta(days=1),
             "1w": timedelta(days=7),
@@ -340,6 +342,14 @@ class IngestionOrchestrator:
         end = self._now_iso(now)
         manifest = plan.manifest
         manifest_hash = manifest_digest(manifest)
+        selected_ids = set(plan.instrument_ids) if plan.instrument_ids is not None else None
+        if selected_ids is not None:
+            known_ids = {instrument.instrument_id for instrument in manifest.instruments}
+            missing_ids = sorted(selected_ids - known_ids)
+            if missing_ids:
+                raise IngestionError(
+                    f"ingestion identities missing from manifest: {', '.join(missing_ids)}"
+                )
         cells: list[CellResult] = []
         blocked_cells: list[dict[str, Any]] = []
         source_attempts: list[dict[str, Any]] = []
@@ -352,6 +362,8 @@ class IngestionOrchestrator:
         quality_counts = {"pass": 0, "partial": 0, "fail": 0}
 
         for instrument in manifest.instruments:
+            if selected_ids is not None and instrument.instrument_id not in selected_ids:
+                continue
             for timeframe in ("15m", "1h", "4h", "1d", "1w"):
                 if timeframe in instrument.not_applicable_timeframes:
                     cells.append(

--- a/src/kline/mvp_worker.py
+++ b/src/kline/mvp_worker.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 import fcntl
 import os
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from kline.ingestion import (
     IngestionError,
@@ -104,6 +104,7 @@ class MvpWorker:
         interval_seconds: int = MAX_INTERVAL_SECONDS,
         lock_path: str | Path = ".mvp-worker.lock",
         history_start: str | None = None,
+        instrument_ids: Sequence[str] | None = None,
         target_guard: Callable[[], TargetGuardResult | bool] | None = None,
         clock: Callable[[], datetime] | None = None,
     ) -> None:
@@ -114,6 +115,7 @@ class MvpWorker:
         self.interval_seconds = interval_seconds
         self.lock_path = Path(lock_path)
         self.history_start = history_start
+        self.instrument_ids = tuple(instrument_ids) if instrument_ids is not None else None
         self._target_guard = target_guard or (lambda: True)
         self._clock = clock or (lambda: datetime.now(timezone.utc))
         self._orchestrator = orchestrator or IngestionOrchestrator(
@@ -218,6 +220,7 @@ class MvpWorker:
                     run_id=run_id,
                     now=started,
                     history_start=self.history_start,
+                    instrument_ids=self.instrument_ids,
                 )
             )
             completed_at = self._iso(self._clock())

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -1082,6 +1082,33 @@ class KlineStore:
             }
         return {"status": "ok", **counts}
 
+    def mvp_duplicate_key_count(self) -> int:
+        """Count duplicate canonical candle identities, if a legacy import slipped through."""
+
+        with self._engine.connect() as connection:
+            value = connection.exec_driver_sql(
+                "SELECT COUNT(*) FROM ("
+                "SELECT source_id, instrument_id, timeframe, adjustment_basis, "
+                "manifest_version, timestamp FROM mvp_candles "
+                "GROUP BY source_id, instrument_id, timeframe, adjustment_basis, "
+                "manifest_version, timestamp HAVING COUNT(*) > 1)"
+            ).scalar_one()
+        return int(value)
+
+    def mvp_watermark_count_for_runs(self, run_ids: set[str]) -> int:
+        """Count watermark rows attributed to the supplied failed run IDs."""
+
+        if not run_ids:
+            return 0
+        with self._session_factory() as session:
+            return int(
+                session.execute(
+                    select(func.count())
+                    .select_from(MvpWatermarkRow)
+                    .where(MvpWatermarkRow.run_id.in_(sorted(run_ids)))
+                ).scalar_one()
+            )
+
     def latest_mvp_run(self) -> dict[str, Any] | None:
         """Return the newest persisted MVP run receipt summary."""
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -14,6 +14,10 @@ from kline.store import KlineStore
 
 
 MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_ingestion_watermark_overlap_supports_one_hour() -> None:
+    assert IngestionOrchestrator._interval("1h") == timedelta(hours=1)
 
 
 class FakeCryptoAdapter:

--- a/tests/test_mvp_reliability.py
+++ b/tests/test_mvp_reliability.py
@@ -41,6 +41,8 @@ async def test_run_demo_once_writes_a_terminal_receipt_without_network_calls(
     assert run is not None
     assert run["status"] == "partial"
     assert store.mvp_storage_health()["runs"] == 1
+    assert store.mvp_duplicate_key_count() == 0
+    assert store.mvp_watermark_count_for_runs({"missing-run"}) == 0
     assert result["health"]["scope"]["name"] == "demo_3x3"
 
 

--- a/tests/test_mvp_reliability.py
+++ b/tests/test_mvp_reliability.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from kline.mvp_manifest import load_manifest
+from kline.store import KlineStore
+from ops.mvp_reliability import (
+    DEMO_INSTRUMENT_IDS,
+    audit_reliability,
+    demo_manifest,
+    run_demo_once,
+)
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_demo_manifest_is_exactly_three_plus_three() -> None:
+    manifest = demo_manifest(load_manifest(MANIFEST_PATH))
+    assert tuple(item.instrument_id for item in manifest.instruments) == DEMO_INSTRUMENT_IDS
+    assert manifest.counts == {"a_share": 3, "us_stock": 3, "cross_market": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_demo_once_writes_a_terminal_receipt_without_network_calls(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "reliability.db"
+    result = await run_demo_once(
+        db_path=db_path,
+        manifest_path=MANIFEST_PATH,
+        now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+    )
+    assert result["status"] == "partial"
+    assert result["run_id"]
+    store = KlineStore(str(db_path))
+    run = store.latest_mvp_run()
+    assert run is not None
+    assert run["status"] == "partial"
+    assert store.mvp_storage_health()["runs"] == 1
+    assert result["health"]["scope"]["name"] == "demo_3x3"
+
+
+def test_audit_stays_blocked_before_seven_days(tmp_path: Path) -> None:
+    store = KlineStore(str(tmp_path / "audit.db"))
+    end = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
+    report = audit_reliability(
+        load_manifest(MANIFEST_PATH),
+        store,
+        window_start=end - timedelta(days=1),
+        window_end=end,
+    )
+    assert report["status"] == "blocked"
+    assert "terminal_receipt" in report["gates"]
+    assert report["gates"]["seven_calendar_days"]["status"] == "blocked"


### PR DESCRIPTION
## What
- add a real 3+3 reliability runner using the atomic MVP worker and 4-hour heartbeat
- add terminal/silence/coverage/idempotency/failed-watermark audit gates that stay blocked until seven natural calendar days are observed
- add scoped worker identity selection without weakening the full manifest contract, plus the missing 1h watermark overlap interval
- add canonical duplicate and failed-run watermark queries, launchd examples, and the initial runtime evidence receipt

## Why
- start the #71 reliability window safely while keeping unresolved A/US entitlement explicit
- make seven-day completion evidence reproducible instead of treating tests or an HTTP 200 as verification

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (257 passed)
- `python3 -m ruff check ...` (changed files clean)
- `git diff --check`
- `gitleaks detect --no-banner --redact --source .` (no leaks)
- real isolated launchd API `127.0.0.1:18171` and worker are running with KeepAlive; first terminal receipt `mvp-20260901T060237Z` is `partial` and all 30 applicable cells are evidence-backed `blocked`
- first audit correctly returns `blocked` until seven days; no synthetic time/replay data

## Current gate
This PR starts observation but does not close #71. The issue remains open until the natural seven-day window, browser fault/recovery/expiry evidence, and final receipt gates pass.

Refs #71