### PR TITLE
feat: seed remaining stocks with free-source rate guards

### DIFF
--- a/ops/mvp_stock_seed.py
+++ b/ops/mvp_stock_seed.py
@@ -1,0 +1,452 @@
+"""Seed the remaining 100+100 stock MVP with bounded free-source batches.
+
+The existing reliability worker intentionally exercises only the approved 3+3
+vertical slice.  This one-shot runner is the next, resumable step: it skips
+instrument/timeframe identities that already have closed bars, runs coarse bars
+before intraday bars, and writes a redacted batch report for rate-limit review.
+It never touches the legacy service database or performs a NAS cutover.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections import Counter
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+import signal
+from typing import Any, Mapping, Sequence
+
+from kline.config import Settings
+from kline.free_source_profile import apply_free_source_profile
+from kline.ingestion import IngestionOrchestrator, IngestionPlan, IngestionRunReceipt
+from kline.mvp_manifest import MvpManifest, load_manifest, manifest_digest
+from kline.registry import init
+from kline.mvp_worker import _SingleRunLock
+from kline.store import KlineStore
+
+
+STOCK_UNIVERSES = ("a_share", "us_stock")
+COARSE_TIMEFRAMES = ("1d", "1w")
+INTRADAY_TIMEFRAMES = ("15m", "1h", "4h")
+DEFAULT_BATCH_SIZE = 10
+DEFAULT_REQUEST_INTERVAL_SECONDS = 0.25
+DEFAULT_MAX_RETRIES = 2
+DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
+SAFE_OBSERVER_DB = Path("/Users/wendy/datafeed-runtime-issue-71/data/kline.db")
+_RATE_MARKERS = ("429", "rate limit", "too many", "throttl", "quota")
+_FORBIDDEN_MARKERS = ("403", "forbidden", "blocked")
+_SERVER_MARKERS = ("500", "502", "503", "504", "server error", "bad gateway", "service unavailable")
+_TIMEOUT_MARKERS = ("timeout", "timed out", "deadline")
+_EMPTY_MARKERS = ("no data", "no rows", "empty")
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def stock_instrument_ids(manifest: MvpManifest) -> dict[str, tuple[str, ...]]:
+    """Return the canonical stock IDs grouped in deterministic universe order."""
+
+    return {
+        universe: tuple(
+            item.instrument_id for item in manifest.instruments if item.universe == universe
+        )
+        for universe in STOCK_UNIVERSES
+    }
+
+
+def _seeded_keys(store: KlineStore) -> set[tuple[str, str, str, str, str]]:
+    rows = store.mvp_latest_closed_bars()
+    return {
+        (
+            str(row.get("source_id") or ""),
+            str(row.get("instrument_id") or ""),
+            str(row.get("timeframe") or ""),
+            str(row.get("adjustment_basis") or "raw_unadjusted"),
+            str(row.get("manifest_version") or ""),
+        )
+        for row in rows
+    }
+
+
+def remaining_stock_ids(manifest: MvpManifest, store: KlineStore) -> dict[str, tuple[str, ...]]:
+    """Select stock identities missing at least one required closed-bar series."""
+
+    seeded = _seeded_keys(store)
+    result: dict[str, tuple[str, ...]] = {}
+    for universe, ids in stock_instrument_ids(manifest).items():
+        remaining: list[str] = []
+        for instrument_id in ids:
+            item = next(
+                item for item in manifest.instruments if item.instrument_id == instrument_id
+            )
+            complete = all(
+                (
+                    item.source_id,
+                    item.instrument_id,
+                    timeframe,
+                    item.adjustment_basis,
+                    manifest.version,
+                )
+                in seeded
+                for timeframe in item.required_timeframes
+            )
+            if not complete:
+                remaining.append(instrument_id)
+        result[universe] = tuple(remaining)
+    return result
+
+
+def _batches(ids: Sequence[str], size: int) -> list[tuple[str, ...]]:
+    return [tuple(ids[index : index + size]) for index in range(0, len(ids), size)]
+
+
+def validate_seed_target(
+    db_path: str | Path, lock_path: str | Path | None = None
+) -> tuple[Path, Path]:
+    """Fail closed unless the seed targets the isolated observer database."""
+
+    database = Path(db_path).expanduser().resolve()
+    if database != SAFE_OBSERVER_DB.resolve():
+        raise ValueError(f"stock seed refuses non-observer database; expected {SAFE_OBSERVER_DB}")
+    lock_file = (
+        Path(lock_path).expanduser().resolve()
+        if lock_path
+        else SAFE_OBSERVER_DB.with_name("mvp-worker.lock").resolve()
+    )
+    canonical_lock = SAFE_OBSERVER_DB.with_name("mvp-worker.lock").resolve()
+    if lock_file != canonical_lock:
+        raise ValueError(f"stock seed requires the canonical observer lock: {canonical_lock}")
+    return database, lock_file
+
+
+def _classify_attempt(attempt: Mapping[str, Any]) -> str | None:
+    status = str(attempt.get("status") or "").casefold()
+    error = str(attempt.get("error") or "").casefold()
+    http_status = attempt.get("http_status")
+    try:
+        status_code = int(http_status) if http_status is not None else None
+    except (TypeError, ValueError):
+        status_code = None
+    text = f"{status} {error} {http_status or ''}"
+    if any(marker in text for marker in _RATE_MARKERS):
+        return "rate_limit"
+    if any(marker in text for marker in _FORBIDDEN_MARKERS):
+        return "forbidden"
+    if (status_code is not None and 500 <= status_code <= 599) or any(
+        marker in text for marker in _SERVER_MARKERS
+    ):
+        return "server_error"
+    if any(marker in text for marker in _TIMEOUT_MARKERS):
+        return "timeout"
+    if any(marker in text for marker in _EMPTY_MARKERS):
+        return "empty_response"
+    if status in {
+        "failed",
+        "unavailable",
+        "provider_error",
+        "malformed",
+        "transform_incomplete",
+    }:
+        return "other_error"
+    return None
+
+
+def _redact_error(value: str) -> str:
+    text = re.sub(r"(?i)(token|api[_-]?key|secret|password)=?[^\s,;]+", r"\1=<redacted>", value)
+    return text[:240]
+
+
+def _batch_report(
+    receipt: IngestionRunReceipt,
+    *,
+    phase: str,
+    universe: str,
+    batch_index: int,
+    batch_size: int,
+) -> dict[str, Any]:
+    error_counts: Counter[str] = Counter()
+    samples: list[dict[str, Any]] = []
+    latency_values: list[float] = []
+    attempt_count = 0
+    for attempt in receipt.source_attempts:
+        provider_attempts = [
+            dict(item) for item in attempt.get("provider_attempts", ()) if isinstance(item, Mapping)
+        ]
+        records = provider_attempts or [dict(attempt)]
+        if provider_attempts and _classify_attempt(attempt) is not None:
+            records.append(dict(attempt))
+        attempt_count += len(records)
+        for record in records:
+            record.setdefault("symbol", attempt.get("provider_symbol"))
+            record.setdefault("timeframe", attempt.get("timeframe"))
+            if record.get("latency_ms") is None and attempt.get("latency_ms") is not None:
+                record["latency_ms"] = attempt["latency_ms"]
+            try:
+                latency = float(record["latency_ms"])
+            except (KeyError, TypeError, ValueError):
+                latency = None
+            if latency is not None:
+                latency_values.append(latency)
+            category = _classify_attempt(record)
+            if category is None:
+                continue
+            error_counts[category] += 1
+            if len(samples) < 5:
+                samples.append(
+                    {
+                        "symbol": record.get("symbol"),
+                        "timeframe": record.get("timeframe"),
+                        "source": record.get("source"),
+                        "status": record.get("status"),
+                        "http_status": record.get("http_status"),
+                        "error": _redact_error(
+                            str(record.get("error") or attempt.get("error") or "")
+                        ),
+                    }
+                )
+    sorted_latencies = sorted(latency_values)
+    p95_index = (
+        max(0, min(len(sorted_latencies) - 1, (95 * len(sorted_latencies) + 99) // 100 - 1))
+        if sorted_latencies
+        else None
+    )
+    return {
+        "run_id": receipt.run_id,
+        "phase": phase,
+        "universe": universe,
+        "batch_index": batch_index,
+        "batch_size": batch_size,
+        "status": receipt.status,
+        "attempt_count": attempt_count,
+        "latency_sample_count": len(latency_values),
+        "p95_latency_ms": round(sorted_latencies[p95_index], 1) if p95_index is not None else None,
+        "requested_cells": len(receipt.requested_cells),
+        "row_counts": dict(receipt.row_counts),
+        "quality": dict(receipt.quality),
+        "error_counts": dict(error_counts),
+        "error_samples": samples,
+        "_latencies_ms": latency_values,
+    }
+
+
+async def run_stock_seed_once(
+    *,
+    db_path: str | Path,
+    manifest_path: str | Path,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    request_interval_seconds: float = DEFAULT_REQUEST_INTERVAL_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
+    phase: str = "all",
+    include_seeded: bool = False,
+    lock_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Run the remaining stock identities in coarse-first, bounded batches."""
+
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if request_interval_seconds < 0:
+        raise ValueError("request_interval_seconds must be non-negative")
+    if max_retries < 0:
+        raise ValueError("max_retries must be non-negative")
+    if retry_backoff_seconds < 0:
+        raise ValueError("retry_backoff_seconds must be non-negative")
+    phase_map = {
+        "coarse": (COARSE_TIMEFRAMES,),
+        "intraday": (INTRADAY_TIMEFRAMES,),
+        "all": (COARSE_TIMEFRAMES, INTRADAY_TIMEFRAMES),
+    }
+    if phase not in phase_map:
+        raise ValueError(f"unsupported phase: {phase}")
+
+    observed_at = datetime.now(timezone.utc)
+    manifest = apply_free_source_profile(load_manifest(manifest_path))
+    database, lock_file = validate_seed_target(db_path, lock_path)
+    init(Settings(db_path=str(database), load_entrypoint_adapters=False))
+    store = KlineStore(str(database))
+    remaining = (
+        stock_instrument_ids(manifest) if include_seeded else remaining_stock_ids(manifest, store)
+    )
+    selected = {universe: tuple(ids) for universe, ids in remaining.items()}
+    selected_total = sum(len(ids) for ids in selected.values())
+    orchestrator = IngestionOrchestrator(store)
+    reports: list[dict[str, Any]] = []
+    for phase_timeframes in phase_map[phase]:
+        phase_name = "coarse" if phase_timeframes == COARSE_TIMEFRAMES else "intraday"
+        for universe in STOCK_UNIVERSES:
+            for batch_index, batch in enumerate(_batches(selected[universe], batch_size), start=1):
+                run_now = datetime.now(timezone.utc)
+                run_id = (
+                    f"mvp-stocks-{run_now.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+                    f"-{phase_name}-{universe}-{batch_index:03d}"
+                )
+                with _SingleRunLock(lock_file):
+                    receipt = await orchestrator.run_once(
+                        IngestionPlan(
+                            manifest=manifest,
+                            run_id=run_id,
+                            now=run_now,
+                            instrument_ids=batch,
+                            timeframes=phase_timeframes,
+                            max_retries=max_retries,
+                            retry_backoff_seconds=retry_backoff_seconds,
+                            request_interval_seconds=request_interval_seconds,
+                            policy={
+                                "runner": "mvp_stock_seed",
+                                "phase": phase_name,
+                                "universe": universe,
+                                "batch_size": batch_size,
+                                "request_interval_seconds": request_interval_seconds,
+                                "max_retries": max_retries,
+                                "retry_backoff_seconds": retry_backoff_seconds,
+                            },
+                        )
+                    )
+                reports.append(
+                    _batch_report(
+                        receipt,
+                        phase=phase_name,
+                        universe=universe,
+                        batch_index=batch_index,
+                        batch_size=len(batch),
+                    )
+                )
+
+    status_counts: Counter[str] = Counter(report["status"] for report in reports)
+    error_counts: Counter[str] = Counter()
+    row_counts: Counter[str] = Counter()
+    latency_values: list[float] = []
+    for report in reports:
+        error_counts.update(report["error_counts"])
+        row_counts.update(report["row_counts"])
+        latency_values.extend(report.pop("_latencies_ms", []))
+    final_remaining = remaining_stock_ids(manifest, store)
+    latency_values.sort()
+    p95_index = (
+        max(0, min(len(latency_values) - 1, (95 * len(latency_values) + 99) // 100 - 1))
+        if latency_values
+        else None
+    )
+    return {
+        "observed_at": _iso(observed_at),
+        "status": "success"
+        if not final_remaining["a_share"] and not final_remaining["us_stock"]
+        else "partial",
+        "manifest_version": manifest.version,
+        "manifest_hash": manifest_digest(manifest),
+        "selected": {universe: len(ids) for universe, ids in selected.items()},
+        "selected_total": selected_total,
+        "remaining_after": {universe: len(ids) for universe, ids in final_remaining.items()},
+        "batch_size": batch_size,
+        "request_interval_seconds": request_interval_seconds,
+        "max_retries": max_retries,
+        "retry_backoff_seconds": retry_backoff_seconds,
+        "phase": phase,
+        "batch_count": len(reports),
+        "batch_status_counts": dict(status_counts),
+        "row_counts": dict(row_counts),
+        "error_counts": dict(error_counts),
+        "rate_limit_errors": error_counts.get("rate_limit", 0),
+        "server_errors": error_counts.get("server_error", 0),
+        "attempt_count": sum(int(report["attempt_count"]) for report in reports),
+        "latency_sample_count": len(latency_values),
+        "p95_latency_ms": round(latency_values[p95_index], 1) if p95_index is not None else None,
+        "reports": reports,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed remaining 100+100 MVP stock identities")
+    parser.add_argument("--manifest", default="configs/mvp_manifest.json")
+    parser.add_argument("--db", default=str(SAFE_OBSERVER_DB))
+    parser.add_argument("--lock", default=None)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--request-interval", type=float, default=DEFAULT_REQUEST_INTERVAL_SECONDS)
+    parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
+    parser.add_argument("--retry-backoff", type=float, default=DEFAULT_RETRY_BACKOFF_SECONDS)
+    parser.add_argument("--phase", choices=("coarse", "intraday", "all"), default="all")
+    parser.add_argument("--include-seeded", action="store_true")
+    parser.add_argument("--receipt", default=None)
+    parser.add_argument("--forever", action="store_true")
+    parser.add_argument("--interval", type=int, default=4 * 60 * 60)
+    return parser
+
+
+async def _run_forever(args: argparse.Namespace) -> None:
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(signum, stop_event.set)
+        except NotImplementedError:  # pragma: no cover - platform fallback
+            signal.signal(signum, lambda *_: stop_event.set())
+    while not stop_event.is_set():
+        report = await run_stock_seed_once(
+            db_path=args.db,
+            manifest_path=args.manifest,
+            batch_size=args.batch_size,
+            request_interval_seconds=args.request_interval,
+            max_retries=args.max_retries,
+            retry_backoff_seconds=args.retry_backoff,
+            phase=args.phase,
+            include_seeded=args.include_seeded,
+            lock_path=args.lock,
+        )
+        print(
+            json.dumps(
+                {
+                    "observed_at": report["observed_at"],
+                    "status": report["status"],
+                    "selected_total": report["selected_total"],
+                    "remaining_after": report["remaining_after"],
+                    "rate_limit_errors": report["rate_limit_errors"],
+                    "server_errors": report["server_errors"],
+                    "p95_latency_ms": report["p95_latency_ms"],
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=args.interval)
+        except TimeoutError:
+            continue
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.interval <= 0:
+        raise SystemExit("--interval must be positive")
+    if args.forever:
+        asyncio.run(_run_forever(args))
+        return 0
+    report = asyncio.run(
+        run_stock_seed_once(
+            db_path=args.db,
+            manifest_path=args.manifest,
+            batch_size=args.batch_size,
+            request_interval_seconds=args.request_interval,
+            max_retries=args.max_retries,
+            retry_backoff_seconds=args.retry_backoff,
+            phase=args.phase,
+            include_seeded=args.include_seeded,
+            lock_path=args.lock,
+        )
+    )
+    payload = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True)
+    if args.receipt:
+        path = Path(args.receipt).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    return 0 if report["status"] == "success" else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ops/mvp_stock_seed.py
+++ b/ops/mvp_stock_seed.py
@@ -41,6 +41,7 @@ _FORBIDDEN_MARKERS = ("403", "forbidden", "blocked")
 _SERVER_MARKERS = ("500", "502", "503", "504", "server error", "bad gateway", "service unavailable")
 _TIMEOUT_MARKERS = ("timeout", "timed out", "deadline")
 _EMPTY_MARKERS = ("no data", "no rows", "empty")
+_EMPTY_PATTERN = re.compile(r"\bno\s+\w+\s+rows?\b")
 
 
 def _iso(value: datetime) -> str:
@@ -144,7 +145,7 @@ def _classify_attempt(attempt: Mapping[str, Any]) -> str | None:
         return "server_error"
     if any(marker in text for marker in _TIMEOUT_MARKERS):
         return "timeout"
-    if any(marker in text for marker in _EMPTY_MARKERS):
+    if any(marker in text for marker in _EMPTY_MARKERS) or _EMPTY_PATTERN.search(text):
         return "empty_response"
     if status in {
         "failed",

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -8,11 +8,12 @@ from datetime import datetime, timedelta, timezone
 import hashlib
 import inspect
 import json
+import time as time_module
 from typing import Any, Callable, Mapping, Sequence
 
 from kline.market_calendar import QualityResult, assess_quality
 from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
-from kline.mvp_manifest import MvpManifest, manifest_digest
+from kline.mvp_manifest import ALLOWED_TIMEFRAMES, MvpManifest, manifest_digest
 from kline.ports import FetchReceipt, MarketDataPort
 from kline.providers.base import EntitlementBlocked, ProviderError
 from kline.storage import (
@@ -52,6 +53,8 @@ class IngestionPlan:
     rate_budget: int | None = None
     policy: Mapping[str, Any] = field(default_factory=dict)
     instrument_ids: Sequence[str] | None = None
+    timeframes: Sequence[str] | None = None
+    request_interval_seconds: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -214,6 +217,22 @@ class IngestionOrchestrator:
         plan: IngestionPlan,
     ) -> FetchReceipt:
         last_error: Exception | None = None
+        attempts: list[dict[str, Any]] = []
+
+        def adapter_attempts() -> list[dict[str, Any]]:
+            value = getattr(adapter, "last_attempts", ()) or ()
+            return [dict(item) for item in value if isinstance(item, Mapping)]
+
+        def append_attempts(values: Sequence[Mapping[str, Any]], retry_number: int) -> None:
+            attempts.extend(
+                {**dict(item), "retry_number": retry_number}
+                for item in values
+                if isinstance(item, Mapping)
+            )
+
+        def attach_attempts(error: Exception) -> None:
+            setattr(error, "attempts", tuple(attempts))
+
         for attempt in range(plan.max_retries + 1):
             try:
                 fetch_with_receipt = getattr(adapter, "fetch_candles_with_receipt", None)
@@ -228,13 +247,24 @@ class IngestionOrchestrator:
                     if inspect.isawaitable(result):
                         result = await result
                     if isinstance(result, FetchReceipt):
-                        return result
+                        append_attempts(result.attempts or tuple(adapter_attempts()), attempt + 1)
+                        return FetchReceipt(
+                            candles=result.candles,
+                            timeframe_transform=result.timeframe_transform,
+                            source_identity=result.source_identity,
+                            raw_response=result.raw_response,
+                            attempts=tuple(attempts),
+                        )
                     if hasattr(result, "candles"):
+                        append_attempts(
+                            getattr(result, "attempts", ()) or adapter_attempts(), attempt + 1
+                        )
                         return FetchReceipt(
                             candles=list(result.candles),
                             timeframe_transform=getattr(result, "timeframe_transform", None),
                             source_identity=getattr(result, "source_identity", {}) or {},
                             raw_response=getattr(result, "raw_response", None),
+                            attempts=tuple(attempts),
                         )
                 fetch = adapter.fetch_candles(
                     ticker,
@@ -244,16 +274,21 @@ class IngestionOrchestrator:
                     limit=limit,
                 )
                 candles = await fetch if inspect.isawaitable(fetch) else fetch
+                append_attempts(adapter_attempts(), attempt + 1)
                 return FetchReceipt(
                     candles=list(candles),
                     timeframe_transform=getattr(adapter, "timeframe_transform", None),
                     source_identity=getattr(adapter, "source_identity", {}) or {},
                     raw_response=getattr(adapter, "last_raw_response", None),
+                    attempts=tuple(attempts),
                 )
-            except EntitlementBlocked:
+            except EntitlementBlocked as exc:
+                append_attempts(adapter_attempts(), attempt + 1)
+                attach_attempts(exc)
                 raise
             except ProviderError as exc:
                 last_error = exc
+                append_attempts(adapter_attempts(), attempt + 1)
                 if (
                     getattr(exc, "code", "provider_error")
                     in {
@@ -263,15 +298,22 @@ class IngestionOrchestrator:
                     }
                     or attempt >= plan.max_retries
                 ):
+                    attach_attempts(exc)
                     raise
             except Exception as exc:
                 last_error = exc
+                append_attempts(adapter_attempts(), attempt + 1)
                 if attempt >= plan.max_retries:
-                    raise ProviderError(f"provider fetch failed: {exc}") from exc
+                    wrapped = ProviderError(f"provider fetch failed: {exc}")
+                    attach_attempts(wrapped)
+                    raise wrapped from exc
             if plan.retry_backoff_seconds:
                 await asyncio.sleep(plan.retry_backoff_seconds * (attempt + 1))
         assert last_error is not None
-        raise ProviderError(str(last_error)) from last_error
+        attach_attempts(last_error)
+        wrapped = ProviderError(str(last_error))
+        attach_attempts(wrapped)
+        raise wrapped from last_error
 
     def _to_mvp_rows(
         self,
@@ -348,6 +390,11 @@ class IngestionOrchestrator:
         end = self._now_iso(now)
         manifest = plan.manifest
         manifest_hash = manifest_digest(manifest)
+        timeframes = tuple(plan.timeframes or INGESTION_TIMEFRAMES)
+        if not timeframes or any(timeframe not in ALLOWED_TIMEFRAMES for timeframe in timeframes):
+            raise IngestionError(f"ingestion timeframes must be drawn from {ALLOWED_TIMEFRAMES}")
+        if plan.request_interval_seconds < 0:
+            raise IngestionError("request_interval_seconds must be non-negative")
         selected_ids = set(plan.instrument_ids) if plan.instrument_ids is not None else None
         if selected_ids is not None:
             known_ids = {instrument.instrument_id for instrument in manifest.instruments}
@@ -366,11 +413,61 @@ class IngestionOrchestrator:
         watermarks: list[WatermarkWrite] = []
         request_count = 0
         quality_counts = {"pass": 0, "partial": 0, "fail": 0}
+        last_request_at: float | None = None
+
+        def receipt_attempts(value: Any) -> list[dict[str, Any]]:
+            raw = getattr(value, "attempts", ()) or ()
+            return [dict(item) for item in raw if isinstance(item, Mapping)]
+
+        def error_attempts(error: Exception, adapter: Any) -> list[dict[str, Any]]:
+            raw = getattr(error, "attempts", ()) or getattr(adapter, "last_attempts", ()) or ()
+            return [dict(item) for item in raw if isinstance(item, Mapping)]
+
+        def elapsed_ms(started_at: float | None) -> float | None:
+            if started_at is None:
+                return None
+            return round((time_module.perf_counter() - started_at) * 1000, 1)
+
+        def append_failed_observation(
+            *,
+            key: CandleSeriesKey,
+            request_start: str | None,
+            adapter: Any,
+            error: str,
+            latency_ms: float | None,
+            provider_attempts: Sequence[Mapping[str, Any]],
+        ) -> None:
+            raw_response = getattr(adapter, "last_raw_response", None) if adapter else None
+            response_hash = self._hash(raw_response) if isinstance(raw_response, Mapping) else None
+            source_identity = getattr(adapter, "source_identity", {}) if adapter else {}
+            observations.append(
+                SourceObservationWrite(
+                    run_id=plan.run_id,
+                    key=key,
+                    success=False,
+                    request_start=request_start,
+                    request_end=end,
+                    response_hash=response_hash,
+                    policy={
+                        "fallback": "none",
+                        "overlap_bars": plan.overlap_bars,
+                        "source_identity": dict(source_identity or {})
+                        if isinstance(source_identity, Mapping)
+                        else {},
+                        "provider_attempts": [dict(item) for item in provider_attempts],
+                    },
+                    candle_count=0,
+                    latest_timestamp=None,
+                    latency_ms=latency_ms,
+                    served_from="upstream",
+                    error=error,
+                )
+            )
 
         for instrument in manifest.instruments:
             if selected_ids is not None and instrument.instrument_id not in selected_ids:
                 continue
-            for timeframe in INGESTION_TIMEFRAMES:
+            for timeframe in timeframes:
                 if timeframe in instrument.not_applicable_timeframes:
                     cells.append(
                         CellResult(
@@ -454,6 +551,14 @@ class IngestionOrchestrator:
                             "error": "source adapter is not configured",
                         }
                     )
+                    append_failed_observation(
+                        key=key,
+                        request_start=request_start,
+                        adapter=None,
+                        error="source adapter is not configured",
+                        latency_ms=None,
+                        provider_attempts=(),
+                    )
                     qualities.append(
                         QualityReceiptWrite(
                             run_id=plan.run_id, key=key, status="blocked", blocked_cells=1
@@ -461,7 +566,15 @@ class IngestionOrchestrator:
                     )
                     quality_counts["fail"] += 1
                     continue
+                fetch_started_at: float | None = None
                 try:
+                    if last_request_at is not None and plan.request_interval_seconds:
+                        elapsed = time_module.monotonic() - last_request_at
+                        wait_seconds = plan.request_interval_seconds - elapsed
+                        if wait_seconds > 0:
+                            await asyncio.sleep(wait_seconds)
+                    last_request_at = time_module.monotonic()
+                    fetch_started_at = time_module.perf_counter()
                     fetch_receipt = await self._fetch_with_retries(
                         adapter,
                         instrument.display_symbol,
@@ -471,6 +584,8 @@ class IngestionOrchestrator:
                         limit=plan.fetch_limit,
                         plan=plan,
                     )
+                    latency_ms = round((time_module.perf_counter() - fetch_started_at) * 1000, 1)
+                    provider_attempts = receipt_attempts(fetch_receipt)
                     raw_rows = fetch_receipt.candles
                     mvp_rows = self._to_mvp_rows(
                         instrument,
@@ -504,9 +619,11 @@ class IngestionOrchestrator:
                                 "fallback": "none",
                                 "overlap_bars": plan.overlap_bars,
                                 "source_identity": dict(fetch_receipt.source_identity),
+                                "provider_attempts": provider_attempts,
                             },
                             candle_count=len(mvp_rows),
                             latest_timestamp=latest,
+                            latency_ms=latency_ms,
                             served_from="upstream",
                         )
                     )
@@ -518,6 +635,10 @@ class IngestionOrchestrator:
                             "status": quality.status,
                             "candle_count": len(mvp_rows),
                             "response_hash": response_hash,
+                            "latency_ms": latency_ms,
+                            "http_status": (fetch_receipt.raw_response or {}).get("http_status"),
+                            "source_identity": dict(fetch_receipt.source_identity),
+                            "provider_attempts": provider_attempts,
                         }
                     )
                     if quality.status == "pass" and mvp_rows:
@@ -575,6 +696,16 @@ class IngestionOrchestrator:
                     if quality.status == "fail":
                         blocked_cells.append(result.to_dict())
                 except EntitlementBlocked as exc:
+                    latency_ms = elapsed_ms(fetch_started_at)
+                    provider_attempts = error_attempts(exc, adapter)
+                    append_failed_observation(
+                        key=key,
+                        request_start=request_start,
+                        adapter=adapter,
+                        error=str(exc),
+                        latency_ms=latency_ms,
+                        provider_attempts=provider_attempts,
+                    )
                     result = CellResult(
                         instrument.instrument_id,
                         instrument.display_symbol,
@@ -597,6 +728,8 @@ class IngestionOrchestrator:
                             "timeframe": timeframe,
                             "status": "blocked_for_entitlement",
                             "error": str(exc),
+                            "latency_ms": latency_ms,
+                            "provider_attempts": provider_attempts,
                         }
                     )
                     qualities.append(
@@ -609,6 +742,16 @@ class IngestionOrchestrator:
                         )
                     )
                 except ProviderError as exc:
+                    latency_ms = elapsed_ms(fetch_started_at)
+                    provider_attempts = error_attempts(exc, adapter)
+                    append_failed_observation(
+                        key=key,
+                        request_start=request_start,
+                        adapter=adapter,
+                        error=str(exc),
+                        latency_ms=latency_ms,
+                        provider_attempts=provider_attempts,
+                    )
                     result = CellResult(
                         instrument.instrument_id,
                         instrument.display_symbol,
@@ -631,6 +774,11 @@ class IngestionOrchestrator:
                             "timeframe": timeframe,
                             "status": getattr(exc, "code", "unavailable"),
                             "error": str(exc),
+                            "latency_ms": latency_ms,
+                            "http_status": (getattr(adapter, "last_raw_response", {}) or {}).get(
+                                "http_status"
+                            ),
+                            "provider_attempts": provider_attempts,
                         }
                     )
                     qualities.append(
@@ -643,6 +791,16 @@ class IngestionOrchestrator:
                         )
                     )
                 except (StorageError, ValueError) as exc:
