### PR TITLE
Fix stock worker's 4h anchor and A-share opening buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,24 @@ PYTHONPATH=src python3 -m ops.mvp_reliability --once \
   --manifest configs/mvp_manifest.json --db data/kline.db --interval 14400
 ```
 
+The isolated 100+100 stock observer runs the full profile with a start-anchored
+four-hour deadline. Its next cycle is due four hours after the previous cycle
+started, so a long fetch does not add scheduler drift. The A-share opening
+buffer is configurable and defaults to 10 minutes:
+
+```bash
+PYTHONPATH=src python3 -m ops.mvp_stock_seed \
+  --manifest configs/mvp_manifest.json --db /Users/wendy/datafeed-runtime-issue-71/data/kline.db \
+  --lock /Users/wendy/datafeed-runtime-issue-71/data/mvp-worker.lock \
+  --interval 14400 --a-share-market-open-buffer-minutes 10 \
+  --phase all --include-seeded --forever
+```
+
+Only CN A-share 15m/1h quality checks use this opening buffer. Forming bars
+remain excluded from storage and produce `partial`, not `failed`, during the
+buffer; after the buffer the original fail-closed rule applies. Continuous
+24x7 calendars are unchanged.
+
 The command writes only source-bound OHLCV and receipts; it does not emit
 MACD/RSI columns, synthesize missing candles, switch to a paid source, or
 expose data publicly.

--- a/ops/mvp_stock_seed.py
+++ b/ops/mvp_stock_seed.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 import re
@@ -36,6 +36,7 @@ DEFAULT_REQUEST_INTERVAL_SECONDS = 0.25
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 45.0
+DEFAULT_A_SHARE_MARKET_OPEN_BUFFER_MINUTES = 10
 SAFE_OBSERVER_DB = Path("/Users/wendy/datafeed-runtime-issue-71/data/kline.db")
 _RATE_MARKERS = ("429", "rate limit", "too many", "throttl", "quota")
 _FORBIDDEN_MARKERS = ("403", "forbidden", "blocked")
@@ -49,6 +50,21 @@ def _iso(value: datetime) -> str:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def stock_cycle_wait_seconds(
+    *, cycle_started: datetime, now: datetime, interval_seconds: int
+) -> float:
+    """Return the remaining delay to a start-anchored stock-worker deadline."""
+
+    if interval_seconds <= 0:
+        raise ValueError("interval_seconds must be positive")
+    if cycle_started.tzinfo is None:
+        cycle_started = cycle_started.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    due = cycle_started.astimezone(timezone.utc) + timedelta(seconds=interval_seconds)
+    return max(0.0, (due - now.astimezone(timezone.utc)).total_seconds())
 
 
 def stock_instrument_ids(manifest: MvpManifest) -> dict[str, tuple[str, ...]]:
@@ -253,6 +269,7 @@ async def run_stock_seed_once(
     max_retries: int = DEFAULT_MAX_RETRIES,
     retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
     provider_timeout_seconds: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS,
+    a_share_market_open_buffer_minutes: int = DEFAULT_A_SHARE_MARKET_OPEN_BUFFER_MINUTES,
     phase: str = "all",
     include_seeded: bool = False,
     lock_path: str | Path | None = None,
@@ -269,6 +286,8 @@ async def run_stock_seed_once(
         raise ValueError("retry_backoff_seconds must be non-negative")
     if provider_timeout_seconds <= 0:
         raise ValueError("provider_timeout_seconds must be positive")
+    if not 0 <= a_share_market_open_buffer_minutes <= 60:
+        raise ValueError("a_share_market_open_buffer_minutes must be between 0 and 60")
     phase_map = {
         "coarse": (COARSE_TIMEFRAMES,),
         "intraday": (INTRADAY_TIMEFRAMES,),
@@ -319,6 +338,7 @@ async def run_stock_seed_once(
                             retry_backoff_seconds=retry_backoff_seconds,
                             provider_timeout_seconds=provider_timeout_seconds,
                             request_interval_seconds=request_interval_seconds,
+                            market_open_buffer_minutes=a_share_market_open_buffer_minutes,
                             policy={
                                 "runner": "mvp_stock_seed",
                                 "phase": phase_name,
@@ -328,6 +348,9 @@ async def run_stock_seed_once(
                                 "max_retries": max_retries,
                                 "retry_backoff_seconds": retry_backoff_seconds,
                                 "provider_timeout_seconds": provider_timeout_seconds,
+                                "a_share_market_open_buffer_minutes": (
+                                    a_share_market_open_buffer_minutes
+                                ),
                             },
                         )
                     )
@@ -372,6 +395,7 @@ async def run_stock_seed_once(
         "max_retries": max_retries,
         "retry_backoff_seconds": retry_backoff_seconds,
         "provider_timeout_seconds": provider_timeout_seconds,
+        "a_share_market_open_buffer_minutes": a_share_market_open_buffer_minutes,
         "phase": phase,
         "batch_count": len(reports),
         "batch_status_counts": dict(status_counts),
@@ -396,6 +420,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
     parser.add_argument("--retry-backoff", type=float, default=DEFAULT_RETRY_BACKOFF_SECONDS)
     parser.add_argument("--provider-timeout", type=float, default=DEFAULT_PROVIDER_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--a-share-market-open-buffer-minutes",
+        type=int,
+        default=DEFAULT_A_SHARE_MARKET_OPEN_BUFFER_MINUTES,
+    )
     parser.add_argument("--phase", choices=("coarse", "intraday", "all"), default="all")
     parser.add_argument("--include-seeded", action="store_true")
     parser.add_argument("--receipt", default=None)
@@ -413,6 +442,7 @@ async def _run_forever(args: argparse.Namespace) -> None:
         except NotImplementedError:  # pragma: no cover - platform fallback
             signal.signal(signum, lambda *_: stop_event.set())
     while not stop_event.is_set():
+        cycle_started = datetime.now(timezone.utc)
         report = await run_stock_seed_once(
             db_path=args.db,
             manifest_path=args.manifest,
@@ -421,6 +451,7 @@ async def _run_forever(args: argparse.Namespace) -> None:
             max_retries=args.max_retries,
             retry_backoff_seconds=args.retry_backoff,
             provider_timeout_seconds=args.provider_timeout,
+            a_share_market_open_buffer_minutes=args.a_share_market_open_buffer_minutes,
             phase=args.phase,
             include_seeded=args.include_seeded,
             lock_path=args.lock,
@@ -440,8 +471,15 @@ async def _run_forever(args: argparse.Namespace) -> None:
             ),
             flush=True,
         )
+        wait_seconds = stock_cycle_wait_seconds(
+            cycle_started=cycle_started,
+            now=datetime.now(timezone.utc),
+            interval_seconds=args.interval,
+        )
+        if wait_seconds <= 0:
+            continue
         try:
-            await asyncio.wait_for(stop_event.wait(), timeout=args.interval)
+            await asyncio.wait_for(stop_event.wait(), timeout=wait_seconds)
         except TimeoutError:
             continue
 
@@ -462,6 +500,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             max_retries=args.max_retries,
             retry_backoff_seconds=args.retry_backoff,
             provider_timeout_seconds=args.provider_timeout,
+            a_share_market_open_buffer_minutes=args.a_share_market_open_buffer_minutes,
             phase=args.phase,
             include_seeded=args.include_seeded,
             lock_path=args.lock,

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -466,14 +466,27 @@ def _cell(
 def _worker_payload(
     storage: StoragePort, *, now: datetime, interval_seconds: int
 ) -> dict[str, Any]:
-    runs = storage.latest_mvp_runs(limit=6) if hasattr(storage, "latest_mvp_runs") else []
+    runs = storage.latest_mvp_runs(limit=64) if hasattr(storage, "latest_mvp_runs") else []
     latest = (
         runs[0]
         if runs
         else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
     )
-    last_activity = (latest.get("completed_at") or latest.get("started_at")) if latest else None
-    parsed_activity = parse_utc_timestamp(last_activity)
+    latest_run_id = str(latest.get("run_id") or "") if latest else ""
+    cycle_start = (
+        next(
+            (
+                run.get("started_at")
+                for run in runs
+                if str(run.get("run_id") or "").endswith("-coarse-a_share-001")
+            ),
+            None,
+        )
+        if latest_run_id.startswith("mvp-stocks-")
+        else None
+    )
+    schedule_anchor = cycle_start or (latest.get("started_at") if latest else None)
+    parsed_activity = parse_utc_timestamp(schedule_anchor)
     next_due = None
     if parsed_activity is not None:
         due = parsed_activity + timedelta(seconds=interval_seconds)

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -466,23 +466,15 @@ def _cell(
 def _worker_payload(
     storage: StoragePort, *, now: datetime, interval_seconds: int
 ) -> dict[str, Any]:
-    runs = storage.latest_mvp_runs(limit=64) if hasattr(storage, "latest_mvp_runs") else []
+    runs = storage.latest_mvp_runs(limit=6) if hasattr(storage, "latest_mvp_runs") else []
     latest = (
         runs[0]
         if runs
         else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
     )
-    latest_run_id = str(latest.get("run_id") or "") if latest else ""
     cycle_start = (
-        next(
-            (
-                run.get("started_at")
-                for run in runs
-                if str(run.get("run_id") or "").endswith("-coarse-a_share-001")
-            ),
-            None,
-        )
-        if latest_run_id.startswith("mvp-stocks-")
+        storage.latest_mvp_stock_cycle_start()
+        if hasattr(storage, "latest_mvp_stock_cycle_start")
         else None
     )
     schedule_anchor = cycle_start or (latest.get("started_at") if latest else None)

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -64,6 +64,7 @@ class IngestionPlan:
     timeframes: Sequence[str] | None = None
     request_interval_seconds: float = 0.0
     provider_timeout_seconds: float = 60.0
+    market_open_buffer_minutes: int = 0
 
 
 @dataclass(frozen=True)
@@ -644,6 +645,7 @@ class IngestionOrchestrator:
                         timeframe=timeframe,
                         calendar_id=instrument.calendar_id,
                         cutoff=now,
+                        market_open_buffer_minutes=plan.market_open_buffer_minutes,
                     )
                     quality_counts[quality.status] = quality_counts.get(quality.status, 0) + 1
                     quality_receipt = self._quality_receipt(plan.run_id, mvp_rows, quality)

--- a/src/kline/market_calendar.py
+++ b/src/kline/market_calendar.py
@@ -753,6 +753,9 @@ def assess_quality(
             <= local_cutoff
             < first_open + timedelta(minutes=market_open_buffer_minutes)
         )
+    # The opening buffer softens only the receipt classification. Ingestion
+    # still promotes candles/watermarks exclusively for ``pass``, so a
+    # ``partial`` forming result remains fail-closed for persistence.
     if not market_open_buffer_active:
         blocking.add("forming")
     status = (

--- a/src/kline/market_calendar.py
+++ b/src/kline/market_calendar.py
@@ -644,11 +644,14 @@ def assess_quality(
     holidays: Iterable[date] = (),
     suspension_dates: Iterable[date] = (),
     stale_after: timedelta | None = None,
+    market_open_buffer_minutes: int = 0,
 ) -> QualityResult:
     """Classify closed/forming/holiday/suspension/gap/duplicate/stale input."""
 
     if timeframe not in _ALLOWED_TIMEFRAMES:
         raise CalendarError(f"unsupported quality timeframe: {timeframe}")
+    if market_open_buffer_minutes < 0:
+        raise CalendarError("market_open_buffer_minutes must be non-negative")
     spec = calendar_spec(calendar_id)
     cutoff_utc = _parse_cutoff(cutoff)
     issues = _sequence_issues(candles)
@@ -733,7 +736,25 @@ def assess_quality(
                 "stale", "latest closed candle exceeded freshness window", latest_end.isoformat()
             )
         )
-    blocking = {"malformed", "duplicate", "out_of_order", "mixed_source", "forming", "missing"}
+    blocking = {"malformed", "duplicate", "out_of_order", "mixed_source", "missing"}
+    local_cutoff = cutoff_utc.astimezone(spec.zone)
+    market_open_buffer_active = False
+    if (
+        market_open_buffer_minutes > 0
+        and spec.calendar_id == "cn_a"
+        and timeframe in {"15m", "1h"}
+        and is_trading_session(spec.calendar_id, local_cutoff.date())
+    ):
+        first_open = datetime.combine(
+            local_cutoff.date(), spec.sessions[0].open_time, tzinfo=spec.zone
+        )
+        market_open_buffer_active = (
+            first_open
+            <= local_cutoff
+            < first_open + timedelta(minutes=market_open_buffer_minutes)
+        )
+    if not market_open_buffer_active:
+        blocking.add("forming")
     status = (
         "fail"
         if any(issue.status in blocking for issue in issues)

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -1140,6 +1140,28 @@ class KlineStore:
             "error": row.error,
         }
 
+    def latest_mvp_stock_cycle_start(self) -> str | None:
+        """Return the first-batch start for the newest stock worker cycle."""
+
+        with self._session_factory() as session:
+            latest = session.execute(
+                select(MvpRunRow)
+                .order_by(MvpRunRow.started_at.desc(), MvpRunRow.run_id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+            if latest is None or not latest.run_id.startswith("mvp-stocks-"):
+                return None
+            anchor = session.execute(
+                select(MvpRunRow)
+                .where(
+                    MvpRunRow.run_id.like("mvp-stocks-%-coarse-a_share-001"),
+                    MvpRunRow.started_at <= latest.started_at,
+                )
+                .order_by(MvpRunRow.started_at.desc(), MvpRunRow.run_id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+        return anchor.started_at if anchor is not None else None
+
     def latest_mvp_runs(self, *, limit: int = 6) -> list[dict[str, Any]]:
         """Return recent MVP run receipts for the health matrix timeline."""
 

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -243,6 +243,75 @@ def test_full_scope_preserves_manifest_cartesian_product_and_coverage_invariants
         )
 
 
+def test_worker_next_due_uses_the_stock_cycle_first_batch_start(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-cycle-anchor.db"))
+    for run_id, started_at, completed_at in (
+        (
+            "mvp-stocks-20260902T013000Z-coarse-a_share-001",
+            "2026-09-02T01:30:00+00:00",
+            "2026-09-02T01:31:00+00:00",
+        ),
+        (
+            "mvp-stocks-20260902T015900Z-intraday-us_stock-010",
+            "2026-09-02T01:59:00+00:00",
+            "2026-09-02T02:00:00+00:00",
+        ),
+    ):
+        store.commit_mvp_run(
+            MvpRunWrite(
+                run_id=run_id,
+                manifest_version=manifest.version,
+                manifest_hash=manifest_digest(manifest),
+                started_at=started_at,
+                completed_at=completed_at,
+                window_start=None,
+                window_end=completed_at,
+                policy={"runner": "mvp_stock_seed"},
+            )
+        )
+
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 2, 2, 5, tzinfo=timezone.utc),
+    )
+
+    assert snapshot["worker"]["next_due_at"] == "2026-09-02T05:30:00+00:00"
+
+
+def test_worker_next_due_keeps_non_stock_run_anchor(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-non-stock-anchor.db"))
+    for run_id, started_at in (
+        (
+            "mvp-stocks-20260902T013000Z-coarse-a_share-001",
+            "2026-09-02T01:30:00+00:00",
+        ),
+        ("mvp-20260902T030000Z", "2026-09-02T03:00:00+00:00"),
+    ):
+        store.commit_mvp_run(
+            MvpRunWrite(
+                run_id=run_id,
+                manifest_version=manifest.version,
+                manifest_hash=manifest_digest(manifest),
+                started_at=started_at,
+                completed_at=started_at,
+                window_start=None,
+                window_end=started_at,
+                policy={"runner": "test"},
+            )
+        )
+
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 2, 3, 5, tzinfo=timezone.utc),
+    )
+
+    assert snapshot["worker"]["next_due_at"] == "2026-09-02T07:00:00+00:00"
+
+
 def test_freshness_uses_session_and_continuous_calendar_slas() -> None:
     manifest = load_manifest(MANIFEST_PATH)
     aapl = next(item for item in manifest.instruments if item.display_symbol == "AAPL")

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from dataclasses import replace
 import json
 from pathlib import Path
@@ -310,6 +310,41 @@ def test_worker_next_due_keeps_non_stock_run_anchor(tmp_path: Path) -> None:
     )
 
     assert snapshot["worker"]["next_due_at"] == "2026-09-02T07:00:00+00:00"
+
+
+def test_worker_next_due_finds_stock_cycle_anchor_beyond_timeline_limit(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "matrix-long-cycle-anchor.db"))
+    started = datetime(2026, 9, 2, 1, 30, tzinfo=timezone.utc)
+    for index in range(70):
+        stamp = started.replace(minute=30) + timedelta(minutes=index)
+        run_id = (
+            "mvp-stocks-20260902T013000Z-coarse-a_share-001"
+            if index == 0
+            else f"mvp-stocks-20260902T{stamp:%H%M%S}Z-intraday-us_stock-{index:03d}"
+        )
+        store.commit_mvp_run(
+            MvpRunWrite(
+                run_id=run_id,
+                manifest_version=manifest.version,
+                manifest_hash=manifest_digest(manifest),
+                started_at=stamp.isoformat(),
+                completed_at=stamp.isoformat(),
+                window_start=None,
+                window_end=stamp.isoformat(),
+                policy={"runner": "mvp_stock_seed"},
+            )
+        )
+
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 2, 3, tzinfo=timezone.utc),
+    )
+
+    assert snapshot["worker"]["next_due_at"] == "2026-09-02T05:30:00+00:00"
 
 
 def test_freshness_uses_session_and_continuous_calendar_slas() -> None:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -132,6 +132,8 @@ async def test_run_once_marks_cn_a_opening_forming_bars_partial_inside_buffer(
     assert receipt.quality["partial"] == 2
     assert receipt.quality["fail"] == 0
     assert receipt.row_counts["promoted_candles"] == 0
+    assert receipt.row_counts["watermarks"] == 0
+    assert store.mvp_storage_health()["candles"] == 0
 
 
 class FakeCryptoAdapter:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -81,6 +81,59 @@ async def test_ingestion_fetches_provider_symbol_when_display_identity_is_differ
     assert calls == ["SPY"]
 
 
+@pytest.mark.asyncio
+async def test_run_once_marks_cn_a_opening_forming_bars_partial_inside_buffer(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "opening-buffer.db"))
+
+    class OpeningAdapter:
+        async def fetch_candles_with_receipt(
+            self,
+            _ticker: str,
+            _timeframe: Timeframe,
+            *,
+            start: str | None,
+            end: str,
+            limit: int,
+        ) -> FetchReceipt:
+            del start, end, limit
+            return FetchReceipt(
+                candles=[
+                    Candle(
+                        timestamp="2026-09-02T01:30:00+00:00",
+                        open=100,
+                        high=102,
+                        low=99,
+                        close=101,
+                        volume=10,
+                    )
+                ],
+                timeframe_transform=None,
+                source_identity={"selected_source": "opening-test"},
+                raw_response={"row_count": 1},
+            )
+
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: OpeningAdapter()
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-opening-buffer",
+            now=datetime(2026, 9, 2, 1, 35, tzinfo=timezone.utc),
+            instrument_ids=("CN.A.600519",),
+            timeframes=("15m", "1h"),
+            market_open_buffer_minutes=10,
+        )
+    )
+
+    assert [cell.status for cell in receipt.requested_cells] == ["partial", "partial"]
+    assert receipt.quality["partial"] == 2
+    assert receipt.quality["fail"] == 0
+    assert receipt.row_counts["promoted_candles"] == 0
+
+
 class FakeCryptoAdapter:
     async def fetch_candles_with_receipt(
         self,

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -233,6 +233,57 @@ def test_quality_distinguishes_duplicate_order_forming_gap_missing_holiday_suspe
     assert any(issue.status == "holiday" for issue in holiday.issues)
 
 
+def test_cn_a_market_open_buffer_only_softens_forming_15m_and_1h_bars() -> None:
+    zone = timezone(timedelta(hours=8))
+    cases = (
+        ("15m", datetime(2026, 9, 2, 9, 30, tzinfo=zone)),
+        ("1h", datetime(2026, 9, 2, 9, 30, tzinfo=zone)),
+    )
+    for timeframe, stamp in cases:
+        key = _key(
+            instrument_id="CN.A.300308",
+            display_symbol="300308",
+            timeframe=timeframe,
+        )
+        candle = _bar(key, stamp)
+        before = assess_quality(
+            [candle],
+            timeframe=timeframe,
+            calendar_id="cn_a",
+            cutoff=datetime(2026, 9, 2, 9, 29, tzinfo=zone),
+            market_open_buffer_minutes=10,
+        )
+        inside = assess_quality(
+            [candle],
+            timeframe=timeframe,
+            calendar_id="cn_a",
+            cutoff=datetime(2026, 9, 2, 9, 35, tzinfo=zone),
+            market_open_buffer_minutes=10,
+        )
+        after = assess_quality(
+            [candle],
+            timeframe=timeframe,
+            calendar_id="cn_a",
+            cutoff=datetime(2026, 9, 2, 9, 41, tzinfo=zone),
+            market_open_buffer_minutes=10,
+        )
+
+        assert before.status == "fail"
+        assert inside.status == "partial"
+        assert after.status == "fail"
+        assert all(any(issue.status == "forming" for issue in item.issues) for item in (before, inside, after))
+
+    crypto_key = _key(instrument_id="CRYPTO.BTC", display_symbol="BTC", timeframe="15m")
+    crypto = assess_quality(
+        [_bar(crypto_key, datetime(2026, 9, 2, 9, 30, tzinfo=timezone.utc))],
+        timeframe="15m",
+        calendar_id="crypto_24x7",
+        cutoff=datetime(2026, 9, 2, 9, 35, tzinfo=timezone.utc),
+        market_open_buffer_minutes=10,
+    )
+    assert crypto.status == "fail"
+
+
 def test_calendar_spec_rejects_unknown_calendar() -> None:
     with pytest.raises(CalendarError, match="unknown market calendar"):
         calendar_spec("not-a-calendar")

--- a/tests/test_mvp_stock_seed.py
+++ b/tests/test_mvp_stock_seed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -11,12 +12,33 @@ from ops.mvp_stock_seed import (
     _batches,
     _classify_attempt,
     remaining_stock_ids,
+    stock_cycle_wait_seconds,
     stock_instrument_ids,
     validate_seed_target,
 )
 
 
 MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "mvp_manifest.json"
+
+
+def test_stock_cycle_wait_is_anchored_to_start_across_runtime_variation() -> None:
+    started = datetime(2026, 9, 2, 1, 30, tzinfo=timezone.utc)
+
+    assert stock_cycle_wait_seconds(
+        cycle_started=started,
+        now=started + timedelta(minutes=29),
+        interval_seconds=4 * 60 * 60,
+    ) == 3 * 60 * 60 + 31 * 60
+    assert stock_cycle_wait_seconds(
+        cycle_started=started,
+        now=started + timedelta(hours=3, minutes=58),
+        interval_seconds=4 * 60 * 60,
+    ) == 2 * 60
+    assert stock_cycle_wait_seconds(
+        cycle_started=started,
+        now=started + timedelta(hours=4, minutes=5),
+        interval_seconds=4 * 60 * 60,
+    ) == 0
 
 
 def test_stock_seed_selects_the_100_plus_100_manifest_universes() -> None:


### PR DESCRIPTION
## What
- anchor the stock worker deadline to cycle start rather than completion
- add a configurable 10-minute CN A-share 15m/1h market-open buffer
- keep forming bars non-persisting and partial only during the buffer
- compute health `next_due_at` from the durable first batch of the latest stock cycle
- add duration, boundary, >64-batch, non-stock, ingestion, and crypto regression tests

## Why
The previous loop slept four hours after a 15–30 minute run, creating 4:29–4:39 start intervals. A-share opening fetches also marked current forming 15m/1h bars failed.

## Validation
- focused: 56 passed
- full suite: 298 passed
- Ruff: all changed files pass
- Standards review: 0 hard findings; one advisory run-ID grammar smell
- Spec review: code-level requirements pass
- pending acceptance: at least 24 hours real runtime evidence and before/after opening pass/fail comparison in `docs/verification`

Closes #115