### PR TITLE
fix: cap free provider timeouts

### DIFF
--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -38,6 +38,7 @@ _settings: Settings | None = None
 _providers: dict[AssetClass, Provider] = {}
 _live_providers: dict[str, Provider] = {}
 _adapters: dict[str, MarketDataPort] = {}
+_FREE_PROVIDER_TIMEOUT_SECONDS = 15.0
 
 
 def init(settings: Settings | None = None) -> None:
@@ -69,7 +70,7 @@ def init(settings: Settings | None = None) -> None:
     register_adapter(
         ProviderBackedMarketDataAdapter(
             source_manifest("yahoo_finance_free", AssetClass.US_STOCK),
-            USFreeProvider(timeout=s.request_timeout),
+            USFreeProvider(timeout=min(s.request_timeout, _FREE_PROVIDER_TIMEOUT_SECONDS)),
         )
     )
     register_adapter(
@@ -186,7 +187,7 @@ def init(settings: Settings | None = None) -> None:
     register_adapter(
         ProviderBackedMarketDataAdapter(
             source_manifest("tencent_stock_free", AssetClass.A_SHARE),
-            AShareFreeProvider(timeout=s.request_timeout),
+            AShareFreeProvider(timeout=min(s.request_timeout, _FREE_PROVIDER_TIMEOUT_SECONDS)),
         )
     )
 

--- a/tests/test_free_sources.py
+++ b/tests/test_free_sources.py
@@ -269,14 +269,21 @@ def test_registry_exposes_free_adapters_without_tokens(tmp_path: Path) -> None:
     from kline.config import Settings
     from kline.registry import get_adapter_for_source, init
 
-    init(Settings(db_path=str(tmp_path / "free-adapters.db"), load_entrypoint_adapters=False))
-    assert get_adapter_for_source("tencent_stock_free", AssetClass.A_SHARE).supported_timeframes()
-    assert get_adapter_for_source(
-        "yahoo_finance_free", AssetClass.US_STOCK
-    ).supported_timeframes() == [
+    init(
+        Settings(
+            db_path=str(tmp_path / "free-adapters.db"),
+            load_entrypoint_adapters=False,
+            request_timeout=60,
+        )
+    )
+    ashare_adapter = get_adapter_for_source("tencent_stock_free", AssetClass.A_SHARE)
+    us_adapter = get_adapter_for_source("yahoo_finance_free", AssetClass.US_STOCK)
+    assert ashare_adapter.supported_timeframes()
+    assert us_adapter.supported_timeframes() == [
         Timeframe.MIN_15,
         Timeframe.HOUR_1,
         Timeframe.HOUR_4,
         Timeframe.DAY,
         Timeframe.WEEK,
     ]
+    assert ashare_adapter._provider._timeout == us_adapter._provider._timeout == 15.0


### PR DESCRIPTION
## What
- cap registry-created free Tencent/Sina/Yahoo provider HTTP timeouts at 15 seconds
- keep the cell-level hard timeout and explicit timeout receipts
- add a registry timeout-cap regression test

## Why
A WAF/TLS stall held the full 100+100 worker for many minutes despite the cell boundary. Free-source requests should fail fast enough for the batch to continue.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 290 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed

Closes #101