+                    latency_ms = elapsed_ms(fetch_started_at)
+                    provider_attempts = error_attempts(exc, adapter)
+                    append_failed_observation(
+                        key=key,
+                        request_start=request_start,
+                        adapter=adapter,
+                        error=str(exc),
+                        latency_ms=latency_ms,
+                        provider_attempts=provider_attempts,
+                    )
                     result = CellResult(
                         instrument.instrument_id,
                         instrument.display_symbol,
@@ -665,6 +823,8 @@ class IngestionOrchestrator:
                             "timeframe": timeframe,
                             "status": "malformed",
                             "error": str(exc),
+                            "latency_ms": latency_ms,
+                            "provider_attempts": provider_attempts,
                         }
                     )
                     qualities.append(

--- a/src/kline/ports.py
+++ b/src/kline/ports.py
@@ -87,6 +87,7 @@ class FetchReceipt:
     timeframe_transform: TimeframeTransform | None
     source_identity: Mapping[str, Any]
     raw_response: dict[str, Any] | None
+    attempts: tuple[Mapping[str, Any], ...] = ()
 
 
 class MarketDataPort(Protocol):
@@ -164,6 +165,11 @@ class ProviderBackedMarketDataAdapter:
         value = getattr(self._provider, "source_identity", None)
         return value if isinstance(value, Mapping) else None
 
+    @property
+    def last_attempts(self) -> tuple[Mapping[str, Any], ...]:
+        value = getattr(self._provider, "last_attempts", ()) or ()
+        return tuple(item for item in value if isinstance(item, Mapping))
+
     def canonical_ticker(self, ticker: str) -> str:
         return self._manifest.canonical_ticker(ticker)
 
@@ -212,6 +218,7 @@ class ProviderBackedMarketDataAdapter:
                 timeframe_transform=self.timeframe_transform,
                 source_identity=dict(self.source_identity or {}),
                 raw_response=dict(self.last_raw_response or {}) if self.last_raw_response else None,
+                attempts=tuple(getattr(self._provider, "last_attempts", ()) or ()),
             )
 
     async def stream_candles(

--- a/src/kline/providers/free_ashare.py
+++ b/src/kline/providers/free_ashare.py
@@ -12,6 +12,7 @@ from hashlib import sha256
 import json
 import math
 import re
+import time
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -20,7 +21,7 @@ import httpx
 from kline.market_calendar import aggregate_15m_to_4h, aggregate_daily_to_weekly
 from kline.models import Candle, Timeframe, TimeframeTransform
 from kline.providers.base import ProviderError
-from kline.providers.free_common import requested_cutoff
+from kline.providers.free_common import RequestPacer, requested_cutoff
 from kline.storage import CandleSeriesKey, MvpCandle
 
 
@@ -166,12 +167,45 @@ def parse_10jqka_rows(
 class AShareFreeProvider:
     """Fetch A-share bars from Tencent with a Tonghuashun fallback."""
 
-    def __init__(self, *, timeout: float = 15.0, transport: httpx.AsyncBaseTransport | None = None):
+    def __init__(
+        self,
+        *,
+        timeout: float = 15.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+        request_interval_seconds: float = 0.25,
+    ):
         self._timeout = timeout
         self._transport = transport
+        self._pacer = RequestPacer(request_interval_seconds)
         self.last_raw_response: dict[str, Any] | None = None
+        self.last_attempts: list[dict[str, Any]] = []
         self.timeframe_transform: TimeframeTransform | None = None
         self.source_identity: dict[str, Any] = {}
+
+    def _record_attempt(
+        self,
+        *,
+        source: str,
+        endpoint: str,
+        started_at: float,
+        status: str,
+        http_status: int | None = None,
+        error: str | None = None,
+        row_count: int | None = None,
+    ) -> None:
+        record: dict[str, Any] = {
+            "source": source,
+            "endpoint": endpoint,
+            "status": status,
+            "latency_ms": round((time.perf_counter() - started_at) * 1000, 1),
+        }
+        if http_status is not None:
+            record["http_status"] = http_status
+        if row_count is not None:
+            record["row_count"] = row_count
+        if error:
+            record["error"] = str(error)[:240]
+        self.last_attempts.append(record)
 
     def supported_timeframes(self) -> list[Timeframe]:
         return list(_A_SHARE_TIMEFRAMES)
@@ -187,6 +221,7 @@ class AShareFreeProvider:
     ) -> list[Candle]:
         if timeframe not in _A_SHARE_TIMEFRAMES:
             raise ProviderError(f"free A-share source does not support {timeframe.value}")
+        self.last_attempts = []
         self.timeframe_transform = None
         self.last_raw_response = None
         if timeframe == Timeframe.HOUR_4:
@@ -274,7 +309,9 @@ class AShareFreeProvider:
             "selected_source": selected,
             "adjustment_basis": "qfq" if selected == "tencent" else "unverified",
             "canonical_adjustment_basis": "qfq",
-            "adjustment_basis_evidence": "tonghuashun_unverified" if selected == "tonghuashun" else "tencent_qfq",
+            "adjustment_basis_evidence": "tonghuashun_unverified"
+            if selected == "tonghuashun"
+            else "tencent_qfq",
             "fallback_from": "tencent" if selected == "tonghuashun" else None,
             "fallback_chain": ["tonghuashun"] if selected == "tonghuashun" else [],
         }
