### PR TITLE
fix: suppress stale watermark regressions

### DIFF
--- a/ops/mvp_stock_seed.py
+++ b/ops/mvp_stock_seed.py
@@ -132,6 +132,8 @@ def validate_seed_target(
 
 
 def _classify_attempt(attempt: Mapping[str, Any]) -> str | None:
+    if attempt.get("watermark_regression_suppressed"):
+        return "watermark_regression"
     status = str(attempt.get("status") or "").casefold()
     error = str(attempt.get("error") or "").casefold()
     http_status = attempt.get("http_status")

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -414,6 +414,7 @@ class IngestionOrchestrator:
         watermarks: list[WatermarkWrite] = []
         request_count = 0
         quality_counts = {"pass": 0, "partial": 0, "fail": 0}
+        watermark_regressions = 0
         last_request_at: float | None = None
 
         def receipt_attempts(value: Any) -> list[dict[str, Any]]:
@@ -644,14 +645,25 @@ class IngestionOrchestrator:
                     )
                     if quality.status == "pass" and mvp_rows:
                         candles.extend(mvp_rows)
-                        watermarks.append(
-                            WatermarkWrite(
-                                key=key,
-                                last_closed_timestamp=latest or end,
-                                cursor=None,
-                                run_id=plan.run_id,
+                        existing_watermark = self._storage.get_mvp_watermark(key)
+                        if (
+                            existing_watermark is not None
+                            and latest is not None
+                            and latest < existing_watermark.last_closed_timestamp
+                        ):
+                            watermark_regressions += 1
+                            source_attempts[-1]["watermark_regression_suppressed"] = True
+                            for provider_attempt in provider_attempts:
+                                provider_attempt["watermark_regression_suppressed"] = True
+                        else:
+                            watermarks.append(
+                                WatermarkWrite(
+                                    key=key,
+                                    last_closed_timestamp=latest or end,
+                                    cursor=None,
+                                    run_id=plan.run_id,
+                                )
                             )
-                        )
                     if fetch_receipt.timeframe_transform is not None and mvp_rows:
                         transform = fetch_receipt.timeframe_transform
                         if transform.timeframe_origin == "aggregated":
@@ -680,6 +692,10 @@ class IngestionOrchestrator:
                                 )
                             )
                     status = "ready" if quality.status == "pass" else quality.status
+                    cell_error = None if quality.status != "fail" else "quality gate failed"
+                    if source_attempts[-1].get("watermark_regression_suppressed"):
+                        status = "partial"
+                        cell_error = "watermark regression suppressed"
                     result = CellResult(
                         instrument.instrument_id,
                         instrument.display_symbol,
@@ -691,10 +707,10 @@ class IngestionOrchestrator:
                         end,
                         len(mvp_rows) if quality.status != "fail" else 0,
                         tuple(issue.status for issue in quality.issues),
-                        None if quality.status != "fail" else "quality gate failed",
+                        cell_error,
                     )
                     cells.append(result)
-                    if quality.status == "fail":
+                    if cell_error is not None:
                         blocked_cells.append(result.to_dict())
                 except EntitlementBlocked as exc:
                     latency_ms = elapsed_ms(fetch_started_at)
@@ -876,6 +892,7 @@ class IngestionOrchestrator:
                 "quality_receipts": len(qualities),
                 "transform_receipts": len(transforms),
                 "watermarks": len(watermarks),
+                "watermarks_skipped": watermark_regressions,
             },
             quality=quality_counts,
             blocked_cells=tuple(blocked_cells),

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -434,6 +434,75 @@ async def test_run_once_does_not_retry_terminal_empty_response(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_run_once_suppresses_watermark_regression_without_failing_transaction(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "watermark-regression.db"))
+    key = "CRYPTO.PERP.BTC"
+    watermark_key = CandleSeriesKey(
+        instrument_id=key,
+        display_symbol="BTC",
+        provider_symbol="BTC",
+        source_id="hyperliquid_perpetual_public",
+        asset_class="crypto",
+        timeframe="1d",
+        adjustment_basis="raw_unadjusted",
+        manifest_version=manifest.version,
+    )
+    first = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: FakeCryptoAdapter()
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-watermark-forward",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=(key,),
+            timeframes=("1d",),
+        )
+    )
+    assert first.status == "success"
+
+    class OlderAdapter:
+        async def fetch_candles_with_receipt(self, *_args, **_kwargs) -> FetchReceipt:
+            return FetchReceipt(
+                candles=[
+                    Candle(
+                        timestamp="2026-08-30T00:00:00+00:00",
+                        open=100,
+                        high=102,
+                        low=99,
+                        close=101,
+                        volume=10,
+                    )
+                ],
+                timeframe_transform=None,
+                source_identity={"provider_symbol": "BTC"},
+                raw_response={"row_count": 1},
+                attempts=({"source": "fake", "status": "success", "latency_ms": 1.0},),
+            )
+
+    second = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: OlderAdapter()
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-watermark-backward",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=(key,),
+            timeframes=("1d",),
+        )
+    )
+    assert second.status == "partial"
+    assert second.row_counts["watermarks"] == 0
+    assert second.row_counts["watermarks_skipped"] == 1
+    assert second.source_attempts[0]["watermark_regression_suppressed"] is True
+    assert (
+        store.get_mvp_watermark(watermark_key).last_closed_timestamp == "2026-08-31T00:00:00+00:00"
+    )
+
+
+@pytest.mark.asyncio
 async def test_intraday_source_failure_still_persists_daily_and_weekly_data(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What
- suppress older upstream watermark updates while retaining valid candle/receipt writes
- mark affected cells/runs partial and report `watermarks_skipped`
- add regression coverage for preserving the previous watermark

## Why
The full 100+100 worker refresh hit `watermark cannot move backwards` when Tencent returned a stale daily bar. The storage invariant is correct; the ingestion layer should isolate that stale response instead of crashing the whole worker.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 289 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed
- reproduction now commits a partial run without moving the watermark backwards

Closes #97
