### PR TITLE
fix: prefer Sina for US coarse bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ MarketDataPort
         │
         ├─ Binance USD-M Futures adapter
         ├─ Binance Spot adapter
-        ├─ Yahoo adapter + free Sina daily fallback
+        ├─ Yahoo adapter + free Sina daily primary/fallback
         ├─ TuShare adapter
         ├─ Free Tencent A-share adapter + Tonghuashun fallback
         ├─ Tencent A-share index adapter
@@ -140,8 +140,8 @@ keeps `fallback_policy=none`.
 The local MVP does not require a current TuShare subscription or a paid U.S.
 market-data plan. Its runtime free profile keeps canonical instrument IDs but
 routes A-share stocks through `tencent_stock_free` (Tonghuashun is a bounded
-fallback for 1h/daily) and U.S. stocks through `yahoo_finance_free` (Sina is a
-daily fallback). Yahoo/Tencent/Sina responses are recorded as
+fallback for 1h/daily) and U.S. stocks through `yahoo_finance_free` (Sina is
+the daily/weekly primary, Yahoo is the explicit coarse fallback). Yahoo/Tencent/Sina responses are recorded as
 `entitlement_unverified` and therefore remain `partial` until the operator
 documents the personal-use terms; HTTP 200 is never promoted to commercial or
 `verified` status. The Tencent path is requested as qfq; a Tonghuashun fallback

