### PR TITLE
fix: stop retrying deterministic empty responses

### DIFF
--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -295,6 +295,7 @@ class IngestionOrchestrator:
                         "blocked_for_entitlement",
                         "market_closed",
                         "malformed_row",
+                        "empty_response",
                     }
                     or attempt >= plan.max_retries
                 ):

--- a/src/kline/providers/free_ashare.py
+++ b/src/kline/providers/free_ashare.py
@@ -224,6 +224,7 @@ class AShareFreeProvider:
         self.last_attempts = []
         self.timeframe_transform = None
         self.last_raw_response = None
+        self.source_identity = {}
         if timeframe == Timeframe.HOUR_4:
             base = await self.fetch(
                 ticker, Timeframe.MIN_15, start=start, end=end, limit=max(limit * 16, 320)
@@ -337,7 +338,9 @@ class AShareFreeProvider:
                 item.get(key), timezone_name="Asia/Shanghai", interval=interval
             )
             if not rows:
-                raise ProviderError("Tencent returned no minute rows")
+                error = ProviderError("Tencent returned no minute rows")
+                error.code = "empty_response"
+                raise error
             self.last_raw_response = {
                 "endpoint": _TENCENT_MINUTE_URL,
                 "http_status": response.status_code,
@@ -362,7 +365,9 @@ class AShareFreeProvider:
                 http_status=response.status_code if response is not None else None,
                 error=str(error),
             )
-            raise ProviderError(f"Tencent minute request failed for {code}: {error}") from error
+            wrapped = ProviderError(f"Tencent minute request failed for {code}: {error}")
+            wrapped.code = getattr(error, "code", "provider_error")
+            raise wrapped from error
 
     async def _tencent_daily(
         self, code: str, *, start: str | None, end: str | None, limit: int
@@ -385,7 +390,9 @@ class AShareFreeProvider:
                 item.get("qfqday") or item.get("day"), timezone_name="Asia/Shanghai"
             )
             if not rows:
-                raise ProviderError("Tencent returned no daily rows")
+                error = ProviderError("Tencent returned no daily rows")
+                error.code = "empty_response"
+                raise error
             self.last_raw_response = {
                 "endpoint": _TENCENT_DAILY_URL,
                 "http_status": response.status_code,
@@ -410,7 +417,9 @@ class AShareFreeProvider:
                 http_status=response.status_code if response is not None else None,
                 error=str(error),
             )
-            raise ProviderError(f"Tencent daily request failed for {code}: {error}") from error
+            wrapped = ProviderError(f"Tencent daily request failed for {code}: {error}")
+            wrapped.code = getattr(error, "code", "provider_error")
+            raise wrapped from error
 
     async def _with_fallback(
         self,
@@ -444,7 +453,9 @@ class AShareFreeProvider:
                 payload = json.loads(match.group(0)) if match else {}
                 rows = parse_10jqka_rows(payload.get("data", ""), timezone_name="Asia/Shanghai")
                 if not rows:
-                    raise ProviderError("Tonghuashun returned no rows")
+                    error = ProviderError("Tonghuashun returned no rows")
+                    error.code = "empty_response"
+                    raise error
                 self.last_raw_response = {
                     "endpoint": str(response.url),
                     "http_status": response.status_code,
@@ -476,9 +487,16 @@ class AShareFreeProvider:
                     http_status=response.status_code if response is not None else None,
                     error=str(fallback_error),
                 )
-                raise ProviderError(
+                error = ProviderError(
                     f"free A-share sources failed for {code}: Tencent={tencent_error}; Tonghuashun={fallback_error}"
-                ) from fallback_error
+                )
+                error.code = (
+                    "empty_response"
+                    if getattr(tencent_error, "code", "") == "empty_response"
+                    and getattr(fallback_error, "code", "") == "empty_response"
+                    else "provider_error"
+                )
+                raise error from fallback_error
 
     @staticmethod
     def _as_mvp(candles: list[Candle], ticker: str, timeframe: str) -> list[MvpCandle]:

--- a/src/kline/providers/free_us.py
+++ b/src/kline/providers/free_us.py
@@ -85,6 +85,8 @@ class USFreeProvider(USStockProvider):
     ) -> list[Candle]:
         self.last_attempts = []
         self.last_raw_response = None
+        self.source_identity = {}
+        self.timeframe_transform = None
         requested_ticker = ticker.upper().strip()
         yahoo_ticker = _yahoo_ticker(requested_ticker)
         if timeframe == Timeframe.HOUR_4:

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -101,6 +101,30 @@ async def test_free_a_share_provider_reports_both_sources_failed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_free_a_share_empty_response_is_terminal_and_resets_identity() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        code = "sh600519" if "sh600519" in str(request.url) else "sh601989"
+        rows = {
+            "sh600519": [["202609011500", "100", "101", "102", "99", "10"]],
+            "sh601989": [],
+        }[code]
+        return httpx.Response(
+            200,
+            request=request,
+            json={"data": {code: {"m15": rows}}},
+        )
+
+    provider = AShareFreeProvider(transport=httpx.MockTransport(handler))
+    assert await provider.fetch("600519", Timeframe.MIN_15, limit=10)
+    assert provider.source_identity["provider_symbol"] == "sh600519"
+    with pytest.raises(ProviderError) as error:
+        await provider.fetch("601989", Timeframe.MIN_15, limit=10)
+    assert error.value.code == "empty_response"
+    assert len(provider.last_attempts) == 1
+    assert provider.source_identity == {}
+
+
+@pytest.mark.asyncio
 async def test_adapter_exposes_failed_provider_attempts() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, request=request)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -395,6 +395,45 @@ async def test_run_once_persists_failed_attempts_through_provider_adapter(
 
 
 @pytest.mark.asyncio
+async def test_run_once_does_not_retry_terminal_empty_response(tmp_path: Path) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "terminal-empty.db"))
+
+    class EmptyAdapter:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.last_attempts: list[dict[str, object]] = []
+
+        async def fetch_candles_with_receipt(self, *_args, **_kwargs) -> FetchReceipt:
+            self.calls += 1
+            self.last_attempts = [
+                {"source": "fake", "status": "error", "http_status": 200, "latency_ms": 1.0}
+            ]
+            error = ProviderError("Tencent returned no minute rows")
+            error.code = "empty_response"
+            raise error
+
+    adapter = EmptyAdapter()
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-terminal-empty",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CN.A.600519",),
+            timeframes=("15m",),
+            max_retries=2,
+            retry_backoff_seconds=0.001,
+        )
+    )
+
+    assert receipt.status == "partial"
+    assert adapter.calls == 1
+    assert receipt.source_attempts[0]["provider_attempts"][0]["retry_number"] == 1
+
+
+@pytest.mark.asyncio
 async def test_intraday_source_failure_still_persists_daily_and_weekly_data(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What
- mark deterministic Tencent/Tonghuashun empty responses as terminal `empty_response`
- avoid retrying known-empty intraday series
- reset failed-request source identity so errors cannot inherit the previous symbol
- preserve failed provider attempts in the orchestrator and SQLite receipts

## Why
The final recovery run showed 601989 had no intraday rows; three retries per timeframe added ~39 seconds without changing the result and left stale provider identity in the receipt.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 286 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed
- targeted empty-response and source-identity regression tests pass

Closes #93
