### PR TITLE
Add isolated combined health dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,13 @@ python -m kline
 | `WS` | `/api/ws/candles/{asset_class}/{ticker}` | 实时 candle update；当前支持 Binance USD-M Futures |
 | `GET` | `/api/tickers` | 列出本地已缓存的 ticker |
 | `GET` | `/api/health` | 健康检查 + provider availability |
+| `GET` | `/api/mvp/health/matrix` | Screening manifest 的只读资产 × 时间级别健康矩阵 |
+| `GET` | `/api/health/combined-matrix` | 同时读取 Screening 与 Watchlist 两个数据库的只读合并矩阵 |
 | `GET` | `/api/sessions/{asset_class}/{ticker}` | 获取 adapter-owned market sessions |
+
+Operator 面板：`/health-ui` 保留 Screening 观察；`/health-ui?view=combined` 显示
+Screening + Watchlist，并可按数据集筛选。合并视图需要同时配置
+`KLINE_DB_PATH` 与 `KLINE_MARKET_DB_PATH`，且应启用 `KLINE_READ_ONLY=true`。
 
 ### 参数
 
@@ -478,6 +484,7 @@ kline/
 │   ├── ports.py            # MarketDataPort + SourceManifest
 │   ├── quality.py          # stale/gap/out-of-order 检测
 │   ├── store.py            # SQLite 存储 (upsert + query)
+│   ├── combined_health.py  # Screening + Watchlist 双库只读健康视图
 │   ├── registry.py         # Adapter 注册与初始化
 │   ├── config.py           # 环境变量配置
 │   └── providers/
@@ -501,6 +508,8 @@ kline/
 |------|------|------|--------|
 | `KLINE_TUSHARE_TOKEN` | TuShare Pro token（非 Phase 1 A-share equity 可选） | 否 | — |
 | `KLINE_DB_PATH` | SQLite 数据库路径 | 否 | `data/kline.db` |
+| `KLINE_MARKET_DB_PATH` | Combined Health 使用的 Market Data Database 路径 | 仅合并面板 | — |
+| `KLINE_READ_ONLY` | 使用 SQLite `mode=ro`，禁止建表、迁移、WAL 与数据写入 | 否 | `false` |
 | `KLINE_PORT` | 服务端口 | 否 | `8100` |
 | `KLINE_REQUEST_TIMEOUT` | 上游请求超时 (秒) | 否 | `30` |
 

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ kline/
 | `KLINE_TUSHARE_TOKEN` | TuShare Pro token（非 Phase 1 A-share equity 可选） | 否 | — |
 | `KLINE_DB_PATH` | SQLite 数据库路径 | 否 | `data/kline.db` |
 | `KLINE_MARKET_DB_PATH` | Combined Health 使用的 Market Data Database 路径 | 仅合并面板 | — |
-| `KLINE_READ_ONLY` | 使用 SQLite `mode=ro`，禁止建表、迁移、WAL 与数据写入 | 否 | `false` |
+| `KLINE_READ_ONLY` | 使用 SQLite `mode=ro` + `query_only`，禁止建表、迁移和数据写入；SQLite 仍可能维护只读锁所需的 `-shm`/空 `-wal` sidecar | 否 | `false` |
 | `KLINE_PORT` | 服务端口 | 否 | `8100` |
 | `KLINE_REQUEST_TIMEOUT` | 上游请求超时 (秒) | 否 | `30` |
 
@@ -592,6 +592,12 @@ endpoints:
   - path: /api/health
     method: GET
     description: "Health check"
+  - path: /api/mvp/health/matrix
+    method: GET
+    description: "Internal operator-only Screening health matrix"
+  - path: /api/health/combined-matrix
+    method: GET
+    description: "Internal operator-only Screening + Watchlist matrix; requires KLINE_MARKET_DB_PATH and KLINE_READ_ONLY=true"
 install_command: "pip install -e ."
 start_command: "python -m kline"
 health_check: "GET /api/health"

--- a/ops/com.wendy.datafeed.health-dashboard.plist.example
+++ b/ops/com.wendy.datafeed.health-dashboard.plist.example
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wendy.datafeed.health-dashboard</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/python3</string>
+        <string>-m</string>
+        <string>uvicorn</string>
+        <string>kline.app:create_app</string>
+        <string>--factory</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>18172</string>
+        <string>--log-level</string>
+        <string>info</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/wendy/datafeed-runtime-health-dashboard</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>/Users/wendy/datafeed-runtime-health-dashboard/src</string>
+        <key>KLINE_RUNTIME_ROOT</key>
+        <string>/Users/wendy/datafeed-runtime-health-dashboard</string>
+        <key>KLINE_BUILD_SHA</key>
+        <string>__KLINE_BUILD_SHA__</string>
+        <key>KLINE_DB_PATH</key>
+        <string>/Users/wendy/datafeed-runtime-issue-71/data/kline.db</string>
+        <key>KLINE_MARKET_DB_PATH</key>
+        <string>/Users/wendy/park-data/market/kline.db</string>
+        <key>KLINE_LOAD_ENTRYPOINT_ADAPTERS</key>
+        <string>false</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/health-dashboard.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/health-dashboard.stderr.log</string>
+</dict>
+</plist>

--- a/ops/com.wendy.datafeed.health-dashboard.plist.example
+++ b/ops/com.wendy.datafeed.health-dashboard.plist.example
@@ -34,6 +34,8 @@
         <string>/Users/wendy/park-data/market/kline.db</string>
         <key>KLINE_LOAD_ENTRYPOINT_ADAPTERS</key>
         <string>false</string>
+        <key>KLINE_READ_ONLY</key>
+        <string>true</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
     </dict>

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -21,6 +21,7 @@ from kline.models import (
     TimeframeTransform,
     InstrumentDefinition,
 )
+from kline.combined_health import build_combined_health_matrix
 from kline.free_source_profile import apply_free_source_profile
 from kline.health_matrix import (
     MATRIX_SCOPE_DEMO,
@@ -43,6 +44,7 @@ from kline.registry import get_adapter_for_source, get_store, provider_status, r
 
 router = APIRouter()
 _mvp_matrix_last_success_at: str | None = None
+_combined_matrix_last_success_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1150,5 +1152,25 @@ async def mvp_health_matrix(scope: str = MATRIX_SCOPE_FULL) -> dict:
                 "error": "dashboard_unavailable",
                 "detail": type(error).__name__,
                 "last_success_at": _mvp_matrix_last_success_at,
+            },
+        ) from error
+
+
+@router.get("/health/combined-matrix")
+async def combined_health_matrix() -> dict:
+    """Return a read-only snapshot over Screening and Watchlist stores."""
+
+    global _combined_matrix_last_success_at
+    try:
+        payload = build_combined_health_matrix()
+        _combined_matrix_last_success_at = payload["refresh"]["last_success_at"]
+        return payload
+    except Exception as error:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "combined_dashboard_unavailable",
+                "detail": type(error).__name__,
+                "last_success_at": _combined_matrix_last_success_at,
             },
         ) from error

--- a/src/kline/combined_health.py
+++ b/src/kline/combined_health.py
@@ -18,30 +18,20 @@ from kline.health_matrix import (
     build_mvp_health_matrix,
 )
 from kline.mvp_manifest import load_manifest
-from kline.registry import get_store
 from kline.store import KlineReadOnlyStore, KlineStore
+from kline.time_utils import parse_utc_timestamp
 from kline.watchlist_manifest import load_watchlist_manifest
 
 
 COMBINED_SCOPE = "screening_watchlist"
+SCREENING_DB_ENV = "KLINE_DB_PATH"
 MARKET_DATA_DB_ENV = "KLINE_MARKET_DB_PATH"
+_screening_store_cache: dict[str, KlineReadOnlyStore] = {}
 _market_store_cache: dict[str, KlineReadOnlyStore] = {}
 
 