--- a/src/kline/providers/free_us.py
+++ b/src/kline/providers/free_us.py
@@ -1,4 +1,4 @@
-"""Free personal-use US stock provider: Yahoo Chart with Sina daily fallback."""
+"""Free personal-use US stock provider: Sina coarse bars with Yahoo fallback."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ _SINA_DAILY_URL = (
 
 
 class USFreeProvider(USStockProvider):
-    """Use the existing Yahoo implementation and fall back to Sina daily K-lines."""
+    """Use Sina for daily/weekly bars and Yahoo for intraday/fallback data."""
 
     def __init__(
         self,
@@ -78,6 +78,7 @@ class USFreeProvider(USStockProvider):
         limit: int = 500,
     ) -> list[Candle]:
         self.last_attempts = []
+        self.last_raw_response = None
         if timeframe == Timeframe.HOUR_4:
             started_at = time.perf_counter()
             await self._pacer.wait()
@@ -174,6 +175,8 @@ class USFreeProvider(USStockProvider):
             # The inherited weekly transform calls back into this provider for
             # daily bars; that inner call owns the Yahoo/Sina attempt receipt.
             return await super().fetch(ticker, timeframe, start=start, end=end, limit=limit)
+        if timeframe == Timeframe.DAY:
+            return await self._fetch_daily_with_fallback(ticker, start=start, end=end, limit=limit)
         try:
             started_at = time.perf_counter()
             await self._pacer.wait()
@@ -200,38 +203,72 @@ class USFreeProvider(USStockProvider):
                 status="error",
                 error=str(yahoo_error),
             )
-            if timeframe != Timeframe.DAY:
-                raise
+            raise
+
+    async def _fetch_daily_with_fallback(
+        self, ticker: str, *, start: str | None, end: str | None, limit: int
+    ) -> list[Candle]:
+        """Prefer Sina for coarse bars; use Yahoo only when Sina fails."""
+
+        try:
+            started_at = time.perf_counter()
+            candles = await self._fetch_sina_daily(ticker, start=start, end=end, limit=limit)
+            self._record_attempt(
+                source="sina",
+                started_at=started_at,
+                status="success",
+                endpoint=_SINA_DAILY_URL,
+                http_status=(self.last_raw_response or {}).get("http_status"),
+                row_count=len(candles),
+            )
+            self.timeframe_transform = None
+            self.source_identity = {
+                "source_id": "yahoo_finance_free",
+                "provider_symbol": ticker.upper(),
+                "selected_source": "sina",
+                "fallback_from": None,
+                "adjustment_basis": "raw_unadjusted",
+            }
+            return candles
+        except ProviderError as sina_error:
+            self._record_attempt(
+                source="sina",
+                started_at=started_at,
+                status="error",
+                endpoint=_SINA_DAILY_URL,
+                error=str(sina_error),
+            )
             try:
                 started_at = time.perf_counter()
-                candles = await self._fetch_sina_daily(ticker, start=start, end=end, limit=limit)
+                await self._pacer.wait()
+                candles = await super().fetch(
+                    ticker, Timeframe.DAY, start=start, end=end, limit=limit
+                )
                 self._record_attempt(
-                    source="sina",
+                    source="yahoo",
                     started_at=started_at,
                     status="success",
-                    endpoint=_SINA_DAILY_URL,
-                    http_status=(self.last_raw_response or {}).get("http_status"),
                     row_count=len(candles),
                 )
-                self.timeframe_transform = None
                 self.source_identity = {
+                    **self.source_identity,
                     "source_id": "yahoo_finance_free",
                     "provider_symbol": ticker.upper(),
-                    "selected_source": "sina",
-                    "fallback_from": "yahoo",
+                    "selected_source": "yahoo",
+                    "fallback_from": "sina",
+                    "adjustment_basis": "raw_unadjusted",
                 }
                 return candles
-            except ProviderError as sina_error:
+            except ProviderError as yahoo_error:
                 self._record_attempt(
-                    source="sina",
+                    source="yahoo",
                     started_at=started_at,
                     status="error",
-                    endpoint=_SINA_DAILY_URL,
-                    error=str(sina_error),
+                    error=str(yahoo_error),
                 )
                 raise ProviderError(
-                    f"free US sources failed for {ticker}: Yahoo={yahoo_error}; Sina={sina_error}"
-                ) from sina_error
+                    f"free US sources failed for {ticker}: Sina={sina_error}; Yahoo={yahoo_error}"
+                ) from yahoo_error
 
     async def _fetch_sina_daily(
         self, ticker: str, *, start: str | None, end: str | None, limit: int

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -111,7 +111,7 @@ async def test_adapter_exposes_failed_provider_attempts() -> None:
 
 
 @pytest.mark.asyncio
-async def test_free_us_provider_uses_yahoo_and_declares_source(
+async def test_free_us_provider_uses_yahoo_for_intraday_and_declares_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def yahoo_success(
@@ -128,7 +128,7 @@ async def test_free_us_provider_uses_yahoo_and_declares_source(
 
     monkeypatch.setattr(USStockProvider, "fetch", yahoo_success)
     provider = USFreeProvider()
-    candles = await provider.fetch("AAPL", Timeframe.DAY, limit=10)
+    candles = await provider.fetch("AAPL", Timeframe.HOUR_1, limit=10)
     assert len(candles) == 1
     assert provider.source_identity["source_id"] == "yahoo_finance_free"
     assert provider.source_identity["selected_source"] == "yahoo"
@@ -144,20 +144,7 @@ async def test_free_us_provider_uses_yahoo_and_declares_source(
 
 
 @pytest.mark.asyncio
-async def test_free_us_provider_falls_back_to_sina_daily(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def unavailable(
-        _self,
-        _ticker: str,
-        _timeframe: Timeframe,
-        *,
-        start: str | None,
-        end: str | None,
-        limit: int,
-    ) -> list[Candle]:
-        del start, end, limit
-        raise ProviderError("Yahoo unavailable")
-
-    monkeypatch.setattr(USStockProvider, "fetch", unavailable)
+async def test_free_us_provider_prefers_sina_for_daily() -> None:
     payload = '[{"d":"2026-09-01","o":"100","h":"102","l":"99","c":"101","v":"10","a":"1000"}]'
     provider = USFreeProvider(
         transport=httpx.MockTransport(
@@ -168,8 +155,53 @@ async def test_free_us_provider_falls_back_to_sina_daily(monkeypatch: pytest.Mon
     assert len(candles) == 1
     assert candles[0].close == 101
     assert provider.source_identity["selected_source"] == "sina"
-    assert provider.source_identity["fallback_from"] == "yahoo"
-    assert [item["source"] for item in provider.last_attempts] == ["yahoo", "sina"]
+    assert provider.source_identity["fallback_from"] is None
+    assert [item["source"] for item in provider.last_attempts] == ["sina"]
+
+
+@pytest.mark.asyncio
+async def test_free_us_provider_falls_back_to_yahoo_when_sina_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def sina_unavailable(*_args, **_kwargs) -> list[Candle]:
+        raise ProviderError("Sina unavailable")
+
+    async def yahoo_success(
+        _self,
+        _ticker: str,
+        _timeframe: Timeframe,
+        *,
+        start: str | None,
+        end: str | None,
+        limit: int,
+    ) -> list[Candle]:
+        del start, end, limit
+        return [Candle(timestamp="2026-09-01", open=100, high=102, low=99, close=101, volume=10)]
+
+    monkeypatch.setattr(USFreeProvider, "_fetch_sina_daily", sina_unavailable)
+    monkeypatch.setattr(USStockProvider, "fetch", yahoo_success)
+    provider = USFreeProvider()
+    candles = await provider.fetch("AAPL", Timeframe.DAY, limit=10)
+    assert len(candles) == 1
+    assert provider.source_identity["selected_source"] == "yahoo"
+    assert provider.source_identity["fallback_from"] == "sina"
+    assert [item["source"] for item in provider.last_attempts] == ["sina", "yahoo"]
+
+
+@pytest.mark.asyncio
+async def test_free_us_provider_weekly_provenance_uses_sina_daily(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def sina_daily(*_args, **_kwargs) -> list[Candle]:
+        return [Candle(timestamp="2026-08-28", open=100, high=102, low=99, close=101, volume=10)]
+
+    monkeypatch.setattr(USFreeProvider, "_fetch_sina_daily", sina_daily)
+    provider = USFreeProvider()
+    candles = await provider.fetch("AAPL", Timeframe.WEEK, limit=10)
+    assert candles
+    assert provider.source_identity["selected_source"] == "sina"
+    assert provider.timeframe_transform is not None
+    assert provider.timeframe_transform.timeframe_origin == "aggregated"
 
 
 def test_free_source_manifests_are_registered_for_the_right_asset_classes() -> None:


### PR DESCRIPTION
## What
- use Sina as the primary free source for US daily bars
- derive weekly bars from that same daily path, preserving source provenance
- keep Yahoo for US intraday and as the explicit daily fallback when Sina fails
- update tests and README to reflect the rate-limit-safe routing

## Why
The real remaining-stock seed hit Yahoo `Too Many Requests` after roughly 80 US symbols. Sina returned daily histories successfully when probed directly, so coarse bars should avoid spending Yahoo's limited budget.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 283 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed
- direct Sina probes for MSFT/DHR/LMT/AAPL → HTTP 200 with non-empty histories

## Scope boundary
No paid source, licensing claim, public redistribution, NAS migration, Treasury/cross-market expansion, or trading action.

Closes #87
