### PR TITLE
fix: stop retrying fallback 404

### DIFF
--- a/src/kline/providers/free_ashare.py
+++ b/src/kline/providers/free_ashare.py
@@ -493,7 +493,10 @@ class AShareFreeProvider:
                 error.code = (
                     "empty_response"
                     if getattr(tencent_error, "code", "") == "empty_response"
-                    and getattr(fallback_error, "code", "") == "empty_response"
+                    and (
+                        getattr(fallback_error, "code", "") == "empty_response"
+                        or "404" in str(fallback_error)
+                    )
                     else "provider_error"
                 )
                 raise error from fallback_error

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -125,6 +125,20 @@ async def test_free_a_share_empty_response_is_terminal_and_resets_identity() -> 
 
 
 @pytest.mark.asyncio
+async def test_free_a_share_empty_plus_fallback_404_is_terminal() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "ifzq.gtimg.cn" in str(request.url):
+            return httpx.Response(200, request=request, json={"data": {"sh601989": {"m60": []}}})
+        return httpx.Response(404, request=request)
+
+    provider = AShareFreeProvider(transport=httpx.MockTransport(handler))
+    with pytest.raises(ProviderError) as error:
+        await provider.fetch("601989", Timeframe.HOUR_1, limit=10)
+    assert error.value.code == "empty_response"
+    assert len(provider.last_attempts) == 2
+
+
+@pytest.mark.asyncio
 async def test_adapter_exposes_failed_provider_attempts() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, request=request)


### PR DESCRIPTION
## What
- classify Tencent-empty plus Tonghuashun-404 combinations as terminal `empty_response`
- preserve both provider attempts without issuing redundant retries
- add regression coverage

## Why
The only remaining stock gap, 601989 intraday, has no Tencent minute rows and a deterministic Tonghuashun 404. Repeating the pair three times added latency without increasing coverage.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 286 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed

Closes #95