@@ -282,7 +319,10 @@ class AShareFreeProvider:
 
     async def _tencent_minute(self, code: str, key: str, *, limit: int) -> tuple[list[Candle], str]:
         params = {"param": f"{code},{key},,{max(1, min(limit, 320))}"}
+        started_at = time.perf_counter()
+        response: httpx.Response | None = None
         try:
+            await self._pacer.wait()
             async with httpx.AsyncClient(
                 timeout=self._timeout,
                 transport=self._transport,
@@ -304,8 +344,24 @@ class AShareFreeProvider:
                 "response_sha256": sha256(response.content).hexdigest(),
                 "row_count": len(rows),
             }
+            self._record_attempt(
+                source="tencent",
+                endpoint=_TENCENT_MINUTE_URL,
+                started_at=started_at,
+                status="success",
+                http_status=response.status_code,
+                row_count=len(rows),
+            )
             return rows, "tencent"
         except (httpx.HTTPError, ValueError, ProviderError) as error:
+            self._record_attempt(
+                source="tencent",
+                endpoint=_TENCENT_MINUTE_URL,
+                started_at=started_at,
+                status="error",
+                http_status=response.status_code if response is not None else None,
+                error=str(error),
+            )
             raise ProviderError(f"Tencent minute request failed for {code}: {error}") from error
 
     async def _tencent_daily(
@@ -314,7 +370,10 @@ class AShareFreeProvider:
         params = {
             "param": f"{code},day,{(start or '')[:10]},{(end or '')[:10]},{max(1, min(limit, 500))},qfq"
         }
+        started_at = time.perf_counter()
+        response: httpx.Response | None = None
         try:
+            await self._pacer.wait()
             async with httpx.AsyncClient(
                 timeout=self._timeout, transport=self._transport
             ) as client:
@@ -333,8 +392,24 @@ class AShareFreeProvider:
                 "response_sha256": sha256(response.content).hexdigest(),
                 "row_count": len(rows),
             }
