### PR TITLE
fix: explain mixed health matrix state

### DIFF
--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -251,11 +251,24 @@ async def health_ui() -> str:
     const applicable = snapshot.cells.filter(cell => cell.applicability === 'applicable');
     const blocked = applicable.filter(cell => cell.status === 'blocked').length;
     const failed = applicable.filter(cell => cell.status === 'failed').length;
-    const overallText = snapshot.status === 'failed' && blocked && !failed ? '总体状态：授权阻塞' : `总体状态：${statusText(snapshot.status)}`;
+    const unavailable = applicable.filter(cell => cell.status === 'unavailable').length;
+    const technicalReady = applicable.filter(cell => cell.technical_status === 'ready' || cell.status === 'ready').length;
+    const mixedTechnicalState = technicalReady > 0 && (blocked || failed || unavailable);
+    const overallText = mixedTechnicalState && snapshot.status === 'failed' && blocked && !failed
+      ? '总体状态：部分可用（含授权阻塞）'
+      : snapshot.status === 'failed' && blocked && !failed
+        ? '总体状态：授权阻塞'
+        : `总体状态：${statusText(snapshot.status)}`;
     document.getElementById('overall').textContent = overallText;
     document.getElementById('snapshot-meta').textContent = `数据时间 ${fmtTime(snapshot.as_of)} · 自动读取间隔 30 秒 · 请求上限 10 秒`;
     if (snapshot.status === 'failed') {
-      if (blocked && !failed) showBanner(`当前 ${blocked} 个单元格因授权阻塞，尚无可展示数据；不是采集程序崩溃`, 'error');
+      if (blocked && !failed && technicalReady) {
+        const details = [`已有 ${technicalReady} 个单元格有技术数据`, `${blocked} 个单元格因授权未核实`];
+        if (unavailable) details.push(`${unavailable} 个单元格暂无数据`);
+        showBanner(`${details.join('；')}。不是采集程序崩溃，请按资产和时间级别查看`, 'warn');
+      } else if (blocked && !failed) {
+        showBanner(`当前 ${blocked} 个单元格因授权阻塞，尚无可展示数据；不是采集程序崩溃`, 'error');
+      }
       else if (blocked) showBanner(`当前有 ${failed} 个采集失败单元格和 ${blocked} 个授权阻塞单元格，请分别查看详情`, 'error');
       else showBanner(`当前有 ${failed} 个采集失败单元格，请查看矩阵详情`, 'error');
     } else if (snapshot.status === 'partial') {

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -384,6 +384,8 @@ def test_health_matrix_api_and_ui_are_chinese_and_read_only(
     assert payload["refresh"]["request_timeout_seconds"] == 10
     assert page.status_code == 200
     assert "资产 × 时间级别健康矩阵" in page.text
+    assert "部分可用（含授权阻塞）" in page.text
+    assert "有技术数据" in page.text
     assert "最近一次运行" in page.text
     assert "system notification" not in page.text.lower()
     assert "重试" not in page.text


### PR DESCRIPTION
## What
- distinguish mixed snapshots with real free-source technical data from authorization-blocked and unavailable cells
- keep the all-blocked copy unchanged when no technical data exists
- add focused Chinese UI regression assertions

## Why
After the free-source route started writing 3+3 data, the full matrix still contained legacy blocked/unseeded cells. The old header said “授权阻塞、尚无可展示数据” even when 30 cells had real technical data.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 270 passed
- changed-file `python3 -m ruff check ...` → passed
- `git diff --check` → passed
- live browser validation after merge on `http://127.0.0.1:18171/health-ui`

Closes #83
