### PR TITLE
fix: resume stock seed by phase

### DIFF
--- a/ops/mvp_stock_seed.py
+++ b/ops/mvp_stock_seed.py
@@ -75,10 +75,15 @@ def _seeded_keys(store: KlineStore) -> set[tuple[str, str, str, str, str]]:
     }
 
 
-def remaining_stock_ids(manifest: MvpManifest, store: KlineStore) -> dict[str, tuple[str, ...]]:
+def remaining_stock_ids(
+    manifest: MvpManifest,
+    store: KlineStore,
+    required_timeframes: Sequence[str] | None = None,
+) -> dict[str, tuple[str, ...]]:
     """Select stock identities missing at least one required closed-bar series."""
 
     seeded = _seeded_keys(store)
+    timeframes = tuple(required_timeframes or ("15m", "1h", "4h", "1d", "1w"))
     result: dict[str, tuple[str, ...]] = {}
     for universe, ids in stock_instrument_ids(manifest).items():
         remaining: list[str] = []
@@ -95,7 +100,7 @@ def remaining_stock_ids(manifest: MvpManifest, store: KlineStore) -> dict[str, t
                     manifest.version,
                 )
                 in seeded
-                for timeframe in item.required_timeframes
+                for timeframe in timeframes
             )
             if not complete:
                 remaining.append(instrument_id)
@@ -271,17 +276,26 @@ async def run_stock_seed_once(
     database, lock_file = validate_seed_target(db_path, lock_path)
     init(Settings(db_path=str(database), load_entrypoint_adapters=False))
     store = KlineStore(str(database))
-    remaining = (
-        stock_instrument_ids(manifest) if include_seeded else remaining_stock_ids(manifest, store)
-    )
-    selected = {universe: tuple(ids) for universe, ids in remaining.items()}
-    selected_total = sum(len(ids) for ids in selected.values())
     orchestrator = IngestionOrchestrator(store)
     reports: list[dict[str, Any]] = []
+    selected_initial = (
+        stock_instrument_ids(manifest) if include_seeded else remaining_stock_ids(manifest, store)
+    )
+    selected_by_phase: dict[str, dict[str, int]] = {}
     for phase_timeframes in phase_map[phase]:
         phase_name = "coarse" if phase_timeframes == COARSE_TIMEFRAMES else "intraday"
+        phase_selected = (
+            stock_instrument_ids(manifest)
+            if include_seeded
+            else remaining_stock_ids(manifest, store, required_timeframes=phase_timeframes)
+        )
+        selected_by_phase[phase_name] = {
+            universe: len(ids) for universe, ids in phase_selected.items()
+        }
         for universe in STOCK_UNIVERSES:
-            for batch_index, batch in enumerate(_batches(selected[universe], batch_size), start=1):
+            for batch_index, batch in enumerate(
+                _batches(phase_selected[universe], batch_size), start=1
+            ):
                 run_now = datetime.now(timezone.utc)
                 run_id = (
                     f"mvp-stocks-{run_now.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
@@ -341,8 +355,9 @@ async def run_stock_seed_once(
         else "partial",
         "manifest_version": manifest.version,
         "manifest_hash": manifest_digest(manifest),
-        "selected": {universe: len(ids) for universe, ids in selected.items()},
-        "selected_total": selected_total,
+        "selected_initial": {universe: len(ids) for universe, ids in selected_initial.items()},
+        "selected_by_phase": selected_by_phase,
+        "selected_total": sum(sum(counts.values()) for counts in selected_by_phase.values()),
         "remaining_after": {universe: len(ids) for universe, ids in final_remaining.items()},
         "batch_size": batch_size,
         "request_interval_seconds": request_interval_seconds,

--- a/tests/test_mvp_stock_seed.py
+++ b/tests/test_mvp_stock_seed.py
@@ -57,6 +57,33 @@ def test_remaining_stock_ids_skip_only_complete_free_series() -> None:
     assert "US.EQ.AAPL" not in remaining["us_stock"]
 
 
+def test_remaining_stock_ids_can_resume_each_phase_independently() -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    a_share = next(item for item in manifest.instruments if item.instrument_id == "CN.A.600519")
+    us_stock = next(item for item in manifest.instruments if item.instrument_id == "US.EQ.AAPL")
+
+    class FakeStore:
+        def mvp_latest_closed_bars(self) -> list[dict[str, str]]:
+            return [
+                {
+                    "source_id": item.source_id,
+                    "instrument_id": item.instrument_id,
+                    "timeframe": timeframe,
+                    "adjustment_basis": item.adjustment_basis,
+                    "manifest_version": manifest.version,
+                }
+                for item in (a_share, us_stock)
+                for timeframe in ("1d", "1w")
+            ]
+
+    coarse = remaining_stock_ids(manifest, FakeStore(), required_timeframes=("1d", "1w"))
+    intraday = remaining_stock_ids(manifest, FakeStore(), required_timeframes=("15m", "1h", "4h"))
+    assert len(coarse["a_share"]) == 99
+    assert len(coarse["us_stock"]) == 99
+    assert len(intraday["a_share"]) == 100
+    assert len(intraday["us_stock"]) == 100
+
+
 def test_batches_are_deterministic_and_rate_errors_are_classified() -> None:
     assert _batches(("a", "b", "c", "d", "e"), 2) == [
         ("a", "b"),


### PR DESCRIPTION
## What
- compute missing stock identities per requested timeframe phase
- recompute the intraday selection after coarse batches commit
- report initial and per-phase selection counts without refetching completed coarse bars

## Why
The first real coarse run correctly filled A-share daily/weekly data, but a retry would otherwise select every stock again because only intraday series remained missing.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 284 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed
- live coarse run recorded exact 97+97 initial selection and per-batch receipts

Closes #89