+            self._record_attempt(
+                source="tencent",
+                endpoint=_TENCENT_DAILY_URL,
+                started_at=started_at,
+                status="success",
+                http_status=response.status_code,
+                row_count=len(rows),
+            )
             return rows, "tencent"
         except (httpx.HTTPError, ValueError, ProviderError) as error:
+            self._record_attempt(
+                source="tencent",
+                endpoint=_TENCENT_DAILY_URL,
+                started_at=started_at,
+                status="error",
+                http_status=response.status_code if response is not None else None,
+                error=str(error),
+            )
             raise ProviderError(f"Tencent daily request failed for {code}: {error}") from error
 
     async def _with_fallback(
@@ -352,7 +427,11 @@ class AShareFreeProvider:
                 return await self._tencent_daily(code, start=start, end=end, limit=limit)
             return await self._tencent_minute(code, tencent_key, limit=limit)
         except ProviderError as tencent_error:
+            endpoint = _TENJQKA_URL.format(code=code[2:], period=tenjqka_period)
+            started_at = time.perf_counter()
+            response: httpx.Response | None = None
             try:
+                await self._pacer.wait()
                 async with httpx.AsyncClient(
                     timeout=self._timeout, transport=self._transport
                 ) as client:
@@ -373,6 +452,14 @@ class AShareFreeProvider:
                     "row_count": len(rows),
                     "fallback_from": "tencent",
                 }
