### PR TITLE
fix: use free sources for the local MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fail timeframe not supported → supported list
 fail TuShare-only A-share no token → setup instructions; Phase 1 indices need no token
 ```
 
-Built-in sources: `tushare_pro`, `tencent_kline`, `sina_index`,
+Built-in sources: `tushare_pro`, `tencent_stock_free`, `yahoo_finance_free`, `tencent_kline`, `sina_index`,
 `treasury_official_csv`, `treasury_official_csv_derived`, `yahoo_finance`,
 `yahoo_finance_index`, `yahoo_finance_etf`, `yahoo_finance_futures`,
 `binance_spot_public`, `binance_usdm_futures`, `binance_usdm_futures_research`,
@@ -51,8 +51,9 @@ MarketDataPort
         │
         ├─ Binance USD-M Futures adapter
         ├─ Binance Spot adapter
-        ├─ Yahoo adapter
+        ├─ Yahoo adapter + free Sina daily fallback
         ├─ TuShare adapter
+        ├─ Free Tencent A-share adapter + Tonghuashun fallback
         ├─ Tencent A-share index adapter
         ├─ Sina A-share index fallback adapter
         ├─ Official U.S. Treasury yield adapter
@@ -133,6 +134,39 @@ keeps `fallback_policy=none`.
   incomplete bucket count.
 - Daily → weekly responses retain `raw_timeframe=1d`, completed-week rule,
   bucket timezone and input source identity.
+
+### No-membership personal MVP profile
+
+The local MVP does not require a current TuShare subscription or a paid U.S.
+market-data plan. Its runtime free profile keeps canonical instrument IDs but
+routes A-share stocks through `tencent_stock_free` (Tonghuashun is a bounded
+fallback for 1h/daily) and U.S. stocks through `yahoo_finance_free` (Sina is a
+daily fallback). Yahoo/Tencent/Sina responses are recorded as
+`entitlement_unverified` and therefore remain `partial` until the operator
+documents the personal-use terms; HTTP 200 is never promoted to commercial or
+`verified` status. The Tencent path is requested as qfq; a Tonghuashun fallback
+also records `adjustment_basis` provenance as unverified rather than silently
+claiming that its raw line response is adjusted. Baidu and AKShare remain
+probe/fallback candidates because their current network paths are unstable in
+this environment.
+
+The reliability worker uses the same profile:
+
+```bash
+PYTHONPATH=src python3 -m ops.mvp_reliability --once \
+  --manifest configs/mvp_manifest.json --db data/kline.db --interval 14400
+```
+
+The command writes only source-bound OHLCV and receipts; it does not emit
+MACD/RSI columns, synthesize missing candles, switch to a paid source, or
+expose data publicly.
+
+The worker requests daily and weekly first, then intraday. If an intraday
+endpoint is unavailable, it degrades per cell instead of aborting the asset:
+the 15m/1h/4h cells remain `unavailable` or `failed`, while a successful daily
+request is still persisted and used to produce the completed weekly bar. The
+run is explicitly `partial`, so missing intraday coverage cannot be mistaken
+for a healthy feed.
 
 ## Canonical local runtime
 

--- a/docs/verification/free-source-3x3-runtime-2026-09-01.md
+++ b/docs/verification/free-source-3x3-runtime-2026-09-01.md
@@ -1,0 +1,38 @@
+# 免费 source 3+3 端到端运行证据
+
+## 最新复验
+
+- 观察时间：2026-09-01T08:55:42+00:00
+- 执行命令：`python -m ops.mvp_reliability --once --manifest configs/mvp_manifest.json --db <临时库> --lock <临时锁> --interval 14400`
+- run_id：`mvp-20260901T085542Z`
+- run status：`success`
+- free profile hash：`9d21373cd123c2f69d36b552461a71f26a613afd02f6064184bd5953e5adca51`
+- `technical_ready=30/30`；展示状态 `partial=30/30`（仅因 entitlement 未书面核实）
+- 存储凭证：`candles=9,494`、`observations=30`、`quality=30`、`watermarks=30`、`transforms=12`
+- 来源：A 股 `tencent_stock_free`；美股 `yahoo_finance_free`
+- 请求顺序：日线、周线先于 15 分钟/1 小时/4 小时；日内失败不会阻断日/周落库，专项回归测试已覆盖。
+
+- 观察时间：2026-09-01T08:41:21+00:00
+- 执行命令：`python -m ops.mvp_reliability --once --manifest configs/mvp_manifest.json --db <临时库> --interval 14400`
+- run_id：`mvp-20260901T084121Z`
+- run status：`success`
+- manifest：`mvp_universe_v1`
+- free profile hash：`54f2b1bb8b1d61e254689bb3c8e594cf4c3b454ea378f77220050eee859dc17f`
+
+## 落库事实
+
+- 30/30 个 3+3 × `15m/1h/4h/1d/1w` cell 有真实闭合 K 线。
+- `mvp_candles=9,494`、`source_observations=30`、`quality_receipts=30`、`watermarks=30`、`transform_receipts=12`。
+- A 股三只的来源标识为 `tencent_stock_free`；美股三只的来源标识为 `yahoo_finance_free`。
+- 每个 cell 的 `technical_status=ready`（30/30），展示状态为 `partial`，原因是免费个人 source 的 entitlement 尚未做书面核实；没有把它们标为 verified。
+- `4h` 与 `1w` 均带 transform receipt；A 股 `4h` 使用会话规则，美股 `4h` 使用 Yahoo 15m 聚合。
+
+## source 探测事实
+
+- Yahoo Chart：AAPL/NVDA/TSLA 的 15m、1h、1d、1w 均返回非空 OHLCV。
+- 腾讯财经：600519、300750、688981 的 15m/60m 均可返回；日线使用 Tencent qfq 接口。
+- 同花顺 60 分钟/日线 fallback 在模拟失败切换测试中通过；百度当前网络返回 403，AKShare 当前 Eastmoney 路径遇到 SSL 错误，因此没有把它们标为主源。
+
+## 边界
+
+这些事实证明免费技术 source 已经能跑通 provider → quality → transform → watermark → SQLite → Dashboard 的链路；不证明任何 source 允许商业再分发。当前 profile 只用于本机个人研究，公网访问、数据销售和 NAS 迁移仍未开启。

--- a/ops/mvp_reliability.py
+++ b/ops/mvp_reliability.py
@@ -15,9 +15,10 @@ from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 import signal
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from kline.config import Settings
+from kline.free_source_profile import apply_free_source_profile
 from kline.health_matrix import (
     MVP_DEMO_INSTRUMENT_IDS,
     _safe_run,
@@ -69,11 +70,12 @@ async def run_demo_once(
     now: datetime | None = None,
     interval_seconds: int = MAX_INTERVAL_SECONDS,
     lock_path: str | Path | None = None,
+    adapter_resolver: Callable[[Any], Any] | None = None,
 ) -> dict[str, Any]:
     """Execute one real 3+3 worker attempt and return its read-only snapshot."""
 
     observed_at = _parse_time(now or datetime.now(timezone.utc))
-    manifest = load_manifest(manifest_path)
+    manifest = apply_free_source_profile(load_manifest(manifest_path))
     demo_manifest(manifest)
     database = Path(db_path).expanduser()
     init(Settings(db_path=str(database), load_entrypoint_adapters=False))
@@ -84,6 +86,7 @@ async def run_demo_once(
         interval_seconds=interval_seconds,
         lock_path=lock_path or database.with_suffix(".worker.lock"),
         instrument_ids=DEMO_INSTRUMENT_IDS,
+        adapter_resolver=adapter_resolver,
         clock=lambda: observed_at,
     )
     result = await worker.run_once()
@@ -184,8 +187,9 @@ def audit_reliability(
         "observed_days": round(span_days, 4),
         "required_days": RELIABILITY_DAYS,
     }
+    active_manifest = apply_free_source_profile(manifest)
     health = build_mvp_health_matrix(
-        manifest,
+        active_manifest,
         store,
         scope="demo_3x3",
         now=end,
@@ -249,8 +253,8 @@ def audit_reliability(
         "status": overall,
         "window_start": _iso(start),
         "window_end": _iso(end),
-        "manifest_version": manifest.version,
-        "manifest_hash": manifest_digest(manifest),
+        "manifest_version": active_manifest.version,
+        "manifest_hash": manifest_digest(active_manifest),
         "run_count": len(runs),
         "runs": runs,
         "coverage": health["coverage"],
@@ -258,7 +262,7 @@ def audit_reliability(
         "storage": storage_health,
         "gates": gates,
         "unresolved": {
-            "source_entitlement": "A/US pilot source entitlement remains blocked",
+            "source_entitlement": "A/US free-source entitlement remains unverified",
             "nas_cutover": "not in #71 scope",
         },
     }

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -21,6 +21,7 @@ from kline.models import (
     TimeframeTransform,
     InstrumentDefinition,
 )
+from kline.free_source_profile import apply_free_source_profile
 from kline.health_matrix import (
     MATRIX_SCOPE_DEMO,
     MATRIX_SCOPE_FULL,
@@ -1110,7 +1111,7 @@ async def mvp_health_matrix(scope: str = MATRIX_SCOPE_FULL) -> dict:
             detail={"error": "unsupported_matrix_scope", "scope": scope},
         )
     try:
-        manifest = load_manifest(manifest_path)
+        manifest = apply_free_source_profile(load_manifest(manifest_path))
         payload = build_mvp_health_matrix(
             manifest,
             get_store(),

--- a/src/kline/free_source_profile.py
+++ b/src/kline/free_source_profile.py
@@ -1,0 +1,49 @@
+"""Runtime overlay for the no-membership personal research profile.
+
+The checked-in manifest keeps the paid/authorized source contracts explicit.
+This overlay preserves canonical instrument identities while selecting the
+free technical adapters requested for a private local MVP.  It is not a
+commercial redistribution or entitlement claim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from kline.mvp_manifest import ALLOWED_TIMEFRAMES, MvpManifest
+
+
+FREE_SOURCE_PROFILE = "free_personal_v1"
+
+
+def apply_free_source_profile(manifest: MvpManifest) -> MvpManifest:
+    """Return a validated same-universe manifest using free technical sources."""
+
+    instruments = []
+    for item in manifest.instruments:
+        if item.universe == "a_share":
+            instruments.append(
+                replace(
+                    item,
+                    source_id="tencent_stock_free",
+                    required_timeframes=ALLOWED_TIMEFRAMES,
+                    blocked_timeframes=(),
+                    source_status="configured",
+                    adjustment_basis="qfq",
+                    metadata={**item.metadata, "source_profile": FREE_SOURCE_PROFILE},
+                )
+            )
+        elif item.universe == "us_stock":
+            instruments.append(
+                replace(
+                    item,
+                    source_id="yahoo_finance_free",
+                    required_timeframes=ALLOWED_TIMEFRAMES,
+                    blocked_timeframes=(),
+                    source_status="configured",
+                    metadata={**item.metadata, "source_profile": FREE_SOURCE_PROFILE},
+                )
+            )
+        else:
+            instruments.append(item)
+    return replace(manifest, instruments=tuple(instruments))

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -30,6 +30,7 @@ MVP_DEMO_INSTRUMENT_IDS = (
     "US.EQ.NVDA",
     "US.EQ.TSLA",
 )
+FREE_SOURCE_IDS = frozenset({"tencent_stock_free", "yahoo_finance_free"})
 
 
 def _iso(value: datetime) -> str:
@@ -53,7 +54,12 @@ def _parse_timestamp(value: str | None) -> datetime | None:
 def _status_counts(cells: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
     coverage: dict[str, dict[str, Any]] = {}
     for timeframe in MATRIX_TIMEFRAMES:
-        states = {"applicable": 0, "not_applicable": 0, **{status: 0 for status in MATRIX_STATUSES}}
+        states = {
+            "applicable": 0,
+            "not_applicable": 0,
+            "technical_ready": 0,
+            **{status: 0 for status in MATRIX_STATUSES},
+        }
         for cell in cells:
             if cell["timeframe"] != timeframe:
                 continue
@@ -62,6 +68,8 @@ def _status_counts(cells: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, An
             else:
                 states["applicable"] += 1
                 states[cell["status"]] += 1
+                if cell.get("technical_status") == "ready":
+                    states["technical_ready"] += 1
         states["ratio"] = (
             round(states["ready"] / states["applicable"], 4) if states["applicable"] else None
         )
@@ -286,7 +294,7 @@ def _entitlement_block_reason(
     if instrument.source_status == "blocked_for_entitlement":
         return "entitlement_blocked"
     if receipt is None:
-        return "entitlement_unverified"
+        return None if instrument.source_id in FREE_SOURCE_IDS else "entitlement_unverified"
     status = str(receipt.get("status") or "unverified").casefold()
     if status in {"blocked", "missing", "unverified"}:
         return f"entitlement_{status}"
@@ -346,6 +354,7 @@ def _cell(
             "last_success_at": None,
             "run_id": None,
             "policy": None,
+            "technical_status": None,
             "coverage": None,
             "quality": None,
             "watermark": None,
@@ -384,6 +393,14 @@ def _cell(
         or (watermark or {}).get("run_id")
         or (transform or {}).get("run_id")
     )
+    technical_status = (
+        "ready"
+        if latest is not None
+        and quality is not None
+        and quality.get("status") in {"pass", "ready"}
+        and watermark is not None
+        else status
+    )
     return {
         "instrument_id": instrument.instrument_id,
         "display_symbol": instrument.display_symbol,
@@ -405,6 +422,7 @@ def _cell(
         "last_success_at": last_success,
         "run_id": run_id,
         "policy": policy,
+        "technical_status": technical_status,
         "coverage": {
             "expected_bars": None,
             "stored_bars": int(latest.get("row_count", 0)) if latest else 0,
@@ -505,19 +523,33 @@ def build_mvp_health_matrix(
         else []
     )
     latest_map = {_key(row): row for row in latest_rows}
-    observation_map = {_key(row): row for row in observations}
-    quality_map = {_key(row): row for row in qualities}
+    adjustment_by_instrument = {
+        instrument.instrument_id: instrument.adjustment_basis for instrument in manifest.instruments
+    }
+
+    def receipt_key(row: Mapping[str, Any]) -> tuple[str, str, str, str, str]:
+        instrument_id = str(row.get("instrument_id") or "")
+        return _key(
+            {
+                **row,
+                "adjustment_basis": row.get("adjustment_basis")
+                or adjustment_by_instrument.get(instrument_id, "raw_unadjusted"),
+            }
+        )
+
+    observation_map = {receipt_key(row): row for row in observations}
+    quality_map = {receipt_key(row): row for row in qualities}
     transform_map = {
         (
             str(row.get("source_id") or ""),
             str(row.get("instrument_id") or ""),
             str(row.get("output_timeframe") or ""),
-            "raw_unadjusted",
+            adjustment_by_instrument.get(str(row.get("instrument_id") or ""), "raw_unadjusted"),
             str(row.get("manifest_version") or ""),
         ): row
         for row in transforms
     }
-    watermark_map = {_key(row): row for row in watermarks}
+    watermark_map = {receipt_key(row): row for row in watermarks}
     entitlement_map = {
         str(row.get("source_id") or ""): row for row in entitlements if row.get("source_id")
     }
@@ -602,6 +634,12 @@ def build_mvp_health_matrix(
                 status, reason = "partial", "watermark_missing"
             else:
                 status, reason = "ready", "closed_bar_quality_passed"
+            if (
+                status == "ready"
+                and entitlement is None
+                and instrument.source_id in FREE_SOURCE_IDS
+            ):
+                status, reason = "partial", "entitlement_unverified"
             cells.append(
                 _cell(
                     instrument,

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -173,12 +173,13 @@ async def health_ui() -> str:
       const item = snapshot.coverage[tf] || {};
       const applicable = Number(item.applicable || 0);
       const ready = Number(item.ready || 0);
-      const ratio = applicable ? Math.round(ready / applicable * 100) : 0;
+      const dataReady = Number(item.technical_ready ?? ready);
+      const ratio = applicable ? Math.round(dataReady / applicable * 100) : 0;
       const blocked = Number(item.blocked || 0);
       const failed = Number(item.failed || 0);
       const problem = ['stale','partial','unavailable'].reduce((sum, key) => sum + Number(item[key] || 0), 0);
       const details = [blocked ? `阻塞 ${blocked}` : '', failed ? `失败 ${failed}` : '', problem ? `其他需关注 ${problem}` : ''].filter(Boolean).join(' · ') || '没有异常单元格';
-      return `<article class="card coverage-card"><div class="label">${timeframeLabels[tf]}</div><div class="ratio"><strong>${ratio}%</strong><span>${ready}/${applicable} 正常</span></div><div class="counts">${details} · 不适用 ${Number(item.not_applicable || 0)} 个</div><div class="progress"><i style="width:${ratio}%"></i></div></article>`;
+      return `<article class="card coverage-card"><div class="label">${timeframeLabels[tf]}</div><div class="ratio"><strong>${ratio}%</strong><span>${dataReady}/${applicable} 有数据</span></div><div class="counts">${details} · 正常 ${ready} · 不适用 ${Number(item.not_applicable || 0)} 个</div><div class="progress"><i style="width:${ratio}%"></i></div></article>`;
     }).join('');
     document.getElementById('coverage-meta').textContent = `共 ${fmtCount(snapshot.cells.length)} 个单元格 · 清单 ${esc(snapshot.manifest_version)}`;
   }

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -33,6 +33,12 @@ class IngestionError(RuntimeError):
     """The run could not produce a trustworthy storage receipt."""
 
 
+# Coarse bars are the minimum useful fallback. Fetch them before potentially
+# slow/flaky intraday endpoints so a degraded run still produces daily/weekly
+# data for the dashboard.
+INGESTION_TIMEFRAMES = ("1d", "1w", "15m", "1h", "4h")
+
+
 @dataclass(frozen=True)
 class IngestionPlan:
     manifest: MvpManifest
@@ -364,7 +370,7 @@ class IngestionOrchestrator:
         for instrument in manifest.instruments:
             if selected_ids is not None and instrument.instrument_id not in selected_ids:
                 continue
-            for timeframe in ("15m", "1h", "4h", "1d", "1w"):
+            for timeframe in INGESTION_TIMEFRAMES:
                 if timeframe in instrument.not_applicable_timeframes:
                     cells.append(
                         CellResult(
@@ -494,7 +500,11 @@ class IngestionOrchestrator:
                             request_start=request_start,
                             request_end=end,
                             response_hash=response_hash,
-                            policy={"fallback": "none", "overlap_bars": plan.overlap_bars},
+                            policy={
+                                "fallback": "none",
+                                "overlap_bars": plan.overlap_bars,
+                                "source_identity": dict(fetch_receipt.source_identity),
+                            },
                             candle_count=len(mvp_rows),
                             latest_timestamp=latest,
                             served_from="upstream",

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -127,6 +127,8 @@ _SOURCE_ALIASES = {
     "binance_usdm_futures_research": "binance_usdm_futures_research",
     "binance_futures_research": "binance_usdm_futures_research",
     "hyperliquid_perpetual_public": "hyperliquid_perpetual_public",
+    "tencent_stock_free": "tencent_stock_free",
+    "yahoo_finance_free": "yahoo_finance_free",
     "hyperliquid_perp": "hyperliquid_perpetual_public",
     "yahoo": "yahoo",
     "yahoo_finance": "yahoo_finance",
@@ -154,8 +156,10 @@ _SOURCE_ASSET_CLASSES = {
     "binance_usdm_futures_research": AssetClass.CRYPTO,
     "hyperliquid_perpetual_public": AssetClass.CRYPTO,
     "yahoo_finance": AssetClass.US_STOCK,
+    "yahoo_finance_free": AssetClass.US_STOCK,
     "yahoo_finance_futures": AssetClass.COMMODITY,
     "tushare_pro": AssetClass.A_SHARE,
+    "tencent_stock_free": AssetClass.A_SHARE,
     "tencent_kline": AssetClass.INDEX,
     "sina_index": AssetClass.INDEX,
     "treasury_official_csv": AssetClass.MACRO,
@@ -208,6 +212,24 @@ _TENCENT_INDEX_META = ProviderMeta(
     realtime_supported=False,
     market_type="index",
     supported_symbols=("sh000001", "sh000688", "sh000015"),
+)
+_TENCENT_STOCK_FREE_META = ProviderMeta(
+    name="tencent_finance",
+    source_mode="tencent_stock_free",
+    quality_flags=("public_api", "market_hours", "research_only", "entitlement_unverified"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="equity",
+)
+_YAHOO_FREE_META = ProviderMeta(
+    name="yahoo_finance",
+    source_mode="yahoo_finance_free",
+    quality_flags=("public_api", "market_hours", "research_only", "entitlement_unverified"),
+    continuous=False,
+    execution_venue=False,
+    realtime_supported=False,
+    market_type="equity",
 )
 _US_AUTHORIZED_META = ProviderMeta(
     name="authorized_us_pending",
@@ -355,6 +377,12 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         default_for_asset_class=True,
         blocked_timeframes=(Timeframe.HOUR_4,),
     ),
+    "yahoo_finance_free": SourceManifest(
+        source_id="yahoo_finance_free",
+        asset_class=AssetClass.US_STOCK,
+        meta=_YAHOO_FREE_META,
+        default_for_asset_class=False,
+    ),
     "us_authorized_pending": SourceManifest(
         source_id="us_authorized_pending",
         asset_class=AssetClass.US_STOCK,
@@ -457,6 +485,12 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.A_SHARE,
         meta=_PROVIDER_META[AssetClass.A_SHARE],
         default_for_asset_class=True,
+    ),
+    "tencent_stock_free": SourceManifest(
+        source_id="tencent_stock_free",
+        asset_class=AssetClass.A_SHARE,
+        meta=_TENCENT_STOCK_FREE_META,
+        default_for_asset_class=False,
     ),
     "tencent_kline": SourceManifest(
         source_id="tencent_kline",

--- a/src/kline/providers/free_ashare.py
+++ b/src/kline/providers/free_ashare.py
@@ -1,0 +1,431 @@
+"""Free, personal-use A-share OHLCV adapters.
+
+Tencent is the primary technical endpoint for 15m/1h and daily bars.  The
+Tonghuashun line endpoint is a narrow fallback for 1h/daily requests.  The
+adapter records which endpoint answered; it does not infer commercial rights.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+import json
+import math
+import re
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from kline.market_calendar import aggregate_15m_to_4h, aggregate_daily_to_weekly
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.providers.base import ProviderError
+from kline.providers.free_common import requested_cutoff
+from kline.storage import CandleSeriesKey, MvpCandle
+
+
+_TENCENT_MINUTE_URL = "https://ifzq.gtimg.cn/appstock/app/kline/mkline"
+_TENCENT_DAILY_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
+_TENJQKA_URL = "https://d.10jqka.com.cn/v6/line/hs_{code}/{period}/last.js"
+_A_SHARE_TIMEFRAMES = (
+    Timeframe.MIN_15,
+    Timeframe.HOUR_1,
+    Timeframe.HOUR_4,
+    Timeframe.DAY,
+    Timeframe.WEEK,
+)
+
+
+def _provider_code(ticker: str) -> str:
+    normalized = ticker.upper().strip().split(".", 1)[0]
+    if not normalized or not normalized.isdigit():
+        raise ProviderError(f"invalid A-share symbol: {ticker}")
+    return ("sh" if normalized.startswith(("6", "9")) else "sz") + normalized
+
+
+def _stamp(raw: Any, *, timezone_name: str = "Asia/Shanghai") -> str:
+    text = str(raw).strip()
+    zone = ZoneInfo(timezone_name)
+    for fmt in ("%Y%m%d%H%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            return (
+                datetime.strptime(text, fmt)
+                .replace(tzinfo=zone)
+                .astimezone(timezone.utc)
+                .isoformat()
+            )
+        except ValueError:
+            continue
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        if re.fullmatch(r"\d{8}", text):
+            return (
+                datetime.strptime(text, "%Y%m%d")
+                .replace(tzinfo=zone)
+                .astimezone(timezone.utc)
+                .isoformat()
+            )
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
+            return (
+                datetime.strptime(text, "%Y-%m-%d")
+                .replace(tzinfo=zone)
+                .astimezone(timezone.utc)
+                .isoformat()
+            )
+        raise ProviderError(f"invalid Tencent timestamp: {raw}")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=zone)
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _number(value: Any, *, required: bool = True) -> float | None:
+    if value in (None, "", {}):
+        if required:
+            raise ValueError("missing numeric value")
+        return None
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("non-finite numeric value")
+    return result
+
+
+def _candle(
+    row: list[Any] | tuple[Any, ...], *, timezone_name: str, interval: timedelta | None = None
+) -> Candle:
+    if len(row) < 6:
+        raise ValueError("A-share row has fewer than six columns")
+    timestamp = _stamp(row[0], timezone_name=timezone_name)
+    if interval is not None:
+        timestamp = (datetime.fromisoformat(timestamp) - interval).isoformat()
+    open_value = _number(row[1])
+    close_value = _number(row[2])
+    high_value = _number(row[3])
+    low_value = _number(row[4])
+    volume = _number(row[5], required=False)
+    amount = _number(row[6], required=False) if len(row) > 6 else None
+    assert open_value is not None and close_value is not None
+    assert high_value is not None and low_value is not None
+    if high_value < max(open_value, close_value) or low_value > min(open_value, close_value):
+        raise ValueError("OHLC bounds are invalid")
+    return Candle(
+        timestamp=timestamp,
+        open=open_value,
+        high=high_value,
+        low=low_value,
+        close=close_value,
+        volume=volume,
+        amount=amount,
+    )
+
+
+def parse_tencent_rows(
+    rows: Any, *, timezone_name: str = "Asia/Shanghai", interval: timedelta | None = None
+) -> list[Candle]:
+    if not isinstance(rows, list):
+        raise ValueError("Tencent K-line rows are not a list")
+    result: list[Candle] = []
+    for row in rows:
+        if not isinstance(row, (list, tuple)):
+            continue
+        try:
+            result.append(_candle(row, timezone_name=timezone_name, interval=interval))
+        except (TypeError, ValueError):
+            continue
+    return sorted(result, key=lambda candle: candle.timestamp)
+
+
+def parse_10jqka_rows(
+    text_or_rows: str | list[str], *, timezone_name: str = "Asia/Shanghai"
+) -> list[Candle]:
+    rows = text_or_rows if isinstance(text_or_rows, list) else text_or_rows.split(";")
+    result: list[Candle] = []
+    for raw in rows:
+        if not raw:
+            continue
+        values = raw.split(",") if isinstance(raw, str) else raw
+        try:
+            if len(values) < 6:
+                continue
+            result.append(
+                Candle(
+                    timestamp=_stamp(values[0], timezone_name=timezone_name),
+                    open=_number(values[1]),
+                    high=_number(values[2]),
+                    low=_number(values[3]),
+                    close=_number(values[4]),
+                    volume=_number(values[5], required=False),
+                    amount=_number(values[6], required=False) if len(values) > 6 else None,
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return sorted(result, key=lambda candle: candle.timestamp)
+
+
+class AShareFreeProvider:
+    """Fetch A-share bars from Tencent with a Tonghuashun fallback."""
+
+    def __init__(self, *, timeout: float = 15.0, transport: httpx.AsyncBaseTransport | None = None):
+        self._timeout = timeout
+        self._transport = transport
+        self.last_raw_response: dict[str, Any] | None = None
+        self.timeframe_transform: TimeframeTransform | None = None
+        self.source_identity: dict[str, Any] = {}
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return list(_A_SHARE_TIMEFRAMES)
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        if timeframe not in _A_SHARE_TIMEFRAMES:
+            raise ProviderError(f"free A-share source does not support {timeframe.value}")
+        self.timeframe_transform = None
+        self.last_raw_response = None
+        if timeframe == Timeframe.HOUR_4:
+            base = await self.fetch(
+                ticker, Timeframe.MIN_15, start=start, end=end, limit=max(limit * 16, 320)
+            )
+            rows = self._as_mvp(base, ticker, "15m")
+            aggregate = aggregate_15m_to_4h(
+                rows,
+                calendar_id="cn_a",
+                cutoff=requested_cutoff(end),
+                run_id="free-tencent-preview",
+            )
+            if not aggregate.candles:
+                error = ProviderError(f"no complete 4h A-share bars returned for {ticker}")
+                error.code = "transform_incomplete"
+                raise error
+            receipt = aggregate.transform_receipt
+            self.timeframe_transform = TimeframeTransform(
+                raw_timeframe=Timeframe.MIN_15,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": receipt.aggregation_rule_version if receipt else "cn_a_session_4h_v1",
+                    "partial_bucket_count": receipt.partial_bucket_count if receipt else 0,
+                    "bucket_anchor": receipt.bucket_anchor if receipt else "09:30",
+                    "partial_bucket_policy": receipt.partial_bucket_policy
+                    if receipt
+                    else "drop_and_record",
+                },
+            )
+            return self._from_mvp(aggregate.candles, limit)
+        if timeframe == Timeframe.WEEK:
+            base = await self.fetch(
+                ticker, Timeframe.DAY, start=start, end=end, limit=max(limit * 7, 120)
+            )
+            rows = self._as_mvp(base, ticker, "1d")
+            aggregate = aggregate_daily_to_weekly(
+                rows,
+                calendar_id="cn_a",
+                cutoff=requested_cutoff(end),
+                run_id="free-tencent-preview",
+            )
+            if not aggregate.candles:
+                error = ProviderError(f"no completed weekly A-share bars returned for {ticker}")
+                error.code = "transform_incomplete"
+                raise error
+            receipt = aggregate.transform_receipt
+            self.timeframe_transform = TimeframeTransform(
+                raw_timeframe=Timeframe.DAY,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": receipt.aggregation_rule_version
+                    if receipt
+                    else "completed_local_calendar_week_v1",
+                    "partial_bucket_count": receipt.partial_bucket_count if receipt else 0,
+                    "bucket_anchor": receipt.bucket_anchor if receipt else "local_week",
+                    "partial_bucket_policy": receipt.partial_bucket_policy
+                    if receipt
+                    else "defer_until_closed",
+                },
+            )
+            return self._from_mvp(aggregate.candles, limit)
+
+        code = _provider_code(ticker)
+        if timeframe == Timeframe.MIN_15:
+            rows, selected = await self._tencent_minute(code, "m15", limit=limit)
+        elif timeframe == Timeframe.HOUR_1:
+            rows, selected = await self._with_fallback(
+                code, "60", "m60", start=start, end=end, limit=limit
+            )
+        else:
+            rows, selected = await self._with_fallback(
+                code, "01", "day", start=start, end=end, limit=limit
+            )
+        candles = rows
+        if start:
+            candles = [candle for candle in candles if candle.timestamp >= _stamp(start)]
+        if end:
+            candles = [candle for candle in candles if candle.timestamp < _stamp(end)]
+        if limit:
+            candles = candles[-limit:]
+        self.source_identity = {
+            "source_id": "tencent_stock_free",
+            "provider_symbol": code,
+            "selected_source": selected,
+            "adjustment_basis": "qfq" if selected == "tencent" else "unverified",
+            "canonical_adjustment_basis": "qfq",
+            "adjustment_basis_evidence": "tonghuashun_unverified" if selected == "tonghuashun" else "tencent_qfq",
+            "fallback_from": "tencent" if selected == "tonghuashun" else None,
+            "fallback_chain": ["tonghuashun"] if selected == "tonghuashun" else [],
+        }
+        return candles
+
+    async def _tencent_minute(self, code: str, key: str, *, limit: int) -> tuple[list[Candle], str]:
+        params = {"param": f"{code},{key},,{max(1, min(limit, 320))}"}
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                transport=self._transport,
+                headers={"Referer": "https://gu.qq.com/"},
+            ) as client:
+                response = await client.get(_TENCENT_MINUTE_URL, params=params)
+                response.raise_for_status()
+                payload = response.json()
+            item = (payload.get("data") or {}).get(code) or {}
+            interval = timedelta(minutes=15) if key == "m15" else timedelta(hours=1)
+            rows = parse_tencent_rows(
+                item.get(key), timezone_name="Asia/Shanghai", interval=interval
+            )
+            if not rows:
+                raise ProviderError("Tencent returned no minute rows")
+            self.last_raw_response = {
+                "endpoint": _TENCENT_MINUTE_URL,
+                "http_status": response.status_code,
+                "response_sha256": sha256(response.content).hexdigest(),
+                "row_count": len(rows),
+            }
+            return rows, "tencent"
+        except (httpx.HTTPError, ValueError, ProviderError) as error:
+            raise ProviderError(f"Tencent minute request failed for {code}: {error}") from error
+
+    async def _tencent_daily(
+        self, code: str, *, start: str | None, end: str | None, limit: int
+    ) -> tuple[list[Candle], str]:
+        params = {
+            "param": f"{code},day,{(start or '')[:10]},{(end or '')[:10]},{max(1, min(limit, 500))},qfq"
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout, transport=self._transport
+            ) as client:
+                response = await client.get(_TENCENT_DAILY_URL, params=params)
+                response.raise_for_status()
+                payload = response.json()
+            item = (payload.get("data") or {}).get(code) or {}
+            rows = parse_tencent_rows(
+                item.get("qfqday") or item.get("day"), timezone_name="Asia/Shanghai"
+            )
+            if not rows:
+                raise ProviderError("Tencent returned no daily rows")
+            self.last_raw_response = {
+                "endpoint": _TENCENT_DAILY_URL,
+                "http_status": response.status_code,
+                "response_sha256": sha256(response.content).hexdigest(),
+                "row_count": len(rows),
+            }
+            return rows, "tencent"
+        except (httpx.HTTPError, ValueError, ProviderError) as error:
+            raise ProviderError(f"Tencent daily request failed for {code}: {error}") from error
+
+    async def _with_fallback(
+        self,
+        code: str,
+        tenjqka_period: str,
+        tencent_key: str,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> tuple[list[Candle], str]:
+        try:
+            if tencent_key == "day":
+                return await self._tencent_daily(code, start=start, end=end, limit=limit)
+            return await self._tencent_minute(code, tencent_key, limit=limit)
+        except ProviderError as tencent_error:
+            try:
+                async with httpx.AsyncClient(
+                    timeout=self._timeout, transport=self._transport
+                ) as client:
+                    response = await client.get(
+                        _TENJQKA_URL.format(code=code[2:], period=tenjqka_period)
+                    )
+                    response.raise_for_status()
+                text = response.text
+                match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+                payload = json.loads(match.group(0)) if match else {}
+                rows = parse_10jqka_rows(payload.get("data", ""), timezone_name="Asia/Shanghai")
+                if not rows:
+                    raise ProviderError("Tonghuashun returned no rows")
+                self.last_raw_response = {
+                    "endpoint": str(response.url),
+                    "http_status": response.status_code,
+                    "response_sha256": sha256(response.content).hexdigest(),
+                    "row_count": len(rows),
+                    "fallback_from": "tencent",
+                }
+                self.source_identity = {
+                    "selected_source": "tonghuashun",
+                    "fallback_from": "tencent",
+                    "adjustment_basis": "unverified",
+                    "adjustment_basis_evidence": "unverified_tonghuashun_fallback",
+                }
+                return rows, "tonghuashun"
+            except (httpx.HTTPError, ValueError, ProviderError) as fallback_error:
+                raise ProviderError(
+                    f"free A-share sources failed for {code}: Tencent={tencent_error}; Tonghuashun={fallback_error}"
+                ) from fallback_error
+
+    @staticmethod
+    def _as_mvp(candles: list[Candle], ticker: str, timeframe: str) -> list[MvpCandle]:
+        code = _provider_code(ticker)
+        key = CandleSeriesKey(
+            instrument_id=f"CN.A.{code[2:]}",
+            display_symbol=code[2:],
+            provider_symbol=code,
+            source_id="tencent_stock_free",
+            asset_class="a_share",
+            timeframe=timeframe,
+            adjustment_basis="qfq",
+            manifest_version="mvp_universe_v1",
+        )
+        return [
+            MvpCandle(
+                key=key,
+                timestamp=candle.timestamp,
+                open=candle.open,
+                high=candle.high,
+                low=candle.low,
+                close=candle.close,
+                volume=candle.volume,
+                amount=candle.amount,
+                volume_semantics="traded",
+                is_derived=False,
+            )
+            for candle in candles
+        ]
+
+    @staticmethod
+    def _from_mvp(rows: tuple[MvpCandle, ...], limit: int) -> list[Candle]:
+        selected = rows[-limit:] if limit else rows
+        return [
+            Candle(
+                timestamp=row.timestamp,
+                open=row.open,
+                high=row.high,
+                low=row.low,
+                close=row.close,
+                volume=row.volume,
+                amount=row.amount,
+            )
+            for row in selected
+        ]

--- a/src/kline/providers/free_common.py
+++ b/src/kline/providers/free_common.py
@@ -1,0 +1,16 @@
+"""Small shared helpers for the no-membership provider adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def requested_cutoff(end: str | None) -> datetime:
+    """Use the ingestion request boundary for deterministic derived bars."""
+
+    if end:
+        parsed = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return datetime.now(timezone.utc)

--- a/src/kline/providers/free_us.py
+++ b/src/kline/providers/free_us.py
@@ -1,0 +1,209 @@
+"""Free personal-use US stock provider: Yahoo Chart with Sina daily fallback."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+import re
+
+import httpx
+
+from kline.market_calendar import aggregate_15m_to_4h
+from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.providers.base import ProviderError
+from kline.providers.free_common import requested_cutoff
+from kline.providers.us import USStockProvider
+from kline.storage import CandleSeriesKey, MvpCandle
+
+
+_SINA_DAILY_URL = (
+    "https://stock.finance.sina.com.cn/usstock/api/jsonp.php/var/US_MinKService.getDailyK"
+)
+
+
+class USFreeProvider(USStockProvider):
+    """Use the existing Yahoo implementation and fall back to Sina daily K-lines."""
+
+    def __init__(self, *, timeout: float = 15.0, transport: httpx.AsyncBaseTransport | None = None):
+        super().__init__()
+        self._timeout = timeout
+        self._transport = transport
+
+    def supported_timeframes(self) -> list[Timeframe]:
+        return [Timeframe.MIN_15, Timeframe.HOUR_1, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK]
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        if timeframe == Timeframe.HOUR_4:
+            base = await super().fetch(
+                ticker,
+                Timeframe.MIN_15,
+                start=start,
+                end=end,
+                limit=max(limit * 16, 320),
+            )
+            key = CandleSeriesKey(
+                instrument_id=f"US.EQ.{ticker.upper()}",
+                display_symbol=ticker.upper(),
+                provider_symbol=ticker.upper(),
+                source_id="yahoo_finance_free",
+                asset_class="us_stock",
+                timeframe="15m",
+                adjustment_basis="raw_unadjusted",
+                manifest_version="mvp_universe_v1",
+            )
+            rows = [
+                MvpCandle(
+                    key=key,
+                    timestamp=candle.timestamp,
+                    open=candle.open,
+                    high=candle.high,
+                    low=candle.low,
+                    close=candle.close,
+                    volume=candle.volume,
+                    amount=candle.amount,
+                    volume_semantics="traded",
+                )
+                for candle in base
+            ]
+            aggregate = aggregate_15m_to_4h(
+                rows,
+                calendar_id="us_equities",
+                cutoff=requested_cutoff(end),
+                run_id="free-yahoo-preview",
+            )
+            if not aggregate.candles:
+                error = ProviderError(f"no complete 4h US bars returned for {ticker}")
+                error.code = "transform_incomplete"
+                raise error
+            receipt = aggregate.transform_receipt
+            self.timeframe_transform = TimeframeTransform(
+                raw_timeframe=Timeframe.MIN_15,
+                timeframe_origin="aggregated",
+                aggregation={
+                    "rule": receipt.aggregation_rule_version
+                    if receipt
+                    else "us_regular_fixed_4h_v1",
+                    "partial_bucket_count": receipt.partial_bucket_count if receipt else 0,
+                    "bucket_anchor": receipt.bucket_anchor if receipt else "09:30",
+                    "partial_bucket_policy": receipt.partial_bucket_policy
+                    if receipt
+                    else "drop_and_record",
+                },
+            )
+            self.source_identity = {
+                **self.source_identity,
+                "source_id": "yahoo_finance_free",
+                "selected_source": "yahoo",
+            }
+            selected = aggregate.candles[-limit:] if limit else aggregate.candles
+            return [
+                Candle(
+                    timestamp=row.timestamp,
+                    open=row.open,
+                    high=row.high,
+                    low=row.low,
+                    close=row.close,
+                    volume=row.volume,
+                    amount=row.amount,
+                )
+                for row in selected
+            ]
+        try:
+            candles = await super().fetch(ticker, timeframe, start=start, end=end, limit=limit)
+            selected = self.source_identity.get("selected_source", "yahoo")
+            fallback_from = self.source_identity.get("fallback_from")
+            self.source_identity = {
+                **self.source_identity,
+                "source_id": "yahoo_finance_free",
+                "selected_source": selected,
+                "fallback_from": fallback_from,
+            }
+            return candles
+        except ProviderError as yahoo_error:
+            if timeframe != Timeframe.DAY:
+                raise
+            try:
+                candles = await self._fetch_sina_daily(ticker, start=start, end=end, limit=limit)
+                self.timeframe_transform = None
+                self.source_identity = {
+                    "source_id": "yahoo_finance_free",
+                    "provider_symbol": ticker.upper(),
+                    "selected_source": "sina",
+                    "fallback_from": "yahoo",
+                }
+                return candles
+            except ProviderError as sina_error:
+                raise ProviderError(
+                    f"free US sources failed for {ticker}: Yahoo={yahoo_error}; Sina={sina_error}"
+                ) from sina_error
+
+    async def _fetch_sina_daily(
+        self, ticker: str, *, start: str | None, end: str | None, limit: int
+    ) -> list[Candle]:
+        params = {"symbol": ticker.upper(), "num": max(120, min(limit, 5000))}
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                transport=self._transport,
+                headers={"Referer": "https://finance.sina.com.cn/"},
+            ) as client:
+                response = await client.get(_SINA_DAILY_URL, params=params)
+                response.raise_for_status()
+            match = re.search(r"\((\[.*\])\)", response.text, flags=re.DOTALL)
+            rows = json.loads(match.group(1)) if match else []
+            if not isinstance(rows, list):
+                rows = []
+            candles: list[Candle] = []
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                try:
+                    values = [float(row[name]) for name in ("o", "h", "l", "c")]
+                    volume = float(row["v"]) if row.get("v") not in (None, "") else None
+                    amount = float(row["a"]) if row.get("a") not in (None, "") else None
+                    if values[1] < max(values[0], values[3]) or values[2] > min(
+                        values[0], values[3]
+                    ):
+                        continue
+                    candles.append(
+                        Candle(
+                            timestamp=datetime.fromisoformat(str(row["d"]))
+                            .replace(tzinfo=timezone.utc)
+                            .isoformat(),
+                            open=values[0],
+                            high=values[1],
+                            low=values[2],
+                            close=values[3],
+                            volume=volume,
+                            amount=amount,
+                        )
+                    )
+                except (KeyError, TypeError, ValueError):
+                    continue
+            if start:
+                candles = [candle for candle in candles if candle.timestamp >= start]
+            if end:
+                candles = [candle for candle in candles if candle.timestamp < end]
+            if limit:
+                candles = candles[-limit:]
+            if not candles:
+                raise ProviderError("Sina returned no daily rows")
+            self.last_raw_response = {
+                "endpoint": str(response.url),
+                "http_status": response.status_code,
+                "response_sha256": sha256(response.content).hexdigest(),
+                "row_count": len(candles),
+                "fallback_from": "yahoo",
+            }
+            return candles
+        except (httpx.HTTPError, ValueError, ProviderError) as error:
+            raise ProviderError(f"Sina daily request failed for {ticker}: {error}") from error

--- a/src/kline/providers/us.py
+++ b/src/kline/providers/us.py
@@ -222,7 +222,12 @@ class USStockProvider:
         }
         try:
             stock = yf.Ticker(ticker.upper())
-            kwargs: dict = {"interval": interval, "repair": False, "keepna": False}
+            kwargs: dict = {
+                "interval": interval,
+                "repair": False,
+                "keepna": False,
+                "auto_adjust": False,
+            }
             if start and end:
                 kwargs["start"] = start
                 # Give Yahoo a little context beyond the requested cutoff.

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -16,6 +16,8 @@ from kline.providers.binance_usdm import BinanceUsdmFuturesProvider
 from kline.providers.commodity import CommodityProvider
 from kline.providers.crypto import CryptoProvider
 from kline.providers.fred import FredCsvProvider
+from kline.providers.free_ashare import AShareFreeProvider
+from kline.providers.free_us import USFreeProvider
 from kline.providers.hyperliquid import HyperliquidPerpetualProvider
 from kline.providers.sina import SinaIndexProvider
 from kline.providers.treasury import TreasuryCsvProvider
@@ -62,6 +64,12 @@ def init(settings: Settings | None = None) -> None:
         ProviderBackedMarketDataAdapter(
             source_manifest("yahoo_finance", AssetClass.US_STOCK),
             _providers[AssetClass.US_STOCK],
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("yahoo_finance_free", AssetClass.US_STOCK),
+            USFreeProvider(timeout=s.request_timeout),
         )
     )
     register_adapter(
@@ -173,6 +181,12 @@ def init(settings: Settings | None = None) -> None:
         ProviderBackedMarketDataAdapter(
             source_manifest("tushare_pro", AssetClass.A_SHARE),
             _providers[AssetClass.A_SHARE],
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("tencent_stock_free", AssetClass.A_SHARE),
+            AShareFreeProvider(timeout=s.request_timeout),
         )
     )
 

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from kline.free_source_profile import apply_free_source_profile
+from kline.models import AssetClass, Candle, Timeframe
+from kline.mvp_manifest import load_manifest, manifest_digest
+from kline.provenance import source_asset_class, source_manifest
+from kline.providers.base import ProviderError
+from kline.providers.free_ashare import (
+    AShareFreeProvider,
+    parse_10jqka_rows,
+    parse_tencent_rows,
+)
+from kline.providers.free_common import requested_cutoff
+from kline.providers.free_us import USFreeProvider
+from kline.providers.us import USStockProvider
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_derived_bar_cutoff_uses_request_end() -> None:
+    assert requested_cutoff("2026-09-01T08:00:00Z").isoformat() == "2026-09-01T08:00:00+00:00"
+
+
+def test_free_profile_routes_a_share_and_us_stock_without_changing_identity() -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    by_symbol = {item.display_symbol: item for item in manifest.instruments}
+    a_share = by_symbol["600519"]
+    us_stock = by_symbol["AAPL"]
+    assert a_share.instrument_id == "CN.A.600519"
+    assert a_share.source_id == "tencent_stock_free"
+    assert a_share.source_status == "configured"
+    assert a_share.adjustment_basis == "qfq"
+    assert a_share.required_timeframes == ("15m", "1h", "4h", "1d", "1w")
+    assert us_stock.instrument_id == "US.EQ.AAPL"
+    assert us_stock.source_id == "yahoo_finance_free"
+    assert us_stock.source_status == "configured"
+    assert us_stock.required_timeframes == ("15m", "1h", "4h", "1d", "1w")
+    assert len(manifest_digest(manifest)) == 64
+
+
+def test_tencent_and_tonghuashun_parsers_normalize_ohlcv() -> None:
+    rows = [["202609011500", "1301.23", "1299.56", "1304.51", "1299.01", "6674.00", {}, "5.34"]]
+    candles = parse_tencent_rows(rows, timezone_name="Asia/Shanghai")
+    assert candles[0].timestamp == "2026-09-01T07:00:00+00:00"
+    assert candles[0].open == 1301.23
+    assert candles[0].volume == 6674.0
+    assert candles[0].amount is None
+
+    tenjqka = parse_10jqka_rows(
+        "202609011500,1301.23,1304.51,1299.01,1299.56,6674,8670000.00,0.1,,,0"
+    )
+    assert tenjqka[0].timestamp == "2026-09-01T07:00:00+00:00"
+    assert tenjqka[0].volume == 6674.0
+    assert tenjqka[0].amount == 8670000.0
+
+
+@pytest.mark.asyncio
+async def test_free_a_share_provider_falls_back_to_tonghuashun() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "ifzq.gtimg.cn" in str(request.url):
+            return httpx.Response(503, request=request)
+        return httpx.Response(
+            200,
+            request=request,
+            text='quot({"data":"202609011500,1301.23,1304.51,1299.01,1299.56,6674,8670000.00,0.1,,,0"})',
+        )
+
+    provider = AShareFreeProvider(transport=httpx.MockTransport(handler))
+    candles = await provider.fetch("600519", Timeframe.HOUR_1, limit=10)
+    assert len(candles) == 1
+    assert provider.source_identity["selected_source"] == "tonghuashun"
+    assert provider.source_identity["fallback_from"] == "tencent"
+    assert provider.source_identity["adjustment_basis"] == "unverified"
+    assert provider.source_identity["adjustment_basis_evidence"] == "tonghuashun_unverified"
+
+
+@pytest.mark.asyncio
+async def test_free_a_share_provider_reports_both_sources_failed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request)
+
+    provider = AShareFreeProvider(transport=httpx.MockTransport(handler))
+    with pytest.raises(ProviderError) as error:
+        await provider.fetch("600519", Timeframe.HOUR_1, limit=10)
+    assert "Tencent=" in str(error.value)
+    assert "Tonghuashun=" in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_free_us_provider_uses_yahoo_and_declares_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def yahoo_success(
+        _self,
+        _ticker: str,
+        _timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        del start, end, limit
+        return [Candle(timestamp="2026-09-01", open=100, high=102, low=99, close=101, volume=10)]
+
+    monkeypatch.setattr(USStockProvider, "fetch", yahoo_success)
+    provider = USFreeProvider()
+    candles = await provider.fetch("AAPL", Timeframe.DAY, limit=10)
+    assert len(candles) == 1
+    assert provider.source_identity["source_id"] == "yahoo_finance_free"
+    assert provider.source_identity["selected_source"] == "yahoo"
+    assert provider.supported_timeframes() == [
+        Timeframe.MIN_15,
+        Timeframe.HOUR_1,
+        Timeframe.HOUR_4,
+        Timeframe.DAY,
+        Timeframe.WEEK,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_free_us_provider_falls_back_to_sina_daily(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def unavailable(
+        _self,
+        _ticker: str,
+        _timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        del start, end, limit
+        raise ProviderError("Yahoo unavailable")
+
+    monkeypatch.setattr(USStockProvider, "fetch", unavailable)
+    payload = '[{"d":"2026-09-01","o":"100","h":"102","l":"99","c":"101","v":"10","a":"1000"}]'
+    provider = USFreeProvider(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, request=request, text=f"cb({payload})")
+        )
+    )
+    candles = await provider.fetch("AAPL", Timeframe.DAY, limit=10)
+    assert len(candles) == 1
+    assert candles[0].close == 101
+    assert provider.source_identity["selected_source"] == "sina"
+    assert provider.source_identity["fallback_from"] == "yahoo"
+
+
+def test_free_source_manifests_are_registered_for_the_right_asset_classes() -> None:
+    assert source_asset_class("tencent_stock_free") == AssetClass.A_SHARE
+    assert source_asset_class("yahoo_finance_free") == AssetClass.US_STOCK
+    assert (
+        source_manifest("tencent_stock_free", AssetClass.A_SHARE).asset_class == AssetClass.A_SHARE
+    )
+    assert (
+        source_manifest("yahoo_finance_free", AssetClass.US_STOCK).asset_class
+        == AssetClass.US_STOCK
+    )
+
+
+def test_registry_exposes_free_adapters_without_tokens(tmp_path: Path) -> None:
+    from kline.config import Settings
+    from kline.registry import get_adapter_for_source, init
+
+    init(Settings(db_path=str(tmp_path / "free-adapters.db"), load_entrypoint_adapters=False))
+    assert get_adapter_for_source("tencent_stock_free", AssetClass.A_SHARE).supported_timeframes()
+    assert get_adapter_for_source(
+        "yahoo_finance_free", AssetClass.US_STOCK
+    ).supported_timeframes() == [
+        Timeframe.MIN_15,
+        Timeframe.HOUR_1,
+        Timeframe.HOUR_4,
+        Timeframe.DAY,
+        Timeframe.WEEK,
+    ]

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -8,13 +8,14 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from kline.app import create_app
+from kline.free_source_profile import apply_free_source_profile
 from kline.health_matrix import (
     MVP_DEMO_INSTRUMENT_IDS,
     _entitlement_block_reason,
     _freshness_stale,
     build_mvp_health_matrix,
 )
-from kline.mvp_manifest import load_manifest
+from kline.mvp_manifest import load_manifest, manifest_digest
 from kline.storage import (
     CandleSeriesKey,
     EntitlementReceiptWrite,
@@ -154,6 +155,7 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
     assert btc_1h["watermark"]["run_id"] == run_id
     assert btc_1h["entitlement"]["status"] == "active"
     assert snapshot["coverage"]["1h"]["ready"] == 1
+    assert snapshot["coverage"]["1h"]["technical_ready"] == 1
     assert btc_1h["run_id"] == run_id
     serialized = json.dumps(btc_1h, ensure_ascii=False)
     assert "supersecret" not in serialized
@@ -256,6 +258,77 @@ def test_derived_entitlement_does_not_block_native_one_hour_cells() -> None:
     assert _entitlement_block_reason(btc, "1h", receipt, derived=True) == "derived_not_allowed"
 
 
+def test_health_matrix_joins_receipts_to_a_qfq_free_profile_cell(tmp_path: Path) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "matrix-qfq.db"))
+    key = CandleSeriesKey(
+        instrument_id="CN.A.600519",
+        display_symbol="600519",
+        provider_symbol="600519.SH",
+        source_id="tencent_stock_free",
+        asset_class="a_share",
+        timeframe="15m",
+        adjustment_basis="qfq",
+        manifest_version=manifest.version,
+    )
+    run_id = "qfq-run-1"
+    candle = MvpCandle(
+        key=key,
+        timestamp="2026-09-01T06:45:00+00:00",
+        open=100,
+        high=102,
+        low=99,
+        close=101,
+        volume=10,
+    )
+    store.commit_mvp_run(
+        MvpRunWrite(
+            run_id=run_id,
+            manifest_version=manifest.version,
+            manifest_hash=manifest_digest(manifest),
+            started_at="2026-09-01T07:00:00+00:00",
+            window_start=None,
+            window_end="2026-09-01T07:00:00+00:00",
+            policy={},
+            candles=(candle,),
+            source_observations=(
+                SourceObservationWrite(
+                    run_id=run_id,
+                    key=key,
+                    success=True,
+                    request_start=None,
+                    request_end=None,
+                    response_hash=None,
+                    candle_count=1,
+                    latest_timestamp=candle.timestamp,
+                    policy={"source_identity": {"selected_source": "tencent"}},
+                ),
+            ),
+            quality_receipts=(QualityReceiptWrite(run_id=run_id, key=key, status="pass"),),
+            watermarks=(
+                WatermarkWrite(
+                    key=key,
+                    last_closed_timestamp=candle.timestamp,
+                    cursor=None,
+                    run_id=run_id,
+                ),
+            ),
+        )
+    )
+    snapshot = build_mvp_health_matrix(
+        manifest, store, scope="demo_3x3", now=datetime(2026, 9, 1, 8, tzinfo=timezone.utc)
+    )
+    cell = next(
+        item
+        for item in snapshot["cells"]
+        if item["display_symbol"] == "600519" and item["timeframe"] == "15m"
+    )
+    assert cell["status"] == "partial"
+    assert cell["technical_status"] == "ready"
+    assert cell["row_count"] == 1
+    assert cell["policy"]["source_identity"]["selected_source"] == "tencent"
+
+
 def test_run_timeline_does_not_fallback_to_older_than_24_hours(tmp_path: Path) -> None:
     manifest = load_manifest(MANIFEST_PATH)
     store = KlineStore(str(tmp_path / "matrix-runs.db"))
@@ -299,6 +372,14 @@ def test_health_matrix_api_and_ui_are_chinese_and_read_only(
         "instrument_count": 216,
         "universes": {"a_share": 100, "us_stock": 100, "cross_market": 16},
     }
+    assert (
+        next(cell for cell in payload["cells"] if cell["display_symbol"] == "AAPL")["source_id"]
+        == "yahoo_finance_free"
+    )
+    assert (
+        next(cell for cell in payload["cells"] if cell["display_symbol"] == "600519")["source_id"]
+        == "tencent_stock_free"
+    )
     assert payload["refresh"]["poll_interval_seconds"] == 30
     assert payload["refresh"]["request_timeout_seconds"] == 10
     assert page.status_code == 200

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 import pytest
 
+from kline.free_source_profile import apply_free_source_profile
 from kline.ingestion import IngestionError, IngestionOrchestrator, IngestionPlan
 from kline.models import Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import load_manifest
 from kline.ports import FetchReceipt
+from kline.providers.base import ProviderError
 from kline.storage import CandleSeriesKey
 from kline.store import KlineStore
 
@@ -114,6 +116,11 @@ async def test_run_once_promotes_ready_crypto_cells_and_keeps_blocked_cells_expl
     assert len(store.query_mvp_candles(key)) == 1
     assert store.get_mvp_watermark(key) is not None
     assert store.mvp_storage_health()["transform_receipts"] == 6
+    observations = store.latest_mvp_source_observations()
+    assert any(
+        item["policy"].get("source_identity", {}).get("provider_symbol") == "BTC"
+        for item in observations
+    )
 
 
 @pytest.mark.asyncio
@@ -197,3 +204,85 @@ async def test_run_once_rate_budget_blocks_remaining_required_cells(tmp_path: Pa
     )
     assert receipt.status == "partial"
     assert any(cell.status == "blocked_rate_budget" for cell in receipt.requested_cells)
+
+
+@pytest.mark.asyncio
+async def test_intraday_source_failure_still_persists_daily_and_weekly_data(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "daily-weekly-fallback.db"))
+
+    class IntradayUnavailableAdapter:
+        def __init__(self) -> None:
+            self.calls: list[Timeframe] = []
+
+        async def fetch_candles_with_receipt(
+            self,
+            _ticker: str,
+            timeframe: Timeframe,
+            *,
+            start: str | None,
+            end: str,
+            limit: int,
+        ) -> FetchReceipt:
+            del start, end, limit
+            self.calls.append(timeframe)
+            if timeframe in {Timeframe.MIN_15, Timeframe.HOUR_1, Timeframe.HOUR_4}:
+                raise ProviderError("intraday endpoint unavailable")
+            timestamp = (
+                "2026-08-31T00:00:00+00:00"
+                if timeframe == Timeframe.DAY
+                else "2026-08-28T00:00:00+00:00"
+            )
+            transform = (
+                TimeframeTransform(
+                    raw_timeframe=Timeframe.DAY,
+                    timeframe_origin="aggregated",
+                    aggregation={
+                        "rule": "completed_local_calendar_week_v1",
+                        "bucket_anchor": "local_week",
+                        "partial_bucket_policy": "defer_until_closed",
+                        "partial_bucket_count": 0,
+                    },
+                )
+                if timeframe == Timeframe.WEEK
+                else None
+            )
+            return FetchReceipt(
+                candles=[
+                    Candle(
+                        timestamp=timestamp,
+                        open=100,
+                        high=102,
+                        low=99,
+                        close=101,
+                        volume=10,
+                    )
+                ],
+                timeframe_transform=transform,
+                source_identity={"selected_source": "daily-weekly-fallback-test"},
+                raw_response={"row_count": 1},
+            )
+
+    adapter = IntradayUnavailableAdapter()
+    receipt = await IngestionOrchestrator(store, adapter_resolver=lambda _instrument: adapter).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-daily-weekly-fallback",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            fetch_limit=10,
+            instrument_ids=("CN.A.600519",),
+        )
+    )
+
+    statuses = {cell.timeframe: cell.status for cell in receipt.requested_cells}
+    assert receipt.status == "partial"
+    assert statuses["15m"] == "provider_error"
+    assert statuses["1h"] == "provider_error"
+    assert statuses["4h"] == "provider_error"
+    assert statuses["1d"] == "ready"
+    assert statuses["1w"] == "ready"
+    assert adapter.calls[:2] == [Timeframe.DAY, Timeframe.WEEK]
+    latest = store.mvp_latest_closed_bars()
+    assert {row["timeframe"] for row in latest} == {"1d", "1w"}

--- a/tests/test_mvp_reliability.py
+++ b/tests/test_mvp_reliability.py
@@ -35,6 +35,7 @@ async def test_run_demo_once_writes_a_terminal_receipt_without_network_calls(
         db_path=db_path,
         manifest_path=MANIFEST_PATH,
         now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+        adapter_resolver=lambda _instrument: None,
     )
     assert result["status"] == "partial"
     assert result["run_id"]


### PR DESCRIPTION
## What
- route the local MVP's A-share 3+3 slice through Tencent Finance with a bounded Tonghuashun fallback
- route the US 3+3 slice through Yahoo Finance with a Sina daily fallback
- preserve source/fallback and adjustment provenance, and distinguish technical data from unverified entitlement in the matrix/UI
- prioritize daily/weekly collection so intraday source failures still leave useful coarse bars
- add focused provider, fallback, persistence, health-matrix, and real 3+3 runtime evidence

## Why
The previous worker was hardwired to expired TuShare/authorized-US manifests, so the dashboard showed all cells as authorization-blocked even though free public technical endpoints were available. This keeps the no-membership personal MVP local-only and fail-closed about licensing.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 270 passed
- changed-file `python3 -m ruff check ...` → passed
- `git diff --check` → passed
- `gitleaks detect --no-banner --redact --source .` → no leaks
- real `ops.mvp_reliability --once` → `mvp-20260901T085542Z`, success; 9,494 candles, 30 observations, 30 quality receipts, 30 watermarks, 12 transforms; 30/30 technical-ready, displayed partial only for entitlement uncertainty
- evidence: `docs/verification/free-source-3x3-runtime-2026-09-01.md`

## Scope boundary
No paid-source purchase, public redistribution, trading action, NAS migration, legacy migration, or full 100+100 seed in this MVP change. The worker remains the approved 3+3 vertical slice; full universe routing is present in the dashboard profile for later seeding.

Closes #81
