### PR TITLE
Record combined health dashboard verification

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -17,10 +17,11 @@
 - #124 修正 Yahoo 已收盘日线在 source 本地午夜前被误裁掉的问题：纽约/首尔等 source 在本地 18:00 后允许上游已发布的当前交易日，带时区 timestamp `end` 按 source timezone 解释，date-only end 继续排他。QCOM、AAPL、000660.KS 的 production-shaped 实测均返回 2026-09-02；resident 8100/#115 尚未部署此修复。证据见 `docs/verification/yahoo-post-close-daily-2026-09-03.md`。
 - #122 已将 Watchlist runner 接入独立 launchd 日历任务：工作日北京时间 07:15、无 RunAtLoad/KeepAlive、独立 runtime/lock/receipt。#124 合入后 catch-up 已实测 exit 0、42/42 current-ready，A 股/ETF 20 cells 20 次 Tencent HTTP 200、429/403/5xx/timeout 均为 0；证据见 `docs/verification/watchlist-daily-schedule-2026-09-03.md`。
 - #126 已将 #49 的 16 个非国债跨市场资产追加到 Watchlist manifest，Watchlist 现为 58 个日线成员；SPX/NDX 使用显式 SPY/QQQ proxy、DXY 使用 UUP、VIX 使用 `^VIX`，其余沿用已审定 source mapping。真实运行已将 58/58 写入 Market Data Database，限流/403/5xx/timeout 均为 0；证据见 `docs/verification/watchlist-cross-market-ingestion-2026-09-03.md`。
+- #128 已上线独立双库只读健康面板：`http://127.0.0.1:18172/health-ui?view=combined&dataset=watchlist`。Watchlist 视图真实显示 58 个资产/290 个 cell、日线 58/58 有技术数据、跨市场 16/16；Screening/Market Data 两库使用 `mode=ro + query_only`，请求前后 SHA-256 不变。18171/#115 与 resident 8100 未重启或改配置；证据见 `docs/verification/combined-health-dashboard-2026-09-03.md`。
 
 ## 下一步
 - #69 中文 3+3 Health Matrix、#70 全量 216×5 矩阵和交互、#71 可靠性 runner、#81 免费 source 路由、#83 混合状态文案、#85 剩余 97+97 批处理器、#87 美股粗粒度源调整、#89 分阶段恢复、#91 Yahoo 点号 ticker 兼容、#93 空响应终止重试、#95 fallback 404 终止重试、#97 水位倒退保护、#99 provider 硬超时、#101 免费源 HTTP 超时上限、#103 Yahoo 历史请求线程化、#105 Yahoo 修复请求线程化、#107 Yahoo ISO intraday 窗口兼容、#111 Yahoo 美股全时间级别主源已合并；真实全量股票 seed 首轮已完成，Yahoo-only 首轮已验证 100 只美股五级别，DHR 两个粗粒度格按 fail-closed 记录，A 股开盘 forming-bar partial 按规则记录，601989 仍是已知缺口；全量常驻 worker 已切换为 100+100、4 小时刷新并保持 running。美股五级别统一 Yahoo，A 股继续 Tencent→Tonghuashun；日/周优先、日内失败降级、请求间隔/重试退避、P95/限流统计、水位不倒退、provider 超时和同步请求可取消已锁定。#71 七天验收仍开放且 blocked，#54 真实 30-day database acceptance 仍未开始。
 - 继续保持 provider/entitlement/quality 状态显式；不要把 preflight technical availability 当成持久化授权或 verified。
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。
 - 完成 #115 的 24 小时调度锚点/开盘缓冲真实验收后，再按已批准顺序实施 #116；#118 不切换当前 #115 observer build，也不启动 #71 正式计时。
-- Watchlist 数据已落 persistent store；下一步是让健康面板以独立只读方式同时观察 Screening 与 Watchlist 两套 manifest，然后重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
+- Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。

--- a/decision-log.md
+++ b/decision-log.md
@@ -363,3 +363,18 @@ consumers can use without direct exchange or private SQLite access.
   `docs/verification/watchlist-cross-market-ingestion-2026-09-03.md`.
 - This work does not update #115, the Screening manifest/worker, resident 8100, or the existing
   health observer. Dashboard visibility remains a separate dual-store task.
+
+## 2026-09-03 - Observe Screening and Watchlist through an isolated read-only dashboard
+
+- #128 adds a combined health read model while keeping the existing Screening matrix endpoint and
+  18171 service unchanged. Screening and Watchlist remain separate datasets and separate SQLite
+  files; the dashboard merges only their redacted read models.
+- Both combined-route stores are forced through SQLite `mode=ro` plus `query_only`, fail closed when
+  a configured database is missing, and reject public mutation methods. The dedicated launchd
+  service runs on 18172 from `main@ded8741`.
+- The Watchlist-filtered page shows 58 assets / 290 cells: A-share/ETF 20, US/KR 22, cross-market
+  16. Daily technical coverage is 58/58; all other Watchlist timeframes are explicitly
+  `not_applicable`. Public-source entitlement uncertainty remains `partial`, not fabricated ready.
+- A real API read left both database SHA-256 hashes unchanged. Resident 8100 and both #115 services
+  retained their original PID, build, and runtime. See
+  `docs/verification/combined-health-dashboard-2026-09-03.md`.