+                self._record_attempt(
+                    source="tonghuashun",
+                    endpoint=endpoint,
+                    started_at=started_at,
+                    status="success",
+                    http_status=response.status_code,
+                    row_count=len(rows),
+                )
                 self.source_identity = {
                     "selected_source": "tonghuashun",
                     "fallback_from": "tencent",
@@ -381,6 +468,14 @@ class AShareFreeProvider:
                 }
                 return rows, "tonghuashun"
             except (httpx.HTTPError, ValueError, ProviderError) as fallback_error:
+                self._record_attempt(
+                    source="tonghuashun",
+                    endpoint=endpoint,
+                    started_at=started_at,
+                    status="error",
+                    http_status=response.status_code if response is not None else None,
+                    error=str(fallback_error),
+                )
                 raise ProviderError(
                     f"free A-share sources failed for {code}: Tencent={tencent_error}; Tonghuashun={fallback_error}"
                 ) from fallback_error

--- a/src/kline/providers/free_common.py
+++ b/src/kline/providers/free_common.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import asyncio
+import time
 
 
 def requested_cutoff(end: str | None) -> datetime:
@@ -14,3 +16,20 @@ def requested_cutoff(end: str | None) -> datetime:
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed.astimezone(timezone.utc)
     return datetime.now(timezone.utc)
