### PR TITLE
Fix Yahoo intraday ISO start/end parsing

### DIFF
--- a/src/kline/providers/us.py
+++ b/src/kline/providers/us.py
@@ -60,6 +60,27 @@ def _index_text(index: Any, timeframe: Timeframe) -> str:
     return str(index)
 
 
+def _yahoo_history_argument(value: str | None) -> str | datetime | None:
+    """Convert orchestrator ISO timestamps to a yfinance-compatible value.
+
+    yfinance 1.2 parses string arguments with the narrow ``YYYY-MM-DD``
+    format, while the ingestion contract passes timezone-aware ISO timestamps
+    for intraday windows. Passing the latter through as strings raises
+    ``unconverted data remains: T...`` before Yahoo is contacted. Keep
+    date-only strings unchanged for backwards-compatible request receipts and
+    convert timestamp strings to aware ``datetime`` values for yfinance.
+    """
+
+    if value is None or len(value) == 10:
+        return value
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        # Let yfinance produce its normal validation error for malformed
+        # caller input rather than silently changing the requested window.
+        return value
+
+
 def _invalid_indices(frame: Any) -> list[Any]:
     """Return rows that cannot be represented as a finite OHLCV candle."""
 
@@ -227,7 +248,7 @@ class USStockProvider:
                 "auto_adjust": False,
             }
             if start and end:
-                kwargs["start"] = start
+                kwargs["start"] = _yahoo_history_argument(start)
                 # Give Yahoo a little context beyond the requested cutoff.
                 # Its repair path needs the next session to reconstruct a
                 # live row; the public response is still clipped to `end`

--- a/tests/test_timeframe_contract.py
+++ b/tests/test_timeframe_contract.py
@@ -302,6 +302,36 @@ async def test_yahoo_explicit_range_does_not_add_default_period(monkeypatch):
     assert provider.last_raw_response["request_params"]["repair_context_end"] == "2026-08-26"
 
 
+@pytest.mark.asyncio
+async def test_yahoo_intraday_accepts_timezone_aware_iso_window(monkeypatch):
+    calls: dict = {}
+
+    class FakeTicker:
+        def history(self, **kwargs):
+            calls.update(kwargs)
+            return _daily_frame(
+                [("2026-08-31T16:00:00", 100, 105, 99, 104)],
+            )
+
+    monkeypatch.setattr("kline.providers.us.yf.Ticker", lambda ticker: FakeTicker())
+    provider = USStockProvider()
+
+    candles = await provider.fetch(
+        "AAPL",
+        Timeframe.HOUR_1,
+        start="2026-08-31T16:00:00+00:00",
+        end="2026-09-01T00:00:00+00:00",
+        limit=10,
+    )
+
+    assert len(candles) == 1
+    assert calls["start"] == datetime.fromisoformat("2026-08-31T16:00:00+00:00")
+    assert calls["start"].tzinfo is not None
+    assert calls["end"] == "2026-09-08"
+    assert provider.last_raw_response is not None
+    assert provider.last_raw_response["request_params"]["start"] == "2026-08-31T16:00:00+00:00"
+
+
 def test_yahoo_symbol_timeframe_allowlist_is_explicit():
     index = source_manifest("yahoo_finance_index", AssetClass.INDEX)
     etf = source_manifest("yahoo_finance_etf", AssetClass.ETF)


### PR DESCRIPTION
## What
- normalize timezone-aware ISO `start` values to yfinance-compatible datetime arguments
- preserve original request receipt values and date-only behavior
- add a regression test for the orchestrator intraday window

## Why
The stock seed orchestrator passes ISO timestamps such as `2026-08-31T16:00:00+00:00`. yfinance 1.2 parses string windows as `YYYY-MM-DD` only, so 20 US intraday cells were marked failed with `unconverted data remains: T...` before contacting Yahoo.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_timeframe_contract.py tests/test_free_sources.py tests/test_mvp_stock_seed.py tests/test_ingestion.py` (53 passed)
- live AAPL Yahoo free-source probe: 7 one-hour candles returned, no parse error
- `git diff --check`

Closes #107