--- a/docs/verification/combined-health-dashboard-2026-09-03.md
+++ b/docs/verification/combined-health-dashboard-2026-09-03.md
@@ -1,0 +1,84 @@
+# Screening + Watchlist 双库健康面板运行证据 — 2026-09-03
+
+## 部署合同
+
+- Implementation issue / PR: #128 / #129
+- Evidence issue: #130
+- Merged build: `ded8741e2cf29cc710f65f4e468fc082d517462f`
+- URL: `http://127.0.0.1:18172/health-ui?view=combined&dataset=watchlist`
+- API: `GET /api/health/combined-matrix`
+- launchd label: `com.wendy.datafeed.health-dashboard`
+- Runtime: `/Users/wendy/datafeed-runtime-health-dashboard`
+- PID at verification: `47065`
+- Plist backup: `/Users/wendy/Library/LaunchAgents/com.wendy.datafeed.health-dashboard.plist.deployed-20260903.bak`
+
+服务使用独立 port/runtime/label，并设置 `KLINE_READ_ONLY=true`。Screening 与 Market Data
+Database 分别通过 `KLINE_DB_PATH` / `KLINE_MARKET_DB_PATH` 读取；SQLite 使用 `mode=ro`
+和 `query_only`，写方法被显式拒绝。回滚方式为 bootout 此独立 label，并保留上述 plist
+备份；无需重启 #115 或 resident 8100。
+
+## 真实 API
+
+2026-09-03 16:42 CST 对 launchd 常驻服务请求，HTTP 200，约 4.18 秒：
+
+| 指标 | 实测 |
+| --- | ---: |
+| combined assets | 274 |
+| combined cells | 1,370 |
+| Screening assets | 216 |
+| Watchlist assets | 58 |
+| Watchlist cells | 290 |
+| Watchlist daily technical-ready | 58/58 |
+| Watchlist cross-market daily rows | 16/16 |
+| Screening DB status | ready |
+| Market Data DB status | ready |
+
+Watchlist 日线状态为 55 个 `partial`、3 个 `stale`。`partial` 保留公开源 entitlement 未核验
+事实；`stale` 是按市场日历算出的新鲜度结果。页面没有把技术可用伪造成授权 `ready`。
+Watchlist 的 15m/1h/4h/1w 共 232 个 cell 均显式 `not_applicable`。
+
+## 真实浏览器
+
+Codex in-app browser 对永久 18172 服务的 DOM 验证：
+
+- 页面总体状态：`部分`
+- 覆盖元信息：`共 290 个单元格 · 清单 watchlist_universe_v1`
+- 分组：A 股 20、美股/韩股 22、跨市场 16
+- 日线卡：`100% · 58/58 有数据`
+- 数据库卡：`Market Data 数据库 · 只读 SQLite · 正常`
+- Screening 页面仍显示 1,080 cells / 100 A 股 / 100 美股 / 16 跨市场，数据集筛选隐藏
+
+SPX 日线详情直接显示：
+
+- source: `yahoo_finance_etf`
+- provider symbol: `SPY`
+- metadata: `identity_role=proxy`, `proxy_for=S&P 500 Index`
+- row count: 500
+- latest closed: `2026-09-02T00:00:00+00:00`
+- quality: pass
+- watermark run: `watchlist-20260903T080126Z-005`
+
+## 只读证明
+
+同一次真实 combined API 请求前后主数据库 SHA-256：
+
+| Database | Before | After |
+| --- | --- | --- |
+| Screening | `5475fe65ff7ae83a254abeb6125833e776115604efc7870debe00c7e883cc045` | same |
+| Market Data | `2b2d5bccf20beb35b5efc4252e5794e32dcadb3295696f150aa7668bc9370749` | same |
+
+SQLite 在 WAL 模式下可能维护用于读锁的 `-shm`/空 `-wal` sidecar；本证据的只读定义是主
+数据库、schema 和业务数据未改变，且 connection/query contract 拒绝写入。
+
+## 隔离证明
+
+验证后仍为：
+
+| Service | PID | Build / runtime |
+| --- | ---: | --- |
+| `com.wendy.datafeed.mvp-api` (18171) | 878 | `3167f7d...` / issue-115 |
+| `com.wendy.datafeed.mvp-worker` | 912 | `3167f7d...` / issue-115 |
+| `com.wendy.datafeed` (8100) | 915 | `752698e...` / datafeed-runtime-live |
+
+三个 PID、build 和工作目录与 #128 部署前一致；没有修改或重启 #115/18171/8100。
+


### PR DESCRIPTION
## What
- Record the merged #128 launchd deployment, real dual-store API response, browser evidence, SPX proxy provenance, database hashes, rollback path, and #115/8100 isolation.
- Update REGISTRY and decision log to mark the combined read-only dashboard live.

## Why
#128 required durable runtime evidence after its merged build was deployed. This follow-up contains documentation only.

## Validation
- Live `http://127.0.0.1:18172/api/health/combined-matrix`: 274 assets / 1,370 cells; Watchlist 58 / 290 cells; daily technical coverage 58/58; cross-market 16/16.
- Browser Watchlist view: A股20 / 美股韩股22 / 跨市场16; daily card 100% / 58 of 58.
- Screening and Market Data DB SHA-256 unchanged before/after the real API request.
- `com.wendy.datafeed.mvp-api`, `com.wendy.datafeed.mvp-worker`, and resident 8100 retained their PID/build/runtime.

Closes #130