+
+
+class RequestPacer:
+    """Keep consecutive public-source requests at least N seconds apart."""
+
+    def __init__(self, interval_seconds: float = 0.25) -> None:
+        if interval_seconds < 0:
+            raise ValueError("request interval must be non-negative")
+        self._interval_seconds = interval_seconds
+        self._next_allowed = 0.0
+
+    async def wait(self) -> None:
+        now = time.monotonic()
+        delay = self._next_allowed - now
+        if delay > 0:
+            await asyncio.sleep(delay)
+        self._next_allowed = time.monotonic() + self._interval_seconds

--- a/src/kline/providers/free_us.py
+++ b/src/kline/providers/free_us.py
@@ -6,13 +6,14 @@ from datetime import datetime, timezone
 from hashlib import sha256
 import json
 import re
+import time
 
 import httpx
 
 from kline.market_calendar import aggregate_15m_to_4h
 from kline.models import Candle, Timeframe, TimeframeTransform
 from kline.providers.base import ProviderError
-from kline.providers.free_common import requested_cutoff
+from kline.providers.free_common import RequestPacer, requested_cutoff
 from kline.providers.us import USStockProvider
 from kline.storage import CandleSeriesKey, MvpCandle
 
@@ -25,10 +26,44 @@ _SINA_DAILY_URL = (
 class USFreeProvider(USStockProvider):
     """Use the existing Yahoo implementation and fall back to Sina daily K-lines."""
 
-    def __init__(self, *, timeout: float = 15.0, transport: httpx.AsyncBaseTransport | None = None):
+    def __init__(
+        self,
+        *,
+        timeout: float = 15.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+        request_interval_seconds: float = 0.25,
+    ):
         super().__init__()
         self._timeout = timeout
         self._transport = transport
+        self._pacer = RequestPacer(request_interval_seconds)
+        self.last_attempts: list[dict[str, object]] = []
+
+    def _record_attempt(
+        self,
+        *,
+        source: str,
+        started_at: float,
+        status: str,
+        endpoint: str | None = None,
+        http_status: int | None = None,
+        error: str | None = None,
+        row_count: int | None = None,
+    ) -> None:
+        record: dict[str, object] = {
+            "source": source,
+            "status": status,
+            "latency_ms": round((time.perf_counter() - started_at) * 1000, 1),
+        }
+        if endpoint:
+            record["endpoint"] = endpoint
+        if http_status is not None:
+            record["http_status"] = http_status
+        if row_count is not None:
+            record["row_count"] = row_count
+        if error:
+            record["error"] = str(error)[:240]
+        self.last_attempts.append(record)
 
     def supported_timeframes(self) -> list[Timeframe]:
         return [Timeframe.MIN_15, Timeframe.HOUR_1, Timeframe.HOUR_4, Timeframe.DAY, Timeframe.WEEK]
@@ -42,13 +77,31 @@ class USFreeProvider(USStockProvider):
         end: str | None = None,
         limit: int = 500,
     ) -> list[Candle]:
+        self.last_attempts = []
         if timeframe == Timeframe.HOUR_4:
-            base = await super().fetch(
-                ticker,
-                Timeframe.MIN_15,
-                start=start,
-                end=end,
-                limit=max(limit * 16, 320),
+            started_at = time.perf_counter()
+            await self._pacer.wait()
+            try:
+                base = await super().fetch(
+                    ticker,
+                    Timeframe.MIN_15,
+                    start=start,
+                    end=end,
+                    limit=max(limit * 16, 320),
+                )
+            except ProviderError as error:
+                self._record_attempt(
+                    source="yahoo",
+                    started_at=started_at,
+                    status="error",
+                    error=str(error),
+                )
+                raise
+            self._record_attempt(
+                source="yahoo",
+                started_at=started_at,
+                status="success",
+                row_count=len(base),
             )
             key = CandleSeriesKey(
                 instrument_id=f"US.EQ.{ticker.upper()}",
@@ -117,8 +170,20 @@ class USFreeProvider(USStockProvider):
                 )
                 for row in selected
             ]
+        if timeframe == Timeframe.WEEK:
+            # The inherited weekly transform calls back into this provider for
+            # daily bars; that inner call owns the Yahoo/Sina attempt receipt.
+            return await super().fetch(ticker, timeframe, start=start, end=end, limit=limit)
         try:
+            started_at = time.perf_counter()
+            await self._pacer.wait()
             candles = await super().fetch(ticker, timeframe, start=start, end=end, limit=limit)
+            self._record_attempt(
+                source="yahoo",
+                started_at=started_at,
+                status="success",
+                row_count=len(candles),
+            )
             selected = self.source_identity.get("selected_source", "yahoo")
             fallback_from = self.source_identity.get("fallback_from")
             self.source_identity = {
@@ -129,10 +194,25 @@ class USFreeProvider(USStockProvider):
             }
             return candles
         except ProviderError as yahoo_error:
+            self._record_attempt(
+                source="yahoo",
+                started_at=started_at,
+                status="error",
+                error=str(yahoo_error),
+            )
             if timeframe != Timeframe.DAY:
                 raise
             try:
+                started_at = time.perf_counter()
                 candles = await self._fetch_sina_daily(ticker, start=start, end=end, limit=limit)
+                self._record_attempt(
+                    source="sina",
+                    started_at=started_at,
+                    status="success",
+                    endpoint=_SINA_DAILY_URL,
+                    http_status=(self.last_raw_response or {}).get("http_status"),
+                    row_count=len(candles),
+                )
                 self.timeframe_transform = None
                 self.source_identity = {
                     "source_id": "yahoo_finance_free",
@@ -142,6 +222,13 @@ class USFreeProvider(USStockProvider):
                 }
                 return candles
             except ProviderError as sina_error:
+                self._record_attempt(
+                    source="sina",
+                    started_at=started_at,
+                    status="error",
+                    endpoint=_SINA_DAILY_URL,
+                    error=str(sina_error),
+                )
                 raise ProviderError(
                     f"free US sources failed for {ticker}: Yahoo={yahoo_error}; Sina={sina_error}"
                 ) from sina_error
