### PR TITLE
fix: bound upstream cell fetches

### DIFF
--- a/ops/mvp_stock_seed.py
+++ b/ops/mvp_stock_seed.py
@@ -35,6 +35,7 @@ DEFAULT_BATCH_SIZE = 10
 DEFAULT_REQUEST_INTERVAL_SECONDS = 0.25
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
+DEFAULT_PROVIDER_TIMEOUT_SECONDS = 45.0
 SAFE_OBSERVER_DB = Path("/Users/wendy/datafeed-runtime-issue-71/data/kline.db")
 _RATE_MARKERS = ("429", "rate limit", "too many", "throttl", "quota")
 _FORBIDDEN_MARKERS = ("403", "forbidden", "blocked")
@@ -251,6 +252,7 @@ async def run_stock_seed_once(
     request_interval_seconds: float = DEFAULT_REQUEST_INTERVAL_SECONDS,
     max_retries: int = DEFAULT_MAX_RETRIES,
     retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
+    provider_timeout_seconds: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS,
     phase: str = "all",
     include_seeded: bool = False,
     lock_path: str | Path | None = None,
@@ -265,6 +267,8 @@ async def run_stock_seed_once(
         raise ValueError("max_retries must be non-negative")
     if retry_backoff_seconds < 0:
         raise ValueError("retry_backoff_seconds must be non-negative")
+    if provider_timeout_seconds <= 0:
+        raise ValueError("provider_timeout_seconds must be positive")
     phase_map = {
         "coarse": (COARSE_TIMEFRAMES,),
         "intraday": (INTRADAY_TIMEFRAMES,),
@@ -313,6 +317,7 @@ async def run_stock_seed_once(
                             timeframes=phase_timeframes,
                             max_retries=max_retries,
                             retry_backoff_seconds=retry_backoff_seconds,
+                            provider_timeout_seconds=provider_timeout_seconds,
                             request_interval_seconds=request_interval_seconds,
                             policy={
                                 "runner": "mvp_stock_seed",
@@ -322,6 +327,7 @@ async def run_stock_seed_once(
                                 "request_interval_seconds": request_interval_seconds,
                                 "max_retries": max_retries,
                                 "retry_backoff_seconds": retry_backoff_seconds,
+                                "provider_timeout_seconds": provider_timeout_seconds,
                             },
                         )
                     )
@@ -365,6 +371,7 @@ async def run_stock_seed_once(
         "request_interval_seconds": request_interval_seconds,
         "max_retries": max_retries,
         "retry_backoff_seconds": retry_backoff_seconds,
+        "provider_timeout_seconds": provider_timeout_seconds,
         "phase": phase,
         "batch_count": len(reports),
         "batch_status_counts": dict(status_counts),
@@ -388,6 +395,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--request-interval", type=float, default=DEFAULT_REQUEST_INTERVAL_SECONDS)
     parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
     parser.add_argument("--retry-backoff", type=float, default=DEFAULT_RETRY_BACKOFF_SECONDS)
+    parser.add_argument("--provider-timeout", type=float, default=DEFAULT_PROVIDER_TIMEOUT_SECONDS)
     parser.add_argument("--phase", choices=("coarse", "intraday", "all"), default="all")
     parser.add_argument("--include-seeded", action="store_true")
     parser.add_argument("--receipt", default=None)
@@ -412,6 +420,7 @@ async def _run_forever(args: argparse.Namespace) -> None:
             request_interval_seconds=args.request_interval,
             max_retries=args.max_retries,
             retry_backoff_seconds=args.retry_backoff,
+            provider_timeout_seconds=args.provider_timeout,
             phase=args.phase,
             include_seeded=args.include_seeded,
             lock_path=args.lock,
@@ -452,6 +461,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             request_interval_seconds=args.request_interval,
             max_retries=args.max_retries,
             retry_backoff_seconds=args.retry_backoff,
+            provider_timeout_seconds=args.provider_timeout,
             phase=args.phase,
             include_seeded=args.include_seeded,
             lock_path=args.lock,

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -55,6 +55,7 @@ class IngestionPlan:
     instrument_ids: Sequence[str] | None = None
     timeframes: Sequence[str] | None = None
     request_interval_seconds: float = 0.0
+    provider_timeout_seconds: float = 60.0
 
 
 @dataclass(frozen=True)
@@ -245,7 +246,9 @@ class IngestionOrchestrator:
                         limit=limit,
                     )
                     if inspect.isawaitable(result):
-                        result = await result
+                        result = await asyncio.wait_for(
+                            result, timeout=plan.provider_timeout_seconds
+                        )
                     if isinstance(result, FetchReceipt):
                         append_attempts(result.attempts or tuple(adapter_attempts()), attempt + 1)
                         return FetchReceipt(
@@ -273,7 +276,11 @@ class IngestionOrchestrator:
                     end=end,
                     limit=limit,
                 )
-                candles = await fetch if inspect.isawaitable(fetch) else fetch
+                candles = (
+                    await asyncio.wait_for(fetch, timeout=plan.provider_timeout_seconds)
+                    if inspect.isawaitable(fetch)
+                    else fetch
+                )
                 append_attempts(adapter_attempts(), attempt + 1)
                 return FetchReceipt(
                     candles=list(candles),
@@ -286,6 +293,13 @@ class IngestionOrchestrator:
                 append_attempts(adapter_attempts(), attempt + 1)
                 attach_attempts(exc)
                 raise
+            except asyncio.TimeoutError as exc:
+                timeout_error = ProviderError(
+                    f"provider fetch timed out after {plan.provider_timeout_seconds:g}s"
+                )
+                timeout_error.code = "timeout"
+                attach_attempts(timeout_error)
+                raise timeout_error from exc
             except ProviderError as exc:
                 last_error = exc
                 append_attempts(adapter_attempts(), attempt + 1)
@@ -296,6 +310,7 @@ class IngestionOrchestrator:
                         "market_closed",
                         "malformed_row",
                         "empty_response",
+                        "timeout",
                     }
                     or attempt >= plan.max_retries
                 ):
@@ -396,6 +411,8 @@ class IngestionOrchestrator:
             raise IngestionError(f"ingestion timeframes must be drawn from {ALLOWED_TIMEFRAMES}")
         if plan.request_interval_seconds < 0:
             raise IngestionError("request_interval_seconds must be non-negative")
+        if plan.provider_timeout_seconds <= 0:
+            raise IngestionError("provider_timeout_seconds must be positive")
         selected_ids = set(plan.instrument_ids) if plan.instrument_ids is not None else None
         if selected_ids is not None:
             known_ids = {instrument.instrument_id for instrument in manifest.instruments}

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -500,6 +501,40 @@ async def test_run_once_suppresses_watermark_regression_without_failing_transact
     assert (
         store.get_mvp_watermark(watermark_key).last_closed_timestamp == "2026-08-31T00:00:00+00:00"
     )
+
+
+@pytest.mark.asyncio
+async def test_run_once_bounds_hanging_provider_cell(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "provider-timeout.db"))
+
+    class HangingAdapter:
+        calls = 0
+
+        async def fetch_candles_with_receipt(self, *_args, **_kwargs) -> FetchReceipt:
+            self.calls += 1
+            await asyncio.sleep(10)
+            raise AssertionError("timeout should cancel the provider call")
+
+    adapter = HangingAdapter()
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: adapter
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-provider-timeout",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d",),
+            max_retries=2,
+            provider_timeout_seconds=0.01,
+        )
+    )
+
+    assert receipt.status == "partial"
+    assert adapter.calls == 1
+    assert receipt.source_attempts[0]["status"] == "timeout"
+    assert receipt.source_attempts[0]["latency_ms"] >= 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
- add a configurable hard timeout around each provider/fallback cell fetch
- classify timeout receipts as terminal for the current cell so a stalled source cannot hold the seed lock indefinitely
- expose the timeout in stock-seed policy/CLI and add a hanging-provider regression test

## Why
A Tencent WAF/Tonghuashun TLS connection held the full worker on one cell for several minutes. The worker must continue safely after a bounded timeout instead of entering KeepAlive restart loops.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 290 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed
- existing 100+100 data remains intact; no destructive DB operation

Closes #99
