### PR TITLE
fix: normalize dotted Yahoo tickers

### DIFF
--- a/src/kline/providers/free_us.py
+++ b/src/kline/providers/free_us.py
@@ -21,6 +21,12 @@ from kline.storage import CandleSeriesKey, MvpCandle
 _SINA_DAILY_URL = (
     "https://stock.finance.sina.com.cn/usstock/api/jsonp.php/var/US_MinKService.getDailyK"
 )
+_YAHOO_TICKER_ALIASES = {"BRK.B": "BRK-B"}
+
+
+def _yahoo_ticker(ticker: str) -> str:
+    normalized = ticker.upper().strip()
+    return _YAHOO_TICKER_ALIASES.get(normalized, normalized)
 
 
 class USFreeProvider(USStockProvider):
@@ -79,12 +85,14 @@ class USFreeProvider(USStockProvider):
     ) -> list[Candle]:
         self.last_attempts = []
         self.last_raw_response = None
+        requested_ticker = ticker.upper().strip()
+        yahoo_ticker = _yahoo_ticker(requested_ticker)
         if timeframe == Timeframe.HOUR_4:
             started_at = time.perf_counter()
             await self._pacer.wait()
             try:
                 base = await super().fetch(
-                    ticker,
+                    yahoo_ticker,
                     Timeframe.MIN_15,
                     start=start,
                     end=end,
@@ -156,6 +164,8 @@ class USFreeProvider(USStockProvider):
             self.source_identity = {
                 **self.source_identity,
                 "source_id": "yahoo_finance_free",
+                "requested_symbol": requested_ticker,
+                "provider_symbol": yahoo_ticker,
                 "selected_source": "yahoo",
             }
             selected = aggregate.candles[-limit:] if limit else aggregate.candles
@@ -180,7 +190,9 @@ class USFreeProvider(USStockProvider):
         try:
             started_at = time.perf_counter()
             await self._pacer.wait()
-            candles = await super().fetch(ticker, timeframe, start=start, end=end, limit=limit)
+            candles = await super().fetch(
+                yahoo_ticker, timeframe, start=start, end=end, limit=limit
+            )
             self._record_attempt(
                 source="yahoo",
                 started_at=started_at,
@@ -192,6 +204,8 @@ class USFreeProvider(USStockProvider):
             self.source_identity = {
                 **self.source_identity,
                 "source_id": "yahoo_finance_free",
+                "requested_symbol": requested_ticker,
+                "provider_symbol": yahoo_ticker,
                 "selected_source": selected,
                 "fallback_from": fallback_from,
             }
@@ -225,6 +239,7 @@ class USFreeProvider(USStockProvider):
             self.source_identity = {
                 "source_id": "yahoo_finance_free",
                 "provider_symbol": ticker.upper(),
+                "requested_symbol": ticker.upper(),
                 "selected_source": "sina",
                 "fallback_from": None,
                 "adjustment_basis": "raw_unadjusted",
@@ -242,7 +257,7 @@ class USFreeProvider(USStockProvider):
                 started_at = time.perf_counter()
                 await self._pacer.wait()
                 candles = await super().fetch(
-                    ticker, Timeframe.DAY, start=start, end=end, limit=limit
+                    _yahoo_ticker(ticker), Timeframe.DAY, start=start, end=end, limit=limit
                 )
                 self._record_attempt(
                     source="yahoo",
@@ -253,7 +268,8 @@ class USFreeProvider(USStockProvider):
                 self.source_identity = {
                     **self.source_identity,
                     "source_id": "yahoo_finance_free",
-                    "provider_symbol": ticker.upper(),
+                    "requested_symbol": ticker.upper(),
+                    "provider_symbol": _yahoo_ticker(ticker),
                     "selected_source": "yahoo",
                     "fallback_from": "sina",
                     "adjustment_basis": "raw_unadjusted",

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -17,7 +17,7 @@ from kline.providers.free_ashare import (
     parse_tencent_rows,
 )
 from kline.providers.free_common import requested_cutoff
-from kline.providers.free_us import USFreeProvider
+from kline.providers.free_us import USFreeProvider, _yahoo_ticker
 from kline.providers.us import USStockProvider
 
 
@@ -26,6 +26,11 @@ MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
 
 def test_derived_bar_cutoff_uses_request_end() -> None:
     assert requested_cutoff("2026-09-01T08:00:00Z").isoformat() == "2026-09-01T08:00:00+00:00"
+
+
+def test_yahoo_ticker_alias_preserves_dotted_canonical_symbol() -> None:
+    assert _yahoo_ticker("BRK.B") == "BRK-B"
+    assert _yahoo_ticker("AAPL") == "AAPL"
 
 
 def test_free_profile_routes_a_share_and_us_stock_without_changing_identity() -> None:
@@ -114,6 +119,8 @@ async def test_adapter_exposes_failed_provider_attempts() -> None:
 async def test_free_us_provider_uses_yahoo_for_intraday_and_declares_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    seen_tickers: list[str] = []
+
     async def yahoo_success(
         _self,
         _ticker: str,
@@ -123,15 +130,19 @@ async def test_free_us_provider_uses_yahoo_for_intraday_and_declares_source(
         end: str | None,
         limit: int,
     ) -> list[Candle]:
+        seen_tickers.append(_ticker)
         del start, end, limit
         return [Candle(timestamp="2026-09-01", open=100, high=102, low=99, close=101, volume=10)]
 
     monkeypatch.setattr(USStockProvider, "fetch", yahoo_success)
     provider = USFreeProvider()
-    candles = await provider.fetch("AAPL", Timeframe.HOUR_1, limit=10)
+    candles = await provider.fetch("BRK.B", Timeframe.HOUR_1, limit=10)
     assert len(candles) == 1
     assert provider.source_identity["source_id"] == "yahoo_finance_free"
     assert provider.source_identity["selected_source"] == "yahoo"
+    assert provider.source_identity["requested_symbol"] == "BRK.B"
+    assert provider.source_identity["provider_symbol"] == "BRK-B"
+    assert seen_tickers == ["BRK-B"]
     assert provider.last_attempts[0]["source"] == "yahoo"
     assert provider.last_attempts[0]["status"] == "success"
     assert provider.supported_timeframes() == [


### PR DESCRIPTION
## What
- map canonical `BRK.B` to Yahoo's `BRK-B` for US intraday requests
- preserve requested/display identity and record the provider alias in provenance
- add mocked alias and source-routing coverage

## Why
The full intraday seed left only BRK.B without 15m/1h/4h data; Yahoo rejected the dotted symbol while Sina already supplied its daily/weekly history.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 284 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed

Closes #91