@@ -150,7 +237,9 @@ class USFreeProvider(USStockProvider):
         self, ticker: str, *, start: str | None, end: str | None, limit: int
     ) -> list[Candle]:
         params = {"symbol": ticker.upper(), "num": max(120, min(limit, 5000))}
+        response: httpx.Response | None = None
         try:
+            await self._pacer.wait()
             async with httpx.AsyncClient(
                 timeout=self._timeout,
                 transport=self._transport,

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -8,6 +8,7 @@ import pytest
 from kline.free_source_profile import apply_free_source_profile
 from kline.models import AssetClass, Candle, Timeframe
 from kline.mvp_manifest import load_manifest, manifest_digest
+from kline.ports import ProviderBackedMarketDataAdapter
 from kline.provenance import source_asset_class, source_manifest
 from kline.providers.base import ProviderError
 from kline.providers.free_ashare import (
@@ -78,6 +79,7 @@ async def test_free_a_share_provider_falls_back_to_tonghuashun() -> None:
     assert provider.source_identity["fallback_from"] == "tencent"
     assert provider.source_identity["adjustment_basis"] == "unverified"
     assert provider.source_identity["adjustment_basis_evidence"] == "tonghuashun_unverified"
+    assert [item["source"] for item in provider.last_attempts] == ["tencent", "tonghuashun"]
 
 
 @pytest.mark.asyncio
@@ -90,6 +92,22 @@ async def test_free_a_share_provider_reports_both_sources_failed() -> None:
         await provider.fetch("600519", Timeframe.HOUR_1, limit=10)
     assert "Tencent=" in str(error.value)
     assert "Tonghuashun=" in str(error.value)
+    assert [item["http_status"] for item in provider.last_attempts] == [503, 503]
+
+
+@pytest.mark.asyncio
+async def test_adapter_exposes_failed_provider_attempts() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request)
+
+    provider = AShareFreeProvider(transport=httpx.MockTransport(handler))
+    adapter = ProviderBackedMarketDataAdapter(
+        source_manifest("tencent_stock_free", AssetClass.A_SHARE), provider
+    )
+    with pytest.raises(ProviderError):
+        await adapter.fetch_candles_with_receipt("600519", Timeframe.HOUR_1, limit=10)
+    assert [item["source"] for item in adapter.last_attempts] == ["tencent", "tonghuashun"]
+    assert [item["http_status"] for item in adapter.last_attempts] == [503, 503]
 
 
 @pytest.mark.asyncio
@@ -114,6 +132,8 @@ async def test_free_us_provider_uses_yahoo_and_declares_source(
     assert len(candles) == 1
     assert provider.source_identity["source_id"] == "yahoo_finance_free"
     assert provider.source_identity["selected_source"] == "yahoo"
+    assert provider.last_attempts[0]["source"] == "yahoo"
+    assert provider.last_attempts[0]["status"] == "success"
     assert provider.supported_timeframes() == [
         Timeframe.MIN_15,
         Timeframe.HOUR_1,
@@ -149,6 +169,7 @@ async def test_free_us_provider_falls_back_to_sina_daily(monkeypatch: pytest.Mon
     assert candles[0].close == 101
     assert provider.source_identity["selected_source"] == "sina"
     assert provider.source_identity["fallback_from"] == "yahoo"
+    assert [item["source"] for item in provider.last_attempts] == ["yahoo", "sina"]
 
 
 def test_free_source_manifests_are_registered_for_the_right_asset_classes() -> None:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import httpx
 import pytest
 
 from kline.free_source_profile import apply_free_source_profile
 from kline.ingestion import IngestionError, IngestionOrchestrator, IngestionPlan
-from kline.models import Candle, Timeframe, TimeframeTransform
+from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import load_manifest
-from kline.ports import FetchReceipt
+from kline.ports import FetchReceipt, ProviderBackedMarketDataAdapter
 from kline.providers.base import ProviderError
+from kline.providers.free_ashare import AShareFreeProvider
+from kline.provenance import source_manifest
 from kline.storage import CandleSeriesKey
 from kline.store import KlineStore
 
@@ -207,6 +210,191 @@ async def test_run_once_rate_budget_blocks_remaining_required_cells(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_run_once_accepts_coarse_first_phase_selection(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "phase-selection.db"))
+    adapter = FakeCryptoAdapter()
+
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-coarse-phase",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            fetch_limit=10,
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d", "1w"),
+            request_interval_seconds=0.001,
+        )
+    )
+
+    assert [cell.timeframe for cell in receipt.requested_cells] == ["1d", "1w"]
+    assert [cell.status for cell in receipt.requested_cells] == ["ready", "ready"]
+    assert receipt.row_counts["promoted_candles"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_once_preserves_retry_attempts_and_latency_metrics(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "attempt-metrics.db"))
+
+    class RetryingAdapter:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.last_attempts: list[dict[str, object]] = []
+
+        async def fetch_candles_with_receipt(
+            self,
+            _ticker: str,
+            _timeframe: Timeframe,
+            *,
+            start: str | None,
+            end: str,
+            limit: int,
+        ) -> FetchReceipt:
+            del start, end, limit
+            self.calls += 1
+            if self.calls == 1:
+                self.last_attempts = [
+                    {"source": "fake", "status": "error", "http_status": 429, "latency_ms": 1.0}
+                ]
+                raise ProviderError("HTTP 429 rate limit")
+            self.last_attempts = [
+                {"source": "fake", "status": "success", "http_status": 200, "latency_ms": 2.0}
+            ]
+            return FetchReceipt(
+                candles=[
+                    Candle(
+                        timestamp="2026-08-31T00:00:00+00:00",
+                        open=100,
+                        high=102,
+                        low=99,
+                        close=101,
+                        volume=10,
+                    )
+                ],
+                timeframe_transform=None,
+                source_identity={"selected_source": "fake"},
+                raw_response={"http_status": 200, "row_count": 1},
+                attempts=tuple(self.last_attempts),
+            )
+
+    adapter = RetryingAdapter()
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-attempt-metrics",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d",),
+            max_retries=1,
+            retry_backoff_seconds=0.001,
+        )
+    )
+
+    assert receipt.status == "success"
+    attempt = receipt.source_attempts[0]
+    assert attempt["latency_ms"] >= 0
+    assert [item["retry_number"] for item in attempt["provider_attempts"]] == [1, 2]
+    observation = store.latest_mvp_source_observations()[0]
+    assert observation["latency_ms"] >= 0
+    assert len(observation["policy"]["provider_attempts"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_once_persists_failed_provider_attempts(tmp_path: Path) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "failed-attempt-metrics.db"))
+
+    class AlwaysFailAdapter:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.last_attempts: list[dict[str, object]] = []
+
+        async def fetch_candles_with_receipt(
+            self,
+            _ticker: str,
+            _timeframe: Timeframe,
+            *,
+            start: str | None,
+            end: str,
+            limit: int,
+        ) -> FetchReceipt:
+            del start, end, limit
+            self.calls += 1
+            self.last_attempts = [
+                {
+                    "source": "fake",
+                    "status": "error",
+                    "http_status": 503,
+                    "latency_ms": float(self.calls),
+                }
+            ]
+            raise ProviderError("HTTP 503 service unavailable")
+
+    adapter = AlwaysFailAdapter()
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-failed-attempt-metrics",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CN.A.600519",),
+            timeframes=("1d",),
+            max_retries=1,
+            retry_backoff_seconds=0.001,
+        )
+    )
+
+    assert receipt.status == "partial"
+    assert len(receipt.source_attempts[0]["provider_attempts"]) == 2
+    observation = store.latest_mvp_source_observations()[0]
+    assert observation["success"] is False
+    assert len(observation["policy"]["provider_attempts"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_once_persists_failed_attempts_through_provider_adapter(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "wrapped-failed-attempts.db"))
+
+    def handler(request):
+        return httpx.Response(503, request=request)
+
+    provider = AShareFreeProvider(transport=httpx.MockTransport(handler))
+    adapter = ProviderBackedMarketDataAdapter(
+        source_manifest("tencent_stock_free", AssetClass.A_SHARE),
+        provider,
+    )
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-wrapped-failed-attempts",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CN.A.600519",),
+            timeframes=("1h",),
+            max_retries=0,
+        )
+    )
+
+    assert receipt.status == "partial"
+    assert [item["source"] for item in receipt.source_attempts[0]["provider_attempts"]] == [
+        "tencent",
+        "tonghuashun",
+    ]
+    observation = store.latest_mvp_source_observations()[0]
+    assert len(observation["policy"]["provider_attempts"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_intraday_source_failure_still_persists_daily_and_weekly_data(
     tmp_path: Path,
 ) -> None:
@@ -266,7 +454,9 @@ async def test_intraday_source_failure_still_persists_daily_and_weekly_data(
             )
 
     adapter = IntradayUnavailableAdapter()
-    receipt = await IngestionOrchestrator(store, adapter_resolver=lambda _instrument: adapter).run_once(
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
         IngestionPlan(
             manifest=manifest,
             run_id="run-daily-weekly-fallback",

--- a/tests/test_mvp_stock_seed.py
+++ b/tests/test_mvp_stock_seed.py
@@ -76,6 +76,14 @@ def test_batches_are_deterministic_and_rate_errors_are_classified() -> None:
         _classify_attempt({"status": "unavailable", "error": "No data returned"})
         == "empty_response"
     )
+    assert (
+        _classify_attempt({"status": "error", "error": "Tencent returned no minute rows"})
+        == "empty_response"
+    )
+    assert (
+        _classify_attempt({"status": "error", "error": "Sina returned no daily rows"})
+        == "empty_response"
+    )
     assert _classify_attempt({"status": "error", "http_status": 503}) == "server_error"
 
 

--- a/tests/test_mvp_stock_seed.py
+++ b/tests/test_mvp_stock_seed.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kline.free_source_profile import apply_free_source_profile
+from kline.mvp_manifest import load_manifest
+from ops.mvp_stock_seed import (
+    _batch_report,
+    _batches,
+    _classify_attempt,
+    remaining_stock_ids,
+    stock_instrument_ids,
+    validate_seed_target,
+)
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_stock_seed_selects_the_100_plus_100_manifest_universes() -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    selected = stock_instrument_ids(manifest)
+    assert {universe: len(ids) for universe, ids in selected.items()} == {
+        "a_share": 100,
+        "us_stock": 100,
+    }
+    assert all(
+        item_id.startswith(("CN.A.", "US.EQ.")) for ids in selected.values() for item_id in ids
+    )
+
+
+def test_remaining_stock_ids_skip_only_complete_free_series() -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    a_share = next(item for item in manifest.instruments if item.instrument_id == "CN.A.600519")
+    us_stock = next(item for item in manifest.instruments if item.instrument_id == "US.EQ.AAPL")
+
+    class FakeStore:
+        def mvp_latest_closed_bars(self) -> list[dict[str, str]]:
+            return [
+                {
+                    "source_id": item.source_id,
+                    "instrument_id": item.instrument_id,
+                    "timeframe": timeframe,
+                    "adjustment_basis": item.adjustment_basis,
+                    "manifest_version": manifest.version,
+                }
+                for item in (a_share, us_stock)
+                for timeframe in item.required_timeframes
+            ]
+
+    remaining = remaining_stock_ids(manifest, FakeStore())
+    assert len(remaining["a_share"]) == 99
+    assert len(remaining["us_stock"]) == 99
+    assert "CN.A.600519" not in remaining["a_share"]
+    assert "US.EQ.AAPL" not in remaining["us_stock"]
+
+
+def test_batches_are_deterministic_and_rate_errors_are_classified() -> None:
+    assert _batches(("a", "b", "c", "d", "e"), 2) == [
+        ("a", "b"),
+        ("c", "d"),
+        ("e",),
+    ]
+    assert (
+        _classify_attempt({"status": "provider_error", "error": "HTTP 429 rate limit"})
+        == "rate_limit"
+    )
+    assert (
+        _classify_attempt({"status": "provider_error", "error": "HTTP 403 forbidden"})
+        == "forbidden"
+    )
+    assert _classify_attempt({"status": "provider_error", "error": "request timeout"}) == "timeout"
+    assert (
+        _classify_attempt({"status": "unavailable", "error": "No data returned"})
+        == "empty_response"
+    )
+    assert _classify_attempt({"status": "error", "http_status": 503}) == "server_error"
+
+
+def test_stock_seed_refuses_non_observer_database(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="refuses non-observer database"):
+        validate_seed_target(tmp_path / "unsafe.db")
+
+
+def test_stock_seed_refuses_non_canonical_lock() -> None:
+    from ops.mvp_stock_seed import SAFE_OBSERVER_DB
+
+    with pytest.raises(ValueError, match="canonical observer lock"):
+        validate_seed_target(SAFE_OBSERVER_DB, SAFE_OBSERVER_DB.with_name("alternate.lock"))
+
+
+def test_batch_report_calculates_attempt_p95_and_server_errors() -> None:
+    class Receipt:
+        run_id = "run-metrics"
+        status = "partial"
+        requested_cells = (object(),)
+        row_counts = {"promoted_candles": 1}
+        quality = {"pass": 1}
+        source_attempts = (
+            {
+                "provider_symbol": "A",
+                "timeframe": "1d",
+                "latency_ms": 100,
+                "provider_attempts": (
+                    {"source": "tencent", "status": "error", "http_status": 503, "latency_ms": 50},
+                    {
+                        "source": "tonghuashun",
+                        "status": "success",
+                        "http_status": 200,
+                        "latency_ms": 100,
+                    },
+                ),
+            },
+        )
+
+    report = _batch_report(
+        Receipt(), phase="coarse", universe="a_share", batch_index=1, batch_size=1
+    )
+    assert report["attempt_count"] == 2
+    assert report["p95_latency_ms"] == 100.0
+    assert report["error_counts"] == {"server_error": 1}
+    assert report["error_samples"][0]["http_status"] == 503


### PR DESCRIPTION
## What
- add a resumable `ops.mvp_stock_seed` one-shot/forever runner for the remaining 97 A-share + 97 US-stock identities
- run coarse daily/weekly phases before intraday phases, in deterministic batches of 10
- enforce the isolated observer DB and canonical worker lock; never target the legacy DB/NAS
- add inter-request pacing, retry/backoff, provider-internal pacing, source/fallback/retry receipts, HTTP status, latency and P95/error classification
- persist failed attempts in SQLite policy receipts and add regression coverage

## Why
The approved free-source MVP had real data for only 3+3 stocks. This safely fills the remaining 97+97 without turning public endpoints into an uncontrolled concurrent scraper, while preserving explicit unavailable/partial states.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 281 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed
- `gitleaks detect --no-banner --redact --source .` → no leaks
- real staged probes already run: A-share 10@concurrency2, 20@4, 30@8 all succeeded; US same batches all succeeded, with one normal Yahoo→Sina fallback and no 429/403/5xx
- full runner reports `rate_limit_errors`, `server_errors`, `p95_latency_ms`, retry/fallback attempts, and remaining counts

## Scope boundary
This PR only seeds A/US stocks into the isolated local observer SQLite. It does not purchase data, claim redistribution rights, touch Treasury/cross-market assets, migrate NAS, or close the #71 seven-day gate.

Closes #85