-def _parse_timestamp(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
 def _latest_timestamp(values: list[Any], *, default: str | None = None) -> str | None:
-    parsed = [(stamp, _parse_timestamp(stamp)) for stamp in values if stamp]
+    parsed = [(stamp, parse_utc_timestamp(stamp)) for stamp in values if stamp]
     parsed = [(stamp, value) for stamp, value in parsed if value is not None]
     if not parsed:
         return default
@@ -81,18 +71,18 @@ def _merge_worker(snapshots: Mapping[str, dict[str, Any]]) -> dict[str, Any]:
     runs = [worker for worker in workers.values() if worker.get("last_run_id")]
     latest_run = max(
         runs,
-        key=lambda worker: _parse_timestamp(worker.get("last_attempt_at"))
+        key=lambda worker: parse_utc_timestamp(worker.get("last_attempt_at"))
         or datetime.min.replace(tzinfo=timezone.utc),
         default={},
     )
     due_values = [worker.get("next_due_at") for worker in workers.values() if worker.get("next_due_at")]
-    due_values = [value for value in due_values if _parse_timestamp(value) is not None]
+    due_values = [value for value in due_values if parse_utc_timestamp(value) is not None]
     return {
         "status": "last_run" if runs else "idle",
         "last_attempt_at": _latest_timestamp(attempts),
         "last_success_at": _latest_timestamp(successes),
         "last_run_id": latest_run.get("last_run_id"),
-        "next_due_at": min(due_values, key=lambda value: _parse_timestamp(value))
+        "next_due_at": min(due_values, key=lambda value: parse_utc_timestamp(value))
         if due_values
         else None,
         "interval_seconds": None,
@@ -132,14 +122,27 @@ def _combined_manifest_hash(snapshots: Mapping[str, dict[str, Any]]) -> str:
     ).hexdigest()
 
 
-def _market_store(path: str | Path | None = None) -> KlineReadOnlyStore:
-    value = str(path or os.environ.get(MARKET_DATA_DB_ENV) or "").strip()
+def _read_only_store(
+    path: str | Path | None,
+    *,
+    env_name: str,
+    cache: dict[str, KlineReadOnlyStore],
+) -> KlineReadOnlyStore:
+    value = str(path or os.environ.get(env_name) or "").strip()
     if not value:
-        raise RuntimeError(f"{MARKET_DATA_DB_ENV} must be configured for the combined health view")
+        raise RuntimeError(f"{env_name} must be configured for the combined health view")
     resolved = str(Path(value).expanduser().resolve())
-    if resolved not in _market_store_cache:
-        _market_store_cache[resolved] = KlineReadOnlyStore(resolved)
-    return _market_store_cache[resolved]
+    if resolved not in cache:
+        cache[resolved] = KlineReadOnlyStore(resolved)
+    return cache[resolved]
+
+
+def _screening_store(path: str | Path | None = None) -> KlineReadOnlyStore:
+    return _read_only_store(path, env_name=SCREENING_DB_ENV, cache=_screening_store_cache)
+
+
+def _market_store(path: str | Path | None = None) -> KlineReadOnlyStore:
+    return _read_only_store(path, env_name=MARKET_DATA_DB_ENV, cache=_market_store_cache)
 
 
 def build_combined_health_matrix(
@@ -163,7 +166,7 @@ def build_combined_health_matrix(
     snapshots = {
         "screening": build_mvp_health_matrix(
             screening_manifest,
-            screening_store or get_store(),
+            screening_store or _screening_store(),
             now=now,
             interval_seconds=4 * 60 * 60,
             scope=MATRIX_SCOPE_FULL,
@@ -206,7 +209,7 @@ def build_combined_health_matrix(
         for run in snapshot.get("runs", [])
     ]
     runs.sort(
-        key=lambda run: _parse_timestamp(run.get("started_at"))
+        key=lambda run: parse_utc_timestamp(run.get("started_at"))
         or datetime.min.replace(tzinfo=timezone.utc),
         reverse=True,
     )

--- a/src/kline/combined_health.py
+++ b/src/kline/combined_health.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from kline.free_source_profile import apply_free_source_profile
 from kline.health_matrix import (
@@ -19,13 +19,13 @@ from kline.health_matrix import (
 )
 from kline.mvp_manifest import load_manifest
 from kline.registry import get_store
-from kline.store import KlineStore
+from kline.store import KlineReadOnlyStore, KlineStore
 from kline.watchlist_manifest import load_watchlist_manifest
 
 
 COMBINED_SCOPE = "screening_watchlist"
 MARKET_DATA_DB_ENV = "KLINE_MARKET_DB_PATH"
-_market_store_cache: dict[str, KlineStore] = {}
+_market_store_cache: dict[str, KlineReadOnlyStore] = {}
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -48,7 +48,9 @@ def _latest_timestamp(values: list[Any], *, default: str | None = None) -> str |
     return max(parsed, key=lambda item: item[1])[0]
 
 
-def _merge_coverage(snapshots: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+def _merge_coverage(
+    snapshots: Mapping[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     result: dict[str, dict[str, Any]] = {}
     for timeframe in MATRIX_TIMEFRAMES:
         counts = {
@@ -57,7 +59,7 @@ def _merge_coverage(snapshots: list[dict[str, Any]]) -> dict[str, dict[str, Any]
             "technical_ready": 0,
             **{status: 0 for status in MATRIX_STATUSES},
         }
-        for snapshot in snapshots:
+        for snapshot in snapshots.values():
             source = snapshot.get("coverage", {}).get(timeframe, {})
             for key in counts:
                 counts[key] += int(source.get(key, 0) or 0)
@@ -70,10 +72,9 @@ def _merge_coverage(snapshots: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     return result
 
 
-def _merge_worker(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
+def _merge_worker(snapshots: Mapping[str, dict[str, Any]]) -> dict[str, Any]:
     workers = {
-        name: dict(snapshot.get("worker", {}))
-        for name, snapshot in zip(("screening", "watchlist"), snapshots)
+        name: dict(snapshot.get("worker", {})) for name, snapshot in snapshots.items()
     }
     attempts = [worker.get("last_attempt_at") for worker in workers.values()]
     successes = [worker.get("last_success_at") for worker in workers.values()]
@@ -99,9 +100,11 @@ def _merge_worker(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _merge_infrastructure(snapshots: list[dict[str, Any]], worker: dict[str, Any]) -> dict[str, Any]:
-    screening = snapshots[0].get("infrastructure", {})
-    watchlist = snapshots[1].get("infrastructure", {})
+def _merge_infrastructure(
+    snapshots: Mapping[str, dict[str, Any]], worker: dict[str, Any]
+) -> dict[str, Any]:
+    screening = snapshots["screening"].get("infrastructure", {})
+    watchlist = snapshots["watchlist"].get("infrastructure", {})
     databases = {
         "screening": dict(screening.get("database", {})),
         "market_data": dict(watchlist.get("database", {})),
@@ -120,23 +123,22 @@ def _merge_infrastructure(snapshots: list[dict[str, Any]], worker: dict[str, Any
     }
 
 
-def _combined_manifest_hash(snapshots: list[dict[str, Any]]) -> str:
+def _combined_manifest_hash(snapshots: Mapping[str, dict[str, Any]]) -> str:
     payload = {
-        "screening": snapshots[0].get("manifest_hash"),
-        "watchlist": snapshots[1].get("manifest_hash"),
+        name: snapshot.get("manifest_hash") for name, snapshot in snapshots.items()
     }
     return hashlib.sha256(
         json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()
 
 
-def _market_store(path: str | Path | None = None) -> KlineStore:
+def _market_store(path: str | Path | None = None) -> KlineReadOnlyStore:
     value = str(path or os.environ.get(MARKET_DATA_DB_ENV) or "").strip()
     if not value:
         raise RuntimeError(f"{MARKET_DATA_DB_ENV} must be configured for the combined health view")
     resolved = str(Path(value).expanduser().resolve())
     if resolved not in _market_store_cache:
-        _market_store_cache[resolved] = KlineStore(resolved)
+        _market_store_cache[resolved] = KlineReadOnlyStore(resolved)
     return _market_store_cache[resolved]
 
 
@@ -158,15 +160,15 @@ def build_combined_health_matrix(
         for item in watchlist_manifest.instruments
         if item.source_status == "configured"
     }
-    snapshots = [
-        build_mvp_health_matrix(
+    snapshots = {
+        "screening": build_mvp_health_matrix(
             screening_manifest,
             screening_store or get_store(),
             now=now,
             interval_seconds=4 * 60 * 60,
             scope=MATRIX_SCOPE_FULL,
         ),
-        build_mvp_health_matrix(
+        "watchlist": build_mvp_health_matrix(
             watchlist_manifest,
             market_store or _market_store(),
             now=now,
@@ -174,10 +176,10 @@ def build_combined_health_matrix(
             scope=MATRIX_SCOPE_WATCHLIST,
             free_source_ids=watchlist_free_source_ids,
         ),
-    ]
+    }
     cells = [
         {**cell, "dataset": dataset}
-        for dataset, snapshot in zip(("screening", "watchlist"), snapshots)
+        for dataset, snapshot in snapshots.items()
         for cell in snapshot["cells"]
     ]
     statuses = {
@@ -185,7 +187,7 @@ def build_combined_health_matrix(
     }
     infrastructure_statuses = [
         snapshot.get("infrastructure", {}).get("database", {}).get("status")
-        for snapshot in snapshots
+        for snapshot in snapshots.values()
     ]
     if "failed" in infrastructure_statuses or statuses.intersection({"failed", "blocked"}):
         status = "failed"
@@ -194,13 +196,13 @@ def build_combined_health_matrix(
     else:
         status = "ready"
     universes: dict[str, int] = {}
-    for snapshot in snapshots:
+    for snapshot in snapshots.values():
         for universe, count in snapshot.get("scope", {}).get("universes", {}).items():
             universes[universe] = universes.get(universe, 0) + int(count)
     worker = _merge_worker(snapshots)
     runs = [
         {**run, "dataset": dataset}
-        for dataset, snapshot in zip(("screening", "watchlist"), snapshots)
+        for dataset, snapshot in snapshots.items()
         for run in snapshot.get("runs", [])
     ]
     runs.sort(
@@ -215,12 +217,14 @@ def build_combined_health_matrix(
         "manifest_version": "screening_watchlist_v1",
         "manifest_hash": _combined_manifest_hash(snapshots),
         "manifest_versions": {
-            "screening": snapshots[0]["manifest_version"],
-            "watchlist": snapshots[1]["manifest_version"],
+            "screening": snapshots["screening"]["manifest_version"],
+            "watchlist": snapshots["watchlist"]["manifest_version"],
         },
         "scope": {
             "name": COMBINED_SCOPE,
-            "instrument_count": sum(item["scope"]["instrument_count"] for item in snapshots),
+            "instrument_count": sum(
+                item["scope"]["instrument_count"] for item in snapshots.values()
+            ),
             "universes": universes,
         },
         "refresh": {

--- a/src/kline/combined_health.py
+++ b/src/kline/combined_health.py
@@ -1,0 +1,235 @@
+"""Read-only health view that combines the isolated Screening and Watchlist stores."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from kline.free_source_profile import apply_free_source_profile
+from kline.health_matrix import (
+    MATRIX_SCOPE_FULL,
+    MATRIX_SCOPE_WATCHLIST,
+    MATRIX_STATUSES,
+    MATRIX_TIMEFRAMES,
+    build_mvp_health_matrix,
+)
+from kline.mvp_manifest import load_manifest
+from kline.registry import get_store
+from kline.store import KlineStore
+from kline.watchlist_manifest import load_watchlist_manifest
+
+
+COMBINED_SCOPE = "screening_watchlist"
+MARKET_DATA_DB_ENV = "KLINE_MARKET_DB_PATH"
+_market_store_cache: dict[str, KlineStore] = {}
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _latest_timestamp(values: list[Any], *, default: str | None = None) -> str | None:
+    parsed = [(stamp, _parse_timestamp(stamp)) for stamp in values if stamp]
+    parsed = [(stamp, value) for stamp, value in parsed if value is not None]
+    if not parsed:
+        return default
+    return max(parsed, key=lambda item: item[1])[0]
+
+
+def _merge_coverage(snapshots: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for timeframe in MATRIX_TIMEFRAMES:
+        counts = {
+            "applicable": 0,
+            "not_applicable": 0,
+            "technical_ready": 0,
+            **{status: 0 for status in MATRIX_STATUSES},
+        }
+        for snapshot in snapshots:
+            source = snapshot.get("coverage", {}).get(timeframe, {})
+            for key in counts:
+                counts[key] += int(source.get(key, 0) or 0)
+        counts["ratio"] = (
+            round(counts["ready"] / counts["applicable"], 4)
+            if counts["applicable"]
+            else None
+        )
+        result[timeframe] = counts
+    return result
+
+
+def _merge_worker(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
+    workers = {
+        name: dict(snapshot.get("worker", {}))
+        for name, snapshot in zip(("screening", "watchlist"), snapshots)
+    }
+    attempts = [worker.get("last_attempt_at") for worker in workers.values()]
+    successes = [worker.get("last_success_at") for worker in workers.values()]
+    runs = [worker for worker in workers.values() if worker.get("last_run_id")]
+    latest_run = max(
+        runs,
+        key=lambda worker: _parse_timestamp(worker.get("last_attempt_at"))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        default={},
+    )
+    due_values = [worker.get("next_due_at") for worker in workers.values() if worker.get("next_due_at")]
+    due_values = [value for value in due_values if _parse_timestamp(value) is not None]
+    return {
+        "status": "last_run" if runs else "idle",
+        "last_attempt_at": _latest_timestamp(attempts),
+        "last_success_at": _latest_timestamp(successes),
+        "last_run_id": latest_run.get("last_run_id"),
+        "next_due_at": min(due_values, key=lambda value: _parse_timestamp(value))
+        if due_values
+        else None,
+        "interval_seconds": None,
+        "schedules": workers,
+    }
+
+
+def _merge_infrastructure(snapshots: list[dict[str, Any]], worker: dict[str, Any]) -> dict[str, Any]:
+    screening = snapshots[0].get("infrastructure", {})
+    watchlist = snapshots[1].get("infrastructure", {})
+    databases = {
+        "screening": dict(screening.get("database", {})),
+        "market_data": dict(watchlist.get("database", {})),
+    }
+    database_status = (
+        "ready"
+        if all(item.get("status") in {"ready", "ok"} for item in databases.values())
+        else "failed"
+    )
+    return {
+        "worker": worker,
+        "database": {"status": database_status, "filesystem": "local"},
+        "databases": databases,
+        "ssd_mount_guard": dict(watchlist.get("ssd_mount_guard", {"status": "not_observed"})),
+        "nas_backup": dict(watchlist.get("nas_backup", {"status": "pending"})),
+    }
+
+
+def _combined_manifest_hash(snapshots: list[dict[str, Any]]) -> str:
+    payload = {
+        "screening": snapshots[0].get("manifest_hash"),
+        "watchlist": snapshots[1].get("manifest_hash"),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _market_store(path: str | Path | None = None) -> KlineStore:
+    value = str(path or os.environ.get(MARKET_DATA_DB_ENV) or "").strip()
+    if not value:
+        raise RuntimeError(f"{MARKET_DATA_DB_ENV} must be configured for the combined health view")
+    resolved = str(Path(value).expanduser().resolve())
+    if resolved not in _market_store_cache:
+        _market_store_cache[resolved] = KlineStore(resolved)
+    return _market_store_cache[resolved]
+
+
+def build_combined_health_matrix(
+    *,
+    screening_store: KlineStore | None = None,
+    market_store: KlineStore | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build one read-only snapshot over the two intentionally separate stores."""
+
+    root = Path(__file__).resolve().parents[2]
+    screening_manifest = apply_free_source_profile(
+        load_manifest(root / "configs" / "mvp_manifest.json")
+    )
+    watchlist_manifest = load_watchlist_manifest(root / "configs" / "watchlist_manifest.json")
+    watchlist_free_source_ids = {
+        item.source_id
+        for item in watchlist_manifest.instruments
+        if item.source_status == "configured"
+    }
+    snapshots = [
+        build_mvp_health_matrix(
+            screening_manifest,
+            screening_store or get_store(),
+            now=now,
+            interval_seconds=4 * 60 * 60,
+            scope=MATRIX_SCOPE_FULL,
+        ),
+        build_mvp_health_matrix(
+            watchlist_manifest,
+            market_store or _market_store(),
+            now=now,
+            interval_seconds=24 * 60 * 60,
+            scope=MATRIX_SCOPE_WATCHLIST,
+            free_source_ids=watchlist_free_source_ids,
+        ),
+    ]
+    cells = [cell for snapshot in snapshots for cell in snapshot["cells"]]
+    statuses = {
+        cell["status"] for cell in cells if cell["applicability"] == "applicable"
+    }
+    infrastructure_statuses = [
+        snapshot.get("infrastructure", {}).get("database", {}).get("status")
+        for snapshot in snapshots
+    ]
+    if "failed" in infrastructure_statuses or statuses.intersection({"failed", "blocked"}):
+        status = "failed"
+    elif statuses.intersection({"partial", "stale", "unavailable"}):
+        status = "partial"
+    else:
+        status = "ready"
+    universes: dict[str, int] = {}
+    for snapshot in snapshots:
+        for universe, count in snapshot.get("scope", {}).get("universes", {}).items():
+            universes[universe] = universes.get(universe, 0) + int(count)
+    worker = _merge_worker(snapshots)
+    runs = [
+        {**run, "dataset": dataset}
+        for dataset, snapshot in zip(("screening", "watchlist"), snapshots)
+        for run in snapshot.get("runs", [])
+    ]
+    runs.sort(
+        key=lambda run: _parse_timestamp(run.get("started_at"))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    observed_at = now or datetime.now(timezone.utc)
+    return {
+        "status": status,
+        "as_of": observed_at.astimezone(timezone.utc).replace(microsecond=0).isoformat(),
+        "manifest_version": "screening_watchlist_v1",
+        "manifest_hash": _combined_manifest_hash(snapshots),
+        "manifest_versions": {
+            "screening": snapshots[0]["manifest_version"],
+            "watchlist": snapshots[1]["manifest_version"],
+        },
+        "scope": {
+            "name": COMBINED_SCOPE,
+            "instrument_count": sum(item["scope"]["instrument_count"] for item in snapshots),
+            "universes": universes,
+        },
+        "refresh": {
+            "poll_interval_seconds": 30,
+            "request_timeout_seconds": 10,
+            "last_success_at": observed_at.astimezone(timezone.utc).replace(microsecond=0).isoformat(),
+            "snapshot_age_seconds": 0,
+            "snapshot_max_age_seconds": 900,
+        },
+        "worker": worker,
+        "workers": worker["schedules"],
+        "runs": runs[:48],
+        "infrastructure": _merge_infrastructure(snapshots, worker),
+        "coverage": _merge_coverage(snapshots),
+        "cells": cells,
+    }

--- a/src/kline/combined_health.py
+++ b/src/kline/combined_health.py
@@ -175,7 +175,11 @@ def build_combined_health_matrix(
             free_source_ids=watchlist_free_source_ids,
         ),
     ]
-    cells = [cell for snapshot in snapshots for cell in snapshot["cells"]]
+    cells = [
+        {**cell, "dataset": dataset}
+        for dataset, snapshot in zip(("screening", "watchlist"), snapshots)
+        for cell in snapshot["cells"]
+    ]
     statuses = {
         cell["status"] for cell in cells if cell["applicability"] == "applicable"
     }

--- a/src/kline/config.py
+++ b/src/kline/config.py
@@ -8,6 +8,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     # Database
     db_path: str = "data/kline.db"
+    read_only: bool = False
 
     # Server
     port: int = 8100

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -349,12 +349,10 @@ def _cell(
         or instrument.source_status == "blocked_for_entitlement"
     ) and timeframe not in instrument.not_applicable_timeframes
     if not applicable:
-        return {
+        payload = {
             "instrument_id": instrument.instrument_id,
             "display_symbol": instrument.display_symbol,
             "display_name": instrument.display_name,
-            "universe": instrument.universe,
-            "metadata": dict(instrument.metadata),
             "provider_symbol": None,
             "asset_class": instrument.asset_class,
             "source_id": None,
@@ -378,6 +376,9 @@ def _cell(
             "watermark": None,
             "error": None,
         }
+        if instrument.universe == "watchlist":
+            payload.update({"universe": instrument.universe, "metadata": dict(instrument.metadata)})
+        return payload
 
     latest_timestamp = latest.get("latest_timestamp") if latest else None
     last_attempt = observation.get("observed_at") if observation else None
@@ -419,12 +420,10 @@ def _cell(
         and watermark is not None
         else status
     )
-    return {
+    payload = {
         "instrument_id": instrument.instrument_id,
         "display_symbol": instrument.display_symbol,
         "display_name": instrument.display_name,
-        "universe": instrument.universe,
-        "metadata": dict(instrument.metadata),
         "provider_symbol": instrument.provider_symbol,
         "asset_class": instrument.asset_class,
         "source_id": instrument.source_id,
@@ -452,6 +451,9 @@ def _cell(
         "watermark": dict(watermark) if watermark else None,
         "error": error,
     }
+    if instrument.universe == "watchlist":
+        payload.update({"universe": instrument.universe, "metadata": dict(instrument.metadata)})
+    return payload
 
 
 def _worker_payload(

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 import math
-from typing import Any, Mapping, Sequence
+from typing import Any, Collection, Mapping, Sequence
 
 from kline.market_calendar import calendar_spec, is_trading_session
 from kline.models import AssetClass
@@ -16,6 +16,7 @@ MATRIX_TIMEFRAMES = ("15m", "1h", "4h", "1d", "1w")
 MATRIX_STATUSES = ("ready", "partial", "stale", "failed", "blocked", "unavailable")
 MATRIX_SCOPE_DEMO = "demo_3x3"
 MATRIX_SCOPE_FULL = "full_216"
+MATRIX_SCOPE_WATCHLIST = "watchlist_58"
 POLL_INTERVAL_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 10
 SNAPSHOT_MAX_AGE_SECONDS = 900
@@ -85,6 +86,20 @@ def _key(row: Mapping[str, Any]) -> tuple[str, str, str, str, str]:
         str(row.get("adjustment_basis") or "raw_unadjusted"),
         str(row.get("manifest_version") or ""),
     )
+
+
+def _manifest_digest(manifest: Any) -> str:
+    """Return a validated digest for either the Screening or Watchlist manifest."""
+
+    if isinstance(manifest, MvpManifest):
+        return manifest_digest(manifest)
+    digest = getattr(manifest, "validated_digest", None)
+    if not callable(digest):
+        raise ValueError("health matrix manifest must expose a validated digest")
+    value = str(digest())
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError("health matrix manifest digest must be a lowercase SHA-256 digest")
+    return value
 
 
 def _freshness_stale(
@@ -290,11 +305,12 @@ def _entitlement_block_reason(
     receipt: Mapping[str, Any] | None,
     *,
     derived: bool,
+    free_source_ids: Collection[str] = FREE_SOURCE_IDS,
 ) -> str | None:
     if instrument.source_status == "blocked_for_entitlement":
         return "entitlement_blocked"
     if receipt is None:
-        return None if instrument.source_id in FREE_SOURCE_IDS else "entitlement_unverified"
+        return None if instrument.source_id in free_source_ids else "entitlement_unverified"
     status = str(receipt.get("status") or "unverified").casefold()
     if status in {"blocked", "missing", "unverified"}:
         return f"entitlement_{status}"
@@ -337,6 +353,8 @@ def _cell(
             "instrument_id": instrument.instrument_id,
             "display_symbol": instrument.display_symbol,
             "display_name": instrument.display_name,
+            "universe": instrument.universe,
+            "metadata": dict(instrument.metadata),
             "provider_symbol": None,
             "asset_class": instrument.asset_class,
             "source_id": None,
@@ -405,6 +423,8 @@ def _cell(
         "instrument_id": instrument.instrument_id,
         "display_symbol": instrument.display_symbol,
         "display_name": instrument.display_name,
+        "universe": instrument.universe,
+        "metadata": dict(instrument.metadata),
         "provider_symbol": instrument.provider_symbol,
         "asset_class": instrument.asset_class,
         "source_id": instrument.source_id,
@@ -463,13 +483,14 @@ def _worker_payload(
 
 
 def build_mvp_health_matrix(
-    manifest: MvpManifest,
+    manifest: Any,
     storage: StoragePort,
     *,
     now: datetime | None = None,
     interval_seconds: int = 4 * 60 * 60,
     scope: str = MATRIX_SCOPE_FULL,
     instrument_ids: Sequence[str] | None = None,
+    free_source_ids: Collection[str] = FREE_SOURCE_IDS,
 ) -> dict[str, Any]:
     """Build the source-aware matrix from persisted facts only.
 
@@ -490,6 +511,9 @@ def build_mvp_health_matrix(
     elif scope == MATRIX_SCOPE_FULL:
         selected_ids = tuple(instrument.instrument_id for instrument in manifest.instruments)
         scope_name = MATRIX_SCOPE_FULL
+    elif scope == MATRIX_SCOPE_WATCHLIST:
+        selected_ids = tuple(instrument.instrument_id for instrument in manifest.instruments)
+        scope_name = MATRIX_SCOPE_WATCHLIST
     else:
         raise ValueError(f"unsupported matrix scope: {scope}")
     missing_ids = [instrument_id for instrument_id in selected_ids if instrument_id not in by_id]
@@ -592,6 +616,7 @@ def build_mvp_health_matrix(
                 timeframe,
                 entitlement,
                 derived=bool(transform) or timeframe in {"4h", "1w"},
+                free_source_ids=free_source_ids,
             )
             if entitlement_reason or timeframe in instrument.blocked_timeframes:
                 status, reason = "blocked", entitlement_reason or "timeframe_blocked"
@@ -637,7 +662,7 @@ def build_mvp_health_matrix(
             if (
                 status == "ready"
                 and entitlement is None
-                and instrument.source_id in FREE_SOURCE_IDS
+                and instrument.source_id in free_source_ids
             ):
                 status, reason = "partial", "entitlement_unverified"
             cells.append(
@@ -684,7 +709,7 @@ def build_mvp_health_matrix(
         "status": overall,
         "as_of": _iso(observed_at),
         "manifest_version": manifest.version,
-        "manifest_hash": manifest_digest(manifest),
+        "manifest_hash": _manifest_digest(manifest),
         "scope": {
             "name": scope_name,
             "instrument_count": len(selected_instruments),

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -10,6 +10,7 @@ from kline.market_calendar import calendar_spec, is_trading_session
 from kline.models import AssetClass
 from kline.mvp_manifest import MvpManifest, ManifestInstrument, manifest_digest
 from kline.storage import StoragePort
+from kline.time_utils import parse_utc_timestamp
 
 
 MATRIX_TIMEFRAMES = ("15m", "1h", "4h", "1d", "1w")
@@ -38,18 +39,6 @@ def _iso(value: datetime) -> str:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
-
-
-def _parse_timestamp(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def _status_counts(cells: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -111,7 +100,7 @@ def _freshness_stale(
 ) -> bool:
     """Apply calendar-aware freshness without treating a closed session as stale."""
 
-    latest = _parse_timestamp(latest_timestamp)
+    latest = parse_utc_timestamp(latest_timestamp)
     if latest is None:
         return False
     expected = _expected_latest_closed_start(instrument, timeframe, now)
@@ -466,7 +455,7 @@ def _worker_payload(
         else (storage.latest_mvp_run() if hasattr(storage, "latest_mvp_run") else None)
     )
     last_activity = (latest.get("completed_at") or latest.get("started_at")) if latest else None
-    parsed_activity = _parse_timestamp(last_activity)
+    parsed_activity = parse_utc_timestamp(last_activity)
     next_due = None
     if parsed_activity is not None:
         due = parsed_activity + timedelta(seconds=interval_seconds)
@@ -693,7 +682,7 @@ def build_mvp_health_matrix(
     recent_runs = [
         run
         for run in persisted_runs
-        if (started := _parse_timestamp(run.get("started_at"))) is None or started >= run_cutoff
+        if (started := parse_utc_timestamp(run.get("started_at"))) is None or started >= run_cutoff
     ]
     storage_health = storage.mvp_storage_health() if hasattr(storage, "mvp_storage_health") else {}
     backup = storage.latest_mvp_backup() if hasattr(storage, "latest_mvp_backup") else None

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -167,6 +167,45 @@ async def health_ui() -> str:
     if (!timeframes.every(tf => data.coverage[tf] && Number.isFinite(Number(data.coverage[tf].applicable)) && Number.isFinite(Number(data.coverage[tf].not_applicable)))) return false;
     return data.cells.every(cell => timeframes.includes(cell.timeframe) && ['applicable','not_applicable'].includes(cell.applicability) && Object.prototype.hasOwnProperty.call(statusLabels, cell.status));
   };
+  function coverageFromCells(cells) {
+    const statuses = ['ready','partial','stale','failed','blocked','unavailable'];
+    return Object.fromEntries(timeframes.map(tf => {
+      const counts = {applicable:0,not_applicable:0,technical_ready:0,ready:0,partial:0,stale:0,failed:0,blocked:0,unavailable:0};
+      cells.filter(cell => cell.timeframe === tf).forEach(cell => {
+        if (cell.applicability === 'not_applicable') counts.not_applicable += 1;
+        else {
+          counts.applicable += 1;
+          if (statuses.includes(cell.status)) counts[cell.status] += 1;
+          if (cell.technical_status === 'ready' || cell.status === 'ready') counts.technical_ready += 1;
+        }
+      });
+      counts.ratio = counts.applicable ? counts.ready / counts.applicable : null;
+      return [tf, counts];
+    }));
+  }
+  function statusFromCells(cells) {
+    const statuses = new Set(cells.filter(cell => cell.applicability === 'applicable').map(cell => cell.status));
+    if (statuses.has('failed') || statuses.has('blocked')) return 'failed';
+    if (['partial','stale','unavailable'].some(status => statuses.has(status))) return 'partial';
+    return 'ready';
+  }
+  function scopeSnapshot(snapshot) {
+    const dataset = document.getElementById('dataset-filter').value;
+    if (dataset === 'all' || !snapshot.manifest_versions) return snapshot;
+    const cells = snapshot.cells.filter(cell => cell.dataset === dataset);
+    const worker = (snapshot.workers || {})[dataset] || snapshot.worker;
+    const databaseKey = dataset === 'watchlist' ? 'market_data' : 'screening';
+    const allDatabases = (snapshot.infrastructure || {}).databases || {};
+    const databases = allDatabases[databaseKey] ? {[databaseKey]:allDatabases[databaseKey]} : {};
+    return {
+      ...snapshot,
+      status:statusFromCells(cells), cells, coverage:coverageFromCells(cells), worker,
+      runs:(snapshot.runs || []).filter(run => run.dataset === dataset),
+      manifest_version:snapshot.manifest_versions[dataset] || snapshot.manifest_version,
+      manifest_versions:null,
+      infrastructure:{...snapshot.infrastructure,worker,databases}
+    };
+  }
   const showBanner = (text, severity = 'error') => {
     const banner = document.getElementById('banner');
     document.getElementById('banner-text').textContent = text;
@@ -270,21 +309,22 @@ async def health_ui() -> str:
 
   function render(snapshot) {
     latestSnapshot = snapshot;
-    renderCoverage(snapshot); renderMatrix(snapshot); renderRuns(snapshot); renderInfrastructure(snapshot);
-    const applicable = snapshot.cells.filter(cell => cell.applicability === 'applicable');
+    const scoped = scopeSnapshot(snapshot);
+    renderCoverage(scoped); renderMatrix(scoped); renderRuns(scoped); renderInfrastructure(scoped);
+    const applicable = scoped.cells.filter(cell => cell.applicability === 'applicable');
     const blocked = applicable.filter(cell => cell.status === 'blocked').length;
     const failed = applicable.filter(cell => cell.status === 'failed').length;
     const unavailable = applicable.filter(cell => cell.status === 'unavailable').length;
     const technicalReady = applicable.filter(cell => cell.technical_status === 'ready' || cell.status === 'ready').length;
     const mixedTechnicalState = technicalReady > 0 && (blocked || failed || unavailable);
-    const overallText = mixedTechnicalState && snapshot.status === 'failed' && blocked && !failed
+    const overallText = mixedTechnicalState && scoped.status === 'failed' && blocked && !failed
       ? '总体状态：部分可用（含授权阻塞）'
-      : snapshot.status === 'failed' && blocked && !failed
+      : scoped.status === 'failed' && blocked && !failed
         ? '总体状态：授权阻塞'
-        : `总体状态：${statusText(snapshot.status)}`;
+        : `总体状态：${statusText(scoped.status)}`;
     document.getElementById('overall').textContent = overallText;
-    document.getElementById('snapshot-meta').textContent = `数据时间 ${fmtTime(snapshot.as_of)} · 自动读取间隔 30 秒 · 请求上限 10 秒`;
-    if (snapshot.status === 'failed') {
+    document.getElementById('snapshot-meta').textContent = `数据时间 ${fmtTime(scoped.as_of)} · 自动读取间隔 30 秒 · 请求上限 10 秒`;
+    if (scoped.status === 'failed') {
       if (blocked && !failed && technicalReady) {
         const details = [`已有 ${technicalReady} 个单元格有技术数据`, `${blocked} 个单元格因授权未核实`];
         if (unavailable) details.push(`${unavailable} 个单元格暂无数据`);
@@ -294,7 +334,7 @@ async def health_ui() -> str:
       }
       else if (blocked) showBanner(`当前有 ${failed} 个采集失败单元格和 ${blocked} 个授权阻塞单元格，请分别查看详情`, 'error');
       else showBanner(`当前有 ${failed} 个采集失败单元格，请查看矩阵详情`, 'error');
-    } else if (snapshot.status === 'partial') {
+    } else if (scoped.status === 'partial') {
       showBanner('数据源存在过期、部分或不可用单元格，请查看覆盖概览', 'warn');
     } else {
       hideBanner();
@@ -356,7 +396,7 @@ async def health_ui() -> str:
     document.getElementById('dataset-filter-wrap').hidden = true;
   }
   ['search','dataset-filter','market-filter','timeframe-filter','filter'].forEach(id => {
-    document.getElementById(id).addEventListener(id === 'search' ? 'input' : 'change', () => { if (latestSnapshot) renderMatrix(latestSnapshot); });
+    document.getElementById(id).addEventListener(id === 'search' ? 'input' : 'change', () => { if (latestSnapshot) render(latestSnapshot); });
   });
   document.getElementById('close-drawer').addEventListener('click', closeDetail);
   document.getElementById('drawer-backdrop').addEventListener('click', event => { if (event.target.id === 'drawer-backdrop') closeDetail(); });

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -34,6 +34,9 @@ async def health_ui() -> str:
     p { margin:0; color:var(--muted) }
     .header-meta { min-width:230px; text-align:right; color:var(--muted); font-size:12px }
     .header-meta strong { display:block; color:var(--text); font-size:14px; margin-bottom:4px }
+    .view-switch { display:flex; gap:8px; margin-top:12px }
+    .view-switch a { border:1px solid var(--line); border-radius:7px; padding:6px 9px; color:var(--muted); text-decoration:none; font-size:12px }
+    .view-switch a:hover { border-color:var(--accent); color:var(--text) }
     .banner { position:sticky; top:10px; z-index:5; display:none; margin:0 0 18px;
       padding:12px 14px; border:1px solid #71404a; border-radius:10px; background:#321b25; color:#ffdce1; }
     .banner.warn { border-color:#80652d; background:#332c18; color:#ffe5a5; }
@@ -110,6 +113,7 @@ async def health_ui() -> str:
 <main>
   <header>
     <div><div class="eyebrow">市场数据管线 / 运行监控</div><h1>资产 × 时间级别健康矩阵</h1>
+      <nav class="view-switch" aria-label="数据视图"><a href="/health-ui">Screening 观察</a><a href="/health-ui?view=combined">Watchlist + Screening</a></nav>
       <p>只读查看最近一次持久化运行、数据质量和覆盖情况。页面每 30 秒自动读取。</p></div>
     <div class="header-meta"><strong id="overall">等待首次读取</strong><span id="last-success">尚未取得成功快照</span></div>
   </header>
@@ -136,7 +140,8 @@ async def health_ui() -> str:
 
 <script>
 (() => {
-  const API = '/api/mvp/health/matrix';
+  const VIEW = new URLSearchParams(window.location.search).get('view') || 'screening';
+  const API = VIEW === 'combined' ? '/api/health/combined-matrix' : '/api/mvp/health/matrix';
   const POLL_MS = 30000;
   const TIMEOUT_MS = 10000;
   const MAX_SNAPSHOT_MS = 900000;
@@ -181,10 +186,20 @@ async def health_ui() -> str:
       const details = [blocked ? `阻塞 ${blocked}` : '', failed ? `失败 ${failed}` : '', problem ? `其他需关注 ${problem}` : ''].filter(Boolean).join(' · ') || '没有异常单元格';
       return `<article class="card coverage-card"><div class="label">${timeframeLabels[tf]}</div><div class="ratio"><strong>${ratio}%</strong><span>${dataReady}/${applicable} 有数据</span></div><div class="counts">${details} · 正常 ${ready} · 不适用 ${Number(item.not_applicable || 0)} 个</div><div class="progress"><i style="width:${ratio}%"></i></div></article>`;
     }).join('');
-    document.getElementById('coverage-meta').textContent = `共 ${fmtCount(snapshot.cells.length)} 个单元格 · 清单 ${esc(snapshot.manifest_version)}`;
+    const manifestMeta = snapshot.manifest_versions
+      ? `Screening ${esc(snapshot.manifest_versions.screening)} + Watchlist ${esc(snapshot.manifest_versions.watchlist)}`
+      : `清单 ${esc(snapshot.manifest_version)}`;
+    document.getElementById('coverage-meta').textContent = `共 ${fmtCount(snapshot.cells.length)} 个单元格 · ${manifestMeta}`;
   }
 
-  const universeFor = cell => cell.asset_class === 'a_share' ? 'a_share' : cell.asset_class === 'us_stock' ? 'us_stock' : 'cross_market';
+  const universeFor = cell => {
+    if (cell.universe === 'watchlist') {
+      if (String(cell.instrument_id || '').startsWith('WATCH.CROSS.')) return 'cross_market';
+      if (String(cell.instrument_id || '').startsWith('WATCH.CN.')) return 'a_share';
+      if (String(cell.instrument_id || '').startsWith('WATCH.US.') || String(cell.instrument_id || '').startsWith('WATCH.KR.')) return 'us_stock';
+    }
+    return cell.asset_class === 'a_share' ? 'a_share' : cell.asset_class === 'us_stock' ? 'us_stock' : 'cross_market';
+  };
 
   function renderMatrix(snapshot) {
     const query = document.getElementById('search').value.trim().toLowerCase();
@@ -235,11 +250,15 @@ async def health_ui() -> str:
     const infra = snapshot.infrastructure || {};
     const worker = infra.worker || snapshot.worker || {};
     const database = infra.database || {};
+    const databases = infra.databases || {};
     const backup = infra.nas_backup || {};
     const label = value => value === 'ready' || value === 'ok' || value === 'last_run' ? '正常' : statusText(value || 'unavailable');
+    const databaseItems = Object.keys(databases).length
+      ? Object.entries(databases).map(([name, item]) => [name === 'market_data' ? 'Market Data 数据库' : 'Screening 数据库', label(item.status), '只读 SQLite（路径已隐藏）'])
+      : [['本地数据库', label(database.status), database.filesystem === 'local' ? '本地 SQLite（路径已隐藏）' : '路径已隐藏']];
     document.getElementById('infrastructure').innerHTML = [
       ['采集任务', label(worker.status), worker.last_success_at ? `上次成功 ${fmtTime(worker.last_success_at)}` : '尚无成功运行'],
-      ['本地数据库', label(database.status), database.filesystem === 'local' ? '本地 SQLite（路径已隐藏）' : '路径已隐藏'],
+      ...databaseItems,
       ['SSD 挂载保护', label((infra.ssd_mount_guard || {}).status), '仅展示保护状态'],
       ['NAS 备份', label(backup.status), backup.last_backup_at ? `上次备份 ${fmtTime(backup.last_backup_at)}` : '尚无备份证据']
     ].map(item => `<div class="infra-item"><span>${esc(item[0])}<br><small>${esc(item[2])}</small></span><strong>${esc(item[1])}</strong></div>`).join('');
@@ -285,7 +304,7 @@ async def health_ui() -> str:
       ['来源标识', cell.source_id], ['供应商代码', cell.provider_symbol], ['来源模式', cell.source_mode],
       ['最近收盘', cell.latest_closed_timestamp ? fmtTime(cell.latest_closed_timestamp) : null], ['存储行数', fmtCount(cell.row_count)],
       ['是否聚合', cell.is_derived == null ? null : (cell.is_derived ? '是' : '否')], ['最近尝试', fmtTime(cell.last_attempt_at)],
-      ['最近成功', fmtTime(cell.last_success_at)], ['质量', cell.quality], ['水位', cell.watermark], ['转换凭证', cell.transform], ['策略信息', cell.policy], ['错误', cell.error]
+      ['最近成功', fmtTime(cell.last_success_at)], ['资产元数据', cell.metadata], ['质量', cell.quality], ['水位', cell.watermark], ['转换凭证', cell.transform], ['策略信息', cell.policy], ['错误', cell.error]
     ];
     document.getElementById('drawer-title').textContent = `${cell.display_symbol || '资产'} · ${timeframeLabels[cell.timeframe] || cell.timeframe}`;
     document.getElementById('detail-list').innerHTML = rows.map(([key,value]) => `<dt>${esc(key)}</dt><dd>${value && typeof value === 'object' ? `<code>${esc(JSON.stringify(value,null,2))}</code>` : esc(value)}</dd>`).join('');

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -120,6 +120,7 @@ async def health_ui() -> str:
   <div id="banner" class="banner" role="status"><i class="dot"></i><span id="banner-text"></span></div>
   <div class="toolbar"><span id="snapshot-meta">正在连接健康矩阵…</span>
     <label><span>搜索：</span><input id="search" aria-label="搜索" type="search" placeholder="代码或名称" autocomplete="off"></label>
+    <label><span>数据集：</span><select id="dataset-filter" aria-label="数据集"><option value="all">全部数据</option><option value="screening">Screening</option><option value="watchlist">Watchlist</option></select></label>
     <label><span>市场：</span><select id="market-filter" aria-label="市场"><option value="all">全部市场</option><option value="a_share">A 股</option><option value="us_stock">美股</option><option value="cross_market">跨市场</option></select></label>
     <label><span>时间级别：</span><select id="timeframe-filter" aria-label="时间级别"><option value="all">全部级别</option><option value="15m">15 分钟</option><option value="1h">1 小时</option><option value="4h">4 小时</option><option value="1d">日线</option><option value="1w">周线</option></select></label>
     <label><span>状态：</span><select id="filter" aria-label="状态"><option value="all">全部状态</option><option value="ready">正常</option><option value="partial">部分</option><option value="stale">过期</option><option value="failed">失败</option><option value="blocked">阻塞</option><option value="unavailable">不可用</option><option value="not_applicable">不适用</option></select></label></div>
@@ -150,6 +151,8 @@ async def health_ui() -> str:
   const statusLabels = {ready:'正常',partial:'部分',stale:'过期',failed:'失败',blocked:'阻塞',unavailable:'不可用',not_applicable:'不适用'};
   const reasonLabels = {entitlement_blocked:'授权未核实',entitlement_unverified:'授权未核实',entitlement_expired:'授权已过期',persistence_not_allowed:'不允许持久化',derived_not_allowed:'不允许派生',timeframe_not_permitted:'级别未授权',timeframe_permission_unverified:'级别授权未核实'};
   const universeLabels = {a_share:'A 股',us_stock:'美股',cross_market:'跨市场'};
+  const queryParams = new URLSearchParams(window.location.search);
+  const initialDataset = queryParams.get('dataset') || 'all';
   let latestSnapshot = null;
   let latestReceivedAt = 0;
   let loading = false;
@@ -204,13 +207,14 @@ async def health_ui() -> str:
   function renderMatrix(snapshot) {
     const query = document.getElementById('search').value.trim().toLowerCase();
     const market = document.getElementById('market-filter').value;
+    const dataset = document.getElementById('dataset-filter').value;
     const timeframeFilter = document.getElementById('timeframe-filter').value;
     const statusFilter = document.getElementById('filter').value;
     const grouped = new Map();
     snapshot.cells.forEach(cell => {
       const universe = universeFor(cell);
       const matchesText = !query || `${cell.display_symbol || ''} ${cell.display_name || ''}`.toLowerCase().includes(query);
-      if (!matchesText || (market !== 'all' && universe !== market) || (statusFilter !== 'all' && cell.status !== statusFilter)) return;
+      if (!matchesText || (dataset !== 'all' && cell.dataset !== dataset) || (market !== 'all' && universe !== market) || (statusFilter !== 'all' && cell.status !== statusFilter)) return;
       const key = cell.instrument_id || cell.display_symbol;
       if (!grouped.has(universe)) grouped.set(universe, new Map());
       if (!grouped.get(universe).has(key)) grouped.get(universe).set(key, {symbol:cell.display_symbol, name:cell.display_name, cells:{}});
@@ -344,7 +348,8 @@ async def health_ui() -> str:
     } finally { clearTimeout(timeout); loading = false; }
   }
 
-  ['search','market-filter','timeframe-filter','filter'].forEach(id => {
+  if (['all','screening','watchlist'].includes(initialDataset)) document.getElementById('dataset-filter').value = initialDataset;
+  ['search','dataset-filter','market-filter','timeframe-filter','filter'].forEach(id => {
     document.getElementById(id).addEventListener(id === 'search' ? 'input' : 'change', () => { if (latestSnapshot) renderMatrix(latestSnapshot); });
   });
   document.getElementById('close-drawer').addEventListener('click', closeDetail);

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -120,7 +120,7 @@ async def health_ui() -> str:
   <div id="banner" class="banner" role="status"><i class="dot"></i><span id="banner-text"></span></div>
   <div class="toolbar"><span id="snapshot-meta">正在连接健康矩阵…</span>
     <label><span>搜索：</span><input id="search" aria-label="搜索" type="search" placeholder="代码或名称" autocomplete="off"></label>
-    <label><span>数据集：</span><select id="dataset-filter" aria-label="数据集"><option value="all">全部数据</option><option value="screening">Screening</option><option value="watchlist">Watchlist</option></select></label>
+    <label id="dataset-filter-wrap"><span>数据集：</span><select id="dataset-filter" aria-label="数据集"><option value="all">全部数据</option><option value="screening">Screening</option><option value="watchlist">Watchlist</option></select></label>
     <label><span>市场：</span><select id="market-filter" aria-label="市场"><option value="all">全部市场</option><option value="a_share">A 股</option><option value="us_stock">美股</option><option value="cross_market">跨市场</option></select></label>
     <label><span>时间级别：</span><select id="timeframe-filter" aria-label="时间级别"><option value="all">全部级别</option><option value="15m">15 分钟</option><option value="1h">1 小时</option><option value="4h">4 小时</option><option value="1d">日线</option><option value="1w">周线</option></select></label>
     <label><span>状态：</span><select id="filter" aria-label="状态"><option value="all">全部状态</option><option value="ready">正常</option><option value="partial">部分</option><option value="stale">过期</option><option value="failed">失败</option><option value="blocked">阻塞</option><option value="unavailable">不可用</option><option value="not_applicable">不适用</option></select></label></div>
@@ -348,7 +348,13 @@ async def health_ui() -> str:
     } finally { clearTimeout(timeout); loading = false; }
   }
 
-  if (['all','screening','watchlist'].includes(initialDataset)) document.getElementById('dataset-filter').value = initialDataset;
+  const datasetFilter = document.getElementById('dataset-filter');
+  if (VIEW === 'combined' && ['all','screening','watchlist'].includes(initialDataset)) {
+    datasetFilter.value = initialDataset;
+  } else if (VIEW !== 'combined') {
+    datasetFilter.value = 'all';
+    document.getElementById('dataset-filter-wrap').hidden = true;
+  }
   ['search','dataset-filter','market-filter','timeframe-filter','filter'].forEach(id => {
     document.getElementById(id).addEventListener(id === 'search' ? 'input' : 'change', () => { if (latestSnapshot) renderMatrix(latestSnapshot); });
   });

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -32,7 +32,7 @@ from kline.provenance import (
     fred_source_manifest,
     PHASE1_SOURCE_REGISTRY_VERSION,
 )
-from kline.store import KlineStore
+from kline.store import KlineReadOnlyStore, KlineStore
 
 _store: KlineStore | None = None
 _settings: Settings | None = None
@@ -47,9 +47,11 @@ def init(settings: Settings | None = None) -> None:
     global _store, _providers, _live_providers, _adapters, _settings
     s = settings or get_settings()
     _settings = s
-    ensure_data_dir(s)
-
-    _store = KlineStore(s.db_path)
+    if s.read_only:
+        _store = KlineReadOnlyStore(s.db_path)
+    else:
+        ensure_data_dir(s)
+        _store = KlineStore(s.db_path)
     _providers = {}
     _live_providers = {}
     _adapters = {}

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -1458,5 +1458,28 @@ class KlineReadOnlyStore(KlineStore):
             echo=False,
             connect_args={"uri": True},
         )
+        event.listen(self._engine, "connect", self._enable_query_only)
         self._mvp_commit_failpoint = None
         self._session_factory = sessionmaker(bind=self._engine)
+
+    @staticmethod
+    def _enable_query_only(dbapi_conn, _connection_record) -> None:
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA query_only=ON")
+        cursor.close()
+
+    @staticmethod
+    def _write_blocked(operation: str) -> None:
+        raise StorageError(f"read-only store forbids {operation}")
+
+    def save(self, *_args: Any, **_kwargs: Any) -> int:
+        self._write_blocked("save")
+
+    def save_raw_response(self, **_kwargs: Any) -> int:
+        self._write_blocked("save_raw_response")
+
+    def save_source_observation(self, **_kwargs: Any) -> int:
+        self._write_blocked("save_source_observation")
+
+    def commit_mvp_run(self, _write: MvpRunWrite) -> MvpRunReceipt:
+        self._write_blocked("commit_mvp_run")

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import hashlib
 import json
+from pathlib import Path
 from typing import Any, Sequence
+from urllib.parse import quote
 
 from sqlalchemy import create_engine, event, func, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -1441,3 +1443,20 @@ class KlineStore:
             "candle_rows": candle_rows,
             "source_count": source_rows,
         }
+
+
+class KlineReadOnlyStore(KlineStore):
+    """Open an existing SQLite database without schema, WAL, or migration writes."""
+
+    def __init__(self, db_path: str) -> None:
+        path = Path(db_path).expanduser().resolve()
+        if not path.is_file():
+            raise StorageError(f"read-only database does not exist: {path}")
+        encoded = quote(str(path), safe="/")
+        self._engine = create_engine(
+            f"sqlite:///file:{encoded}?mode=ro&uri=true",
+            echo=False,
+            connect_args={"uri": True},
+        )
+        self._mvp_commit_failpoint = None
+        self._session_factory = sessionmaker(bind=self._engine)

--- a/src/kline/time_utils.py
+++ b/src/kline/time_utils.py
@@ -1,0 +1,20 @@
+"""Shared timestamp parsing helpers for read-only health views."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def parse_utc_timestamp(value: Any) -> datetime | None:
+    """Parse an ISO timestamp and normalize it to UTC; invalid values return None."""
+
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/tests/test_combined_health.py
+++ b/tests/test_combined_health.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from kline.app import create_app
+from kline.combined_health import build_combined_health_matrix
+from kline.store import KlineStore
+
+
+def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) -> None:
+    snapshot = build_combined_health_matrix(
+        screening_store=KlineStore(str(tmp_path / "screening.db")),
+        market_store=KlineStore(str(tmp_path / "market.db")),
+        now=datetime(2026, 9, 3, 12, tzinfo=timezone.utc),
+    )
+
+    assert snapshot["scope"] == {
+        "name": "screening_watchlist",
+        "instrument_count": 274,
+        "universes": {"a_share": 100, "us_stock": 100, "cross_market": 16, "watchlist": 58},
+    }
+    assert len(snapshot["cells"]) == 274 * 5
+    watchlist_cells = [cell for cell in snapshot["cells"] if cell["instrument_id"].startswith("WATCH.")]
+    assert len(watchlist_cells) == 58 * 5
+    assert {cell["universe"] for cell in watchlist_cells} == {"watchlist"}
+    spx = next(cell for cell in watchlist_cells if cell["instrument_id"] == "WATCH.CROSS.SPX" and cell["timeframe"] == "1d")
+    assert spx["provider_symbol"] == "SPY"
+    assert spx["source_id"] == "yahoo_finance_etf"
+    assert spx["metadata"]["identity_role"] == "proxy"
+    assert snapshot["manifest_versions"] == {
+        "screening": "mvp_universe_v1",
+        "watchlist": "watchlist_universe_v1",
+    }
+    for timeframe, counts in snapshot["coverage"].items():
+        assert counts["applicable"] + counts["not_applicable"] == 274
+
+
+def test_combined_health_api_reads_market_database_without_replacing_screening(
+    monkeypatch, tmp_path
+) -> None:
+    screening_db = tmp_path / "screening-api.db"
+    market_db = tmp_path / "market-api.db"
+    monkeypatch.setenv("KLINE_DB_PATH", str(screening_db))
+    monkeypatch.setenv("KLINE_MARKET_DB_PATH", str(market_db))
+    monkeypatch.setenv("KLINE_LOAD_ENTRYPOINT_ADAPTERS", "false")
+
+    with TestClient(create_app()) as client:
+        response = client.get("/api/health/combined-matrix")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["scope"]["name"] == "screening_watchlist"
+    assert payload["manifest_versions"]["watchlist"] == "watchlist_universe_v1"
+    assert len(payload["cells"]) == 274 * 5

--- a/tests/test_combined_health.py
+++ b/tests/test_combined_health.py
@@ -25,6 +25,7 @@ def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) 
     watchlist_cells = [cell for cell in snapshot["cells"] if cell["instrument_id"].startswith("WATCH.")]
     assert len(watchlist_cells) == 58 * 5
     assert {cell["universe"] for cell in watchlist_cells} == {"watchlist"}
+    assert {cell["dataset"] for cell in watchlist_cells} == {"watchlist"}
     spx = next(cell for cell in watchlist_cells if cell["instrument_id"] == "WATCH.CROSS.SPX" and cell["timeframe"] == "1d")
     assert spx["provider_symbol"] == "SPY"
     assert spx["source_id"] == "yahoo_finance_etf"

--- a/tests/test_combined_health.py
+++ b/tests/test_combined_health.py
@@ -6,13 +6,82 @@ from fastapi.testclient import TestClient
 
 from kline.app import create_app
 from kline.combined_health import build_combined_health_matrix
+from kline.storage import (
+    CandleSeriesKey,
+    MvpCandle,
+    MvpRunWrite,
+    QualityReceiptWrite,
+    SourceObservationWrite,
+    WatermarkWrite,
+)
 from kline.store import KlineStore
 
 
+def _seed_watchlist_spx(store: KlineStore) -> None:
+    key = CandleSeriesKey(
+        instrument_id="WATCH.CROSS.SPX",
+        display_symbol="SPX",
+        provider_symbol="SPY",
+        source_id="yahoo_finance_etf",
+        asset_class="etf",
+        timeframe="1d",
+        adjustment_basis="raw_unadjusted",
+        manifest_version="watchlist_universe_v1",
+    )
+    candle = MvpCandle(
+        key=key,
+        timestamp="2026-09-02T00:00:00+00:00",
+        open=100,
+        high=102,
+        low=99,
+        close=101,
+        volume=1000,
+    )
+    store.commit_mvp_run(
+        MvpRunWrite(
+            run_id="watchlist-spx-test",
+            manifest_version=key.manifest_version,
+            manifest_hash="a" * 64,
+            started_at="2026-09-03T07:00:00+00:00",
+            completed_at="2026-09-03T07:01:00+00:00",
+            window_start=None,
+            window_end="2026-09-03T07:00:00+00:00",
+            policy={"runner": "fixture"},
+            candles=(candle,),
+            source_observations=(
+                SourceObservationWrite(
+                    run_id="watchlist-spx-test",
+                    key=key,
+                    success=True,
+                    request_start=None,
+                    request_end="2026-09-03T07:00:00+00:00",
+                    response_hash="b" * 64,
+                    candle_count=1,
+                    latest_timestamp=candle.timestamp,
+                    observed_at="2026-09-03T07:01:00+00:00",
+                ),
+            ),
+            quality_receipts=(
+                QualityReceiptWrite(run_id="watchlist-spx-test", key=key, status="pass"),
+            ),
+            watermarks=(
+                WatermarkWrite(
+                    key=key,
+                    last_closed_timestamp=candle.timestamp,
+                    cursor=None,
+                    run_id="watchlist-spx-test",
+                ),
+            ),
+        )
+    )
+
+
 def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) -> None:
+    market_store = KlineStore(str(tmp_path / "market.db"))
+    _seed_watchlist_spx(market_store)
     snapshot = build_combined_health_matrix(
         screening_store=KlineStore(str(tmp_path / "screening.db")),
-        market_store=KlineStore(str(tmp_path / "market.db")),
+        market_store=market_store,
         now=datetime(2026, 9, 3, 12, tzinfo=timezone.utc),
     )
 
@@ -30,6 +99,11 @@ def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) 
     assert spx["provider_symbol"] == "SPY"
     assert spx["source_id"] == "yahoo_finance_etf"
     assert spx["metadata"]["identity_role"] == "proxy"
+    assert spx["latest_closed_timestamp"] == "2026-09-02T00:00:00+00:00"
+    assert spx["technical_status"] == "ready"
+    assert spx["status"] == "partial"
+    assert spx["quality"]["status"] == "pass"
+    assert spx["watermark"]["run_id"] == "watchlist-spx-test"
     assert snapshot["manifest_versions"] == {
         "screening": "mvp_universe_v1",
         "watchlist": "watchlist_universe_v1",
@@ -43,9 +117,12 @@ def test_combined_health_api_reads_market_database_without_replacing_screening(
 ) -> None:
     screening_db = tmp_path / "screening-api.db"
     market_db = tmp_path / "market-api.db"
+    KlineStore(str(screening_db))
+    KlineStore(str(market_db))
     monkeypatch.setenv("KLINE_DB_PATH", str(screening_db))
     monkeypatch.setenv("KLINE_MARKET_DB_PATH", str(market_db))
     monkeypatch.setenv("KLINE_LOAD_ENTRYPOINT_ADAPTERS", "false")
+    monkeypatch.setenv("KLINE_READ_ONLY", "true")
 
     with TestClient(create_app()) as client:
         response = client.get("/api/health/combined-matrix")

--- a/tests/test_health_dashboard_launchd.py
+++ b/tests/test_health_dashboard_launchd.py
@@ -22,6 +22,7 @@ def test_combined_health_dashboard_launchd_isolated_from_screening_worker() -> N
     assert environment["KLINE_BUILD_SHA"] == "__KLINE_BUILD_SHA__"
     assert environment["KLINE_DB_PATH"].endswith("datafeed-runtime-issue-71/data/kline.db")
     assert environment["KLINE_MARKET_DB_PATH"] == "/Users/wendy/park-data/market/kline.db"
+    assert environment["KLINE_READ_ONLY"] == "true"
     assert payload["RunAtLoad"] is True
     assert payload["KeepAlive"] is True
     assert payload["StandardOutPath"].endswith("/health-dashboard.stdout.log")

--- a/tests/test_health_dashboard_launchd.py
+++ b/tests/test_health_dashboard_launchd.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import plistlib
+
+
+PLIST_PATH = (
+    Path(__file__).parents[1] / "ops" / "com.wendy.datafeed.health-dashboard.plist.example"
+)
+RUNTIME = "/Users/wendy/datafeed-runtime-health-dashboard"
+
+
+def test_combined_health_dashboard_launchd_isolated_from_screening_worker() -> None:
+    with PLIST_PATH.open("rb") as handle:
+        payload = plistlib.load(handle)
+
+    assert payload["Label"] == "com.wendy.datafeed.health-dashboard"
+    assert payload["WorkingDirectory"] == RUNTIME
+    arguments = payload["ProgramArguments"]
+    assert arguments[-6:] == ["--host", "127.0.0.1", "--port", "18172", "--log-level", "info"]
+    environment = payload["EnvironmentVariables"]
+    assert environment["PYTHONPATH"] == f"{RUNTIME}/src"
+    assert environment["KLINE_RUNTIME_ROOT"] == RUNTIME
+    assert environment["KLINE_BUILD_SHA"] == "__KLINE_BUILD_SHA__"
+    assert environment["KLINE_DB_PATH"].endswith("datafeed-runtime-issue-71/data/kline.db")
+    assert environment["KLINE_MARKET_DB_PATH"] == "/Users/wendy/park-data/market/kline.db"
+    assert payload["RunAtLoad"] is True
+    assert payload["KeepAlive"] is True
+    assert payload["StandardOutPath"].endswith("/health-dashboard.stdout.log")
+    assert payload["StandardErrorPath"].endswith("/health-dashboard.stderr.log")

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -11,6 +11,7 @@ def test_health_ui_is_browser_visible():
     assert "fetch(`${API}?_=${Date.now()}`" in response.text
     assert "最近一次运行" in response.text
     assert "market-filter" in response.text
+    assert "dataset-filter" in response.text
     assert "timeframe-filter" in response.text
     assert "/api/health/combined-matrix" in response.text
     assert "view=combined" in response.text

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -12,6 +12,9 @@ def test_health_ui_is_browser_visible():
     assert "最近一次运行" in response.text
     assert "market-filter" in response.text
     assert "timeframe-filter" in response.text
+    assert "/api/health/combined-matrix" in response.text
+    assert "view=combined" in response.text
+    assert "Watchlist" in response.text
     assert "data-group-toggle" in response.text
     assert "MAX_SNAPSHOT_MS = 900000" in response.text
     assert "AbortController" in response.text

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -12,6 +12,7 @@ def test_health_ui_is_browser_visible():
     assert "最近一次运行" in response.text
     assert "market-filter" in response.text
     assert "dataset-filter" in response.text
+    assert "dataset-filter-wrap').hidden = true" in response.text
     assert "timeframe-filter" in response.text
     assert "/api/health/combined-matrix" in response.text
     assert "view=combined" in response.text

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -13,6 +13,7 @@ def test_health_ui_is_browser_visible():
     assert "market-filter" in response.text
     assert "dataset-filter" in response.text
     assert "dataset-filter-wrap').hidden = true" in response.text
+    assert "function scopeSnapshot" in response.text
     assert "timeframe-filter" in response.text
     assert "/api/health/combined-matrix" in response.text
     assert "view=combined" in response.text

--- a/tests/test_read_only_store.py
+++ b/tests/test_read_only_store.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import pytest
+
+from kline.store import KlineReadOnlyStore, KlineStore, StorageError
+
+
+def test_read_only_store_rejects_missing_database_without_creating_it(tmp_path: Path) -> None:
+    path = tmp_path / "missing.db"
+
+    with pytest.raises(StorageError, match="does not exist"):
+        KlineReadOnlyStore(str(path))
+
+    assert not path.exists()
+
+
+def test_read_only_store_can_read_without_schema_or_wal_writes(tmp_path: Path) -> None:
+    path = tmp_path / "existing.db"
+    writer = KlineStore(str(path))
+    writer._engine.dispose()
+    before = path.stat().st_mtime_ns
+
+    store = KlineReadOnlyStore(str(path))
+    assert store.mvp_storage_health()["status"] == "ok"
+    assert path.stat().st_mtime_ns == before

--- a/tests/test_read_only_store.py
+++ b/tests/test_read_only_store.py
@@ -19,7 +19,18 @@ def test_read_only_store_can_read_without_schema_or_wal_writes(tmp_path: Path) -
     writer = KlineStore(str(path))
     writer._engine.dispose()
     before = path.stat().st_mtime_ns
-
     store = KlineReadOnlyStore(str(path))
     assert store.mvp_storage_health()["status"] == "ok"
     assert path.stat().st_mtime_ns == before
+    with store._engine.connect() as connection:
+        assert connection.exec_driver_sql("PRAGMA query_only").scalar_one() == 1
+
+
+def test_read_only_store_rejects_mutating_methods(tmp_path: Path) -> None:
+    path = tmp_path / "guarded.db"
+    writer = KlineStore(str(path))
+    writer._engine.dispose()
+    store = KlineReadOnlyStore(str(path))
+
+    with pytest.raises(StorageError, match="forbids save"):
+        store.save("AAPL", "us_stock", "1d", [])


### PR DESCRIPTION
## What
- Add a read-only combined health API over the isolated Screening observer DB and Market Data Database.
- Extend the Chinese health UI with a `Watchlist + Screening` view, dataset filter, and proxy metadata detail while keeping the existing Screening endpoint/page contract.
- Add an independent port-18172 launchd plist example and tests; do not touch `com.wendy.datafeed.mvp-api` or #115.
- Open both SQLite databases with `mode=ro`; missing files fail closed without schema/WAL/migration writes.

## Why
The 58 Watchlist instruments are now persisted, but the existing 18171 observer reads only the #115 Screening database, so Wendy could not see the real Watchlist health state. Directly replacing `KLINE_DB_PATH` would break the two schemas and the reliability observer.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 333 passed
- Targeted Ruff → passed
- gitleaks → no leaks found
- Real Market Data Database read-model probe: 274 assets / 1,370 cells; Watchlist 58/58 technical data present, 16 cross-market rows present with correct provider symbols.
- SHA-256 before/after real combined snapshot: both Screening DB and Market Data DB unchanged.
- Public-source entitlement uncertainty remains explicit as `部分`/stale rather than fabricated `正常`.
- Existing 18171/#115 service remains untouched; new service is isolated by label, runtime, database paths, and port.

Closes #128
