### PR TITLE
fix: make Yahoo repair cancellable

### DIFF
--- a/src/kline/providers/us.py
+++ b/src/kline/providers/us.py
@@ -279,7 +279,9 @@ class USStockProvider:
             repair_kwargs = dict(kwargs)
             repair_kwargs["repair"] = True
             try:
-                repaired_df = yf.Ticker(ticker.upper()).history(**repair_kwargs)
+                repaired_df = await asyncio.to_thread(
+                    yf.Ticker(ticker.upper()).history, **repair_kwargs
+                )
             except Exception as e:
                 self.last_raw_response["error"] = str(e)
                 raise ProviderError(

--- a/tests/test_timeframe_contract.py
+++ b/tests/test_timeframe_contract.py
@@ -107,6 +107,23 @@ async def test_yahoo_sync_history_does_not_block_cell_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_yahoo_sync_repair_does_not_block_cell_timeout(monkeypatch):
+    class RepairHangingTicker:
+        def history(self, **kwargs):
+            if kwargs.get("repair"):
+                time.sleep(0.2)
+                return _repaired_daily_frame()
+            return _broken_daily_frame()
+
+    monkeypatch.setattr("kline.providers.us.yf.Ticker", lambda _ticker: RepairHangingTicker())
+    provider = USStockProvider()
+    started = time.perf_counter()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(provider.fetch("AAPL", Timeframe.DAY), timeout=0.02)
+    assert time.perf_counter() - started < 0.1
+
+
+@pytest.mark.asyncio
 async def test_yahoo_weekly_excludes_current_partial_week(monkeypatch):
     rows = [
         ("2026-08-10", 100, 105, 99, 104),


### PR DESCRIPTION
## What
- run yfinance's repair history call in a worker thread
- ensure the same cell timeout applies to both initial and repair fetches
- add a hanging-repair regression test

## Why
Some full-refresh symbols entered yfinance repair after malformed OHLC rows; the synchronous repair call could still block the event loop after the initial Yahoo fetch was made cancellable.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 292 passed
- changed-file Ruff checks → passed
- `git diff --check` → passed

Closes #105
