### PR TITLE
Distinguish healthy unverified health cells

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -19,6 +19,7 @@
 - #126 已将 #49 的 16 个非国债跨市场资产追加到 Watchlist manifest，Watchlist 现为 58 个日线成员；SPX/NDX 使用显式 SPY/QQQ proxy、DXY 使用 UUP、VIX 使用 `^VIX`，其余沿用已审定 source mapping。真实运行已将 58/58 写入 Market Data Database，限流/403/5xx/timeout 均为 0；证据见 `docs/verification/watchlist-cross-market-ingestion-2026-09-03.md`。
 - #128 已上线独立双库只读健康面板：`http://127.0.0.1:18172/health-ui?view=combined&dataset=watchlist`。Watchlist 视图真实显示 58 个资产/290 个 cell、日线 58/58 有技术数据、跨市场 16/16；Screening/Market Data 两库使用 `mode=ro + query_only`，请求前后 SHA-256 不变。18171/#115 与 resident 8100 未重启或改配置；证据见 `docs/verification/combined-health-dashboard-2026-09-03.md`。
 - #132 已统一 Watchlist proxy metadata：SPX/SPY、NDX/QQQ、DXY/UUP 均使用 `identity_role=proxy + proxy_for`；VIX/^VIX 保持真实指数身份。只改 manifest/validator/test，不改历史 K 线、source 路由、provider 或 runner。
+- #133 已新增 `ready_unverified`，把“数据/质量/水位正常但免费源商业授权未认证”与真实 `partial/stale/failed/blocked` 分开。该状态计入数据健康覆盖但不冒充已认证 ready；真实质量闸和错误强度未放松。
 
 ## 下一步
 - #69 中文 3+3 Health Matrix、#70 全量 216×5 矩阵和交互、#71 可靠性 runner、#81 免费 source 路由、#83 混合状态文案、#85 剩余 97+97 批处理器、#87 美股粗粒度源调整、#89 分阶段恢复、#91 Yahoo 点号 ticker 兼容、#93 空响应终止重试、#95 fallback 404 终止重试、#97 水位倒退保护、#99 provider 硬超时、#101 免费源 HTTP 超时上限、#103 Yahoo 历史请求线程化、#105 Yahoo 修复请求线程化、#107 Yahoo ISO intraday 窗口兼容、#111 Yahoo 美股全时间级别主源已合并；真实全量股票 seed 首轮已完成，Yahoo-only 首轮已验证 100 只美股五级别，DHR 两个粗粒度格按 fail-closed 记录，A 股开盘 forming-bar partial 按规则记录，601989 仍是已知缺口；全量常驻 worker 已切换为 100+100、4 小时刷新并保持 running。美股五级别统一 Yahoo，A 股继续 Tencent→Tonghuashun；日/周优先、日内失败降级、请求间隔/重试退避、P95/限流统计、水位不倒退、provider 超时和同步请求可取消已锁定。#71 七天验收仍开放且 blocked，#54 真实 30-day database acceptance 仍未开始。
@@ -26,4 +27,4 @@
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。
 - 完成 #115 的 24 小时调度锚点/开盘缓冲真实验收后，再按已批准顺序实施 #116；#118 不切换当前 #115 observer build，也不启动 #71 正式计时。
 - Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
-- Dev Queue 下一项为 #133：在不放松质量闸的前提下，把“免费源 entitlement 未认证”与真实 stale/failed/blocked 问题分开展示；完成后才进入 #134 消费者切换。
+- Dev Queue 下一项为 #134：先枚举 Newsletter 与 Human Review 的真实运行时请求集并回帖 issue，再实施 8100 双源消费者切换、逐字节验收和切换→回滚→再验证演练。

--- a/decision-log.md
+++ b/decision-log.md
@@ -387,3 +387,15 @@ consumers can use without direct exchange or private SQLite access.
 - The validator now enforces the complete proxy metadata pair and exact target names. Existing
   candle rows are not rewritten; source IDs, provider symbols, routes, and runner behavior do not
   change.
+
+## 2026-09-03 - Separate healthy unverified data from real degradation
+
+- #133 introduces `ready_unverified` for cells whose candle, quality receipt, freshness, and
+  watermark are healthy while the public/free source lacks a separate commercial entitlement
+  receipt. The API keeps `status_reason=entitlement_unverified` and does not claim certified ready.
+- `ready_unverified` counts as data-healthy for aggregate readiness and coverage, while
+  `quality_partial`, `watermark_missing`, `transform_receipt_missing`, stale, failed, blocked, and
+  unavailable keep their existing severity and continue to degrade the overall status.
+- The Chinese UI gives `ready_unverified` its own filter, label, and visual treatment. A fully
+  healthy Watchlist can show `数据正常（授权未认证）`; mixed real problems remain partial/failed.
+- No provider, entitlement mechanism, Screening manifest/runner, or quality-gate ordering changes.

--- a/src/kline/combined_health.py
+++ b/src/kline/combined_health.py
@@ -54,7 +54,10 @@ def _merge_coverage(
             for key in counts:
                 counts[key] += int(source.get(key, 0) or 0)
         counts["ratio"] = (
-            round(counts["ready"] / counts["applicable"], 4)
+            round(
+                (counts["ready"] + counts["ready_unverified"]) / counts["applicable"],
+                4,
+            )
             if counts["applicable"]
             else None
         )

--- a/src/kline/health_matrix.py
+++ b/src/kline/health_matrix.py
@@ -14,7 +14,15 @@ from kline.time_utils import parse_utc_timestamp
 
 
 MATRIX_TIMEFRAMES = ("15m", "1h", "4h", "1d", "1w")
-MATRIX_STATUSES = ("ready", "partial", "stale", "failed", "blocked", "unavailable")
+MATRIX_STATUSES = (
+    "ready",
+    "ready_unverified",
+    "partial",
+    "stale",
+    "failed",
+    "blocked",
+    "unavailable",
+)
 MATRIX_SCOPE_DEMO = "demo_3x3"
 MATRIX_SCOPE_FULL = "full_216"
 MATRIX_SCOPE_WATCHLIST = "watchlist_58"
@@ -61,7 +69,12 @@ def _status_counts(cells: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, An
                 if cell.get("technical_status") == "ready":
                     states["technical_ready"] += 1
         states["ratio"] = (
-            round(states["ready"] / states["applicable"], 4) if states["applicable"] else None
+            round(
+                (states["ready"] + states["ready_unverified"]) / states["applicable"],
+                4,
+            )
+            if states["applicable"]
+            else None
         )
         coverage[timeframe] = states
     return coverage
@@ -655,7 +668,7 @@ def build_mvp_health_matrix(
                 and entitlement is None
                 and instrument.source_id in free_source_ids
             ):
-                status, reason = "partial", "entitlement_unverified"
+                status, reason = "ready_unverified", "entitlement_unverified"
             cells.append(
                 _cell(
                     instrument,

--- a/src/kline/health_ui.py
+++ b/src/kline/health_ui.py
@@ -79,6 +79,7 @@ async def health_ui() -> str:
     .cell .state { font-weight:700; font-size:12px }
     .cell .age { color:var(--muted); font-size:11px; margin-top:3px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
     .cell.ready { background:#103126; color:#bff4d9 }
+    .cell.ready_unverified { background:#10302d; color:#b9eee5; border-color:#2f6f67; border-style:dashed }
     .cell.partial { background:#332c18; color:#ffe5a5 }
     .cell.stale { background:#332718; color:#ffd0a0 }
     .cell.failed, .cell.blocked, .cell.unavailable { background:#351c25; color:#ffd0d6 }
@@ -123,7 +124,7 @@ async def health_ui() -> str:
     <label id="dataset-filter-wrap"><span>数据集：</span><select id="dataset-filter" aria-label="数据集"><option value="all">全部数据</option><option value="screening">Screening</option><option value="watchlist">Watchlist</option></select></label>
     <label><span>市场：</span><select id="market-filter" aria-label="市场"><option value="all">全部市场</option><option value="a_share">A 股</option><option value="us_stock">美股</option><option value="cross_market">跨市场</option></select></label>
     <label><span>时间级别：</span><select id="timeframe-filter" aria-label="时间级别"><option value="all">全部级别</option><option value="15m">15 分钟</option><option value="1h">1 小时</option><option value="4h">4 小时</option><option value="1d">日线</option><option value="1w">周线</option></select></label>
-    <label><span>状态：</span><select id="filter" aria-label="状态"><option value="all">全部状态</option><option value="ready">正常</option><option value="partial">部分</option><option value="stale">过期</option><option value="failed">失败</option><option value="blocked">阻塞</option><option value="unavailable">不可用</option><option value="not_applicable">不适用</option></select></label></div>
+    <label><span>状态：</span><select id="filter" aria-label="状态"><option value="all">全部状态</option><option value="ready">正常（已认证）</option><option value="ready_unverified">数据正常·授权未认证</option><option value="partial">部分（数据问题）</option><option value="stale">过期</option><option value="failed">失败</option><option value="blocked">阻塞</option><option value="unavailable">不可用</option><option value="not_applicable">不适用</option></select></label></div>
 
   <section><div class="section-head"><h2>覆盖概览</h2><small id="coverage-meta">—</small></div><div id="coverage" class="coverage-grid"></div></section>
 
@@ -148,7 +149,7 @@ async def health_ui() -> str:
   const MAX_SNAPSHOT_MS = 900000;
   const timeframes = ['15m','1h','4h','1d','1w'];
   const timeframeLabels = {'15m':'15 分钟','1h':'1 小时','4h':'4 小时','1d':'日线','1w':'周线'};
-  const statusLabels = {ready:'正常',partial:'部分',stale:'过期',failed:'失败',blocked:'阻塞',unavailable:'不可用',not_applicable:'不适用'};
+  const statusLabels = {ready:'正常',ready_unverified:'数据正常·授权未认证',partial:'部分',stale:'过期',failed:'失败',blocked:'阻塞',unavailable:'不可用',not_applicable:'不适用'};
   const reasonLabels = {entitlement_blocked:'授权未核实',entitlement_unverified:'授权未核实',entitlement_expired:'授权已过期',persistence_not_allowed:'不允许持久化',derived_not_allowed:'不允许派生',timeframe_not_permitted:'级别未授权',timeframe_permission_unverified:'级别授权未核实'};
   const universeLabels = {a_share:'A 股',us_stock:'美股',cross_market:'跨市场'};
   const queryParams = new URLSearchParams(window.location.search);
@@ -168,18 +169,18 @@ async def health_ui() -> str:
     return data.cells.every(cell => timeframes.includes(cell.timeframe) && ['applicable','not_applicable'].includes(cell.applicability) && Object.prototype.hasOwnProperty.call(statusLabels, cell.status));
   };
   function coverageFromCells(cells) {
-    const statuses = ['ready','partial','stale','failed','blocked','unavailable'];
+    const statuses = ['ready','ready_unverified','partial','stale','failed','blocked','unavailable'];
     return Object.fromEntries(timeframes.map(tf => {
-      const counts = {applicable:0,not_applicable:0,technical_ready:0,ready:0,partial:0,stale:0,failed:0,blocked:0,unavailable:0};
+      const counts = {applicable:0,not_applicable:0,technical_ready:0,ready:0,ready_unverified:0,partial:0,stale:0,failed:0,blocked:0,unavailable:0};
       cells.filter(cell => cell.timeframe === tf).forEach(cell => {
         if (cell.applicability === 'not_applicable') counts.not_applicable += 1;
         else {
           counts.applicable += 1;
           if (statuses.includes(cell.status)) counts[cell.status] += 1;
-          if (cell.technical_status === 'ready' || cell.status === 'ready') counts.technical_ready += 1;
+          if (cell.technical_status === 'ready' || ['ready','ready_unverified'].includes(cell.status)) counts.technical_ready += 1;
         }
       });
-      counts.ratio = counts.applicable ? counts.ready / counts.applicable : null;
+      counts.ratio = counts.applicable ? (counts.ready + counts.ready_unverified) / counts.applicable : null;
       return [tf, counts];
     }));
   }
@@ -220,13 +221,14 @@ async def health_ui() -> str:
       const item = snapshot.coverage[tf] || {};
       const applicable = Number(item.applicable || 0);
       const ready = Number(item.ready || 0);
+      const readyUnverified = Number(item.ready_unverified || 0);
       const dataReady = Number(item.technical_ready ?? ready);
       const ratio = applicable ? Math.round(dataReady / applicable * 100) : 0;
       const blocked = Number(item.blocked || 0);
       const failed = Number(item.failed || 0);
       const problem = ['stale','partial','unavailable'].reduce((sum, key) => sum + Number(item[key] || 0), 0);
-      const details = [blocked ? `阻塞 ${blocked}` : '', failed ? `失败 ${failed}` : '', problem ? `其他需关注 ${problem}` : ''].filter(Boolean).join(' · ') || '没有异常单元格';
-      return `<article class="card coverage-card"><div class="label">${timeframeLabels[tf]}</div><div class="ratio"><strong>${ratio}%</strong><span>${dataReady}/${applicable} 有数据</span></div><div class="counts">${details} · 正常 ${ready} · 不适用 ${Number(item.not_applicable || 0)} 个</div><div class="progress"><i style="width:${ratio}%"></i></div></article>`;
+      const details = [readyUnverified ? `数据正常·授权未认证 ${readyUnverified}` : '', blocked ? `阻塞 ${blocked}` : '', failed ? `失败 ${failed}` : '', problem ? `真实需关注 ${problem}` : ''].filter(Boolean).join(' · ') || '没有异常单元格';
+      return `<article class="card coverage-card"><div class="label">${timeframeLabels[tf]}</div><div class="ratio"><strong>${ratio}%</strong><span>${dataReady}/${applicable} 有数据</span></div><div class="counts">${details} · 已认证正常 ${ready} · 不适用 ${Number(item.not_applicable || 0)} 个</div><div class="progress"><i style="width:${ratio}%"></i></div></article>`;
     }).join('');
     const manifestMeta = snapshot.manifest_versions
       ? `Screening ${esc(snapshot.manifest_versions.screening)} + Watchlist ${esc(snapshot.manifest_versions.watchlist)}`
@@ -315,9 +317,12 @@ async def health_ui() -> str:
     const blocked = applicable.filter(cell => cell.status === 'blocked').length;
     const failed = applicable.filter(cell => cell.status === 'failed').length;
     const unavailable = applicable.filter(cell => cell.status === 'unavailable').length;
-    const technicalReady = applicable.filter(cell => cell.technical_status === 'ready' || cell.status === 'ready').length;
+    const readyUnverified = applicable.filter(cell => cell.status === 'ready_unverified').length;
+    const technicalReady = applicable.filter(cell => cell.technical_status === 'ready' || ['ready','ready_unverified'].includes(cell.status)).length;
     const mixedTechnicalState = technicalReady > 0 && (blocked || failed || unavailable);
-    const overallText = mixedTechnicalState && scoped.status === 'failed' && blocked && !failed
+    const overallText = scoped.status === 'ready' && readyUnverified
+      ? '总体状态：数据正常（授权未认证）'
+      : mixedTechnicalState && scoped.status === 'failed' && blocked && !failed
       ? '总体状态：部分可用（含授权阻塞）'
       : scoped.status === 'failed' && blocked && !failed
         ? '总体状态：授权阻塞'

--- a/tests/test_combined_health.py
+++ b/tests/test_combined_health.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 from kline.app import create_app
 from kline.combined_health import build_combined_health_matrix
+from kline.health_matrix import MATRIX_SCOPE_WATCHLIST, build_mvp_health_matrix
 from kline.storage import (
     CandleSeriesKey,
     MvpCandle,
@@ -15,13 +17,25 @@ from kline.storage import (
     WatermarkWrite,
 )
 from kline.store import KlineStore
+from kline.watchlist_manifest import load_watchlist_manifest
 
 
-def _seed_watchlist_spx(store: KlineStore) -> None:
+WATCHLIST_MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "watchlist_manifest.json"
+
+
+def _seed_watchlist_proxy(
+    store: KlineStore,
+    *,
+    instrument_id: str = "WATCH.CROSS.SPX",
+    display_symbol: str = "SPX",
+    provider_symbol: str = "SPY",
+    quality_status: str = "pass",
+) -> None:
+    run_id = f"watchlist-{display_symbol.lower()}-test"
     key = CandleSeriesKey(
-        instrument_id="WATCH.CROSS.SPX",
-        display_symbol="SPX",
-        provider_symbol="SPY",
+        instrument_id=instrument_id,
+        display_symbol=display_symbol,
+        provider_symbol=provider_symbol,
         source_id="yahoo_finance_etf",
         asset_class="etf",
         timeframe="1d",
@@ -39,7 +53,7 @@ def _seed_watchlist_spx(store: KlineStore) -> None:
     )
     store.commit_mvp_run(
         MvpRunWrite(
-            run_id="watchlist-spx-test",
+            run_id=run_id,
             manifest_version=key.manifest_version,
             manifest_hash="a" * 64,
             started_at="2026-09-03T07:00:00+00:00",
@@ -50,7 +64,7 @@ def _seed_watchlist_spx(store: KlineStore) -> None:
             candles=(candle,),
             source_observations=(
                 SourceObservationWrite(
-                    run_id="watchlist-spx-test",
+                    run_id=run_id,
                     key=key,
                     success=True,
                     request_start=None,
@@ -62,14 +76,14 @@ def _seed_watchlist_spx(store: KlineStore) -> None:
                 ),
             ),
             quality_receipts=(
-                QualityReceiptWrite(run_id="watchlist-spx-test", key=key, status="pass"),
+                QualityReceiptWrite(run_id=run_id, key=key, status=quality_status),
             ),
             watermarks=(
                 WatermarkWrite(
                     key=key,
                     last_closed_timestamp=candle.timestamp,
                     cursor=None,
-                    run_id="watchlist-spx-test",
+                    run_id=run_id,
                 ),
             ),
         )
@@ -78,7 +92,7 @@ def _seed_watchlist_spx(store: KlineStore) -> None:
 
 def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) -> None:
     market_store = KlineStore(str(tmp_path / "market.db"))
-    _seed_watchlist_spx(market_store)
+    _seed_watchlist_proxy(market_store)
     snapshot = build_combined_health_matrix(
         screening_store=KlineStore(str(tmp_path / "screening.db")),
         market_store=market_store,
@@ -101,7 +115,8 @@ def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) 
     assert spx["metadata"]["identity_role"] == "proxy"
     assert spx["latest_closed_timestamp"] == "2026-09-02T00:00:00+00:00"
     assert spx["technical_status"] == "ready"
-    assert spx["status"] == "partial"
+    assert spx["status"] == "ready_unverified"
+    assert snapshot["coverage"]["1d"]["ready_unverified"] == 1
     assert spx["quality"]["status"] == "pass"
     assert spx["watermark"]["run_id"] == "watchlist-spx-test"
     assert snapshot["manifest_versions"] == {
@@ -110,6 +125,65 @@ def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) 
     }
     for timeframe, counts in snapshot["coverage"].items():
         assert counts["applicable"] + counts["not_applicable"] == 274
+
+
+def test_ready_unverified_is_overall_data_healthy_without_claiming_entitlement(
+    tmp_path,
+) -> None:
+    store = KlineStore(str(tmp_path / "watchlist-ready-unverified.db"))
+    _seed_watchlist_proxy(store)
+    manifest = load_watchlist_manifest(WATCHLIST_MANIFEST_PATH)
+
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 3, 12, tzinfo=timezone.utc),
+        scope=MATRIX_SCOPE_WATCHLIST,
+        instrument_ids=("WATCH.CROSS.SPX",),
+        free_source_ids={"yahoo_finance_etf"},
+    )
+
+    daily = next(cell for cell in snapshot["cells"] if cell["timeframe"] == "1d")
+    assert daily["status"] == "ready_unverified"
+    assert daily["status_reason"] == "entitlement_unverified"
+    assert daily["technical_status"] == "ready"
+    assert daily["entitlement"]["status"] == "unverified"
+    assert snapshot["status"] == "ready"
+    assert snapshot["coverage"]["1d"]["ready_unverified"] == 1
+    assert snapshot["coverage"]["1d"]["partial"] == 0
+    assert snapshot["coverage"]["1d"]["ready"] == 0
+
+
+def test_real_partial_still_degrades_a_mixed_unverified_snapshot(tmp_path) -> None:
+    store = KlineStore(str(tmp_path / "watchlist-mixed.db"))
+    _seed_watchlist_proxy(store)
+    _seed_watchlist_proxy(
+        store,
+        instrument_id="WATCH.CROSS.NDX",
+        display_symbol="NDX",
+        provider_symbol="QQQ",
+        quality_status="partial",
+    )
+    manifest = load_watchlist_manifest(WATCHLIST_MANIFEST_PATH)
+
+    snapshot = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 3, 12, tzinfo=timezone.utc),
+        scope=MATRIX_SCOPE_WATCHLIST,
+        instrument_ids=("WATCH.CROSS.SPX", "WATCH.CROSS.NDX"),
+        free_source_ids={"yahoo_finance_etf"},
+    )
+
+    daily = {
+        cell["display_symbol"]: cell
+        for cell in snapshot["cells"]
+        if cell["timeframe"] == "1d"
+    }
+    assert daily["SPX"]["status"] == "ready_unverified"
+    assert daily["NDX"]["status"] == "partial"
+    assert daily["NDX"]["status_reason"] == "quality_partial"
+    assert snapshot["status"] == "partial"
 
 
 def test_combined_health_api_reads_market_database_without_replacing_screening(

--- a/tests/test_health_matrix.py
+++ b/tests/test_health_matrix.py
@@ -163,6 +163,7 @@ def test_matrix_promotes_ready_cell_from_real_receipts(tmp_path: Path) -> None:
     assert snapshot["coverage"]["1h"]["applicable"] == 1
     assert (
         snapshot["coverage"]["1h"]["ready"]
+        + snapshot["coverage"]["1h"]["ready_unverified"]
         + snapshot["coverage"]["1h"]["partial"]
         + snapshot["coverage"]["1h"]["stale"]
         + snapshot["coverage"]["1h"]["failed"]
@@ -228,7 +229,15 @@ def test_full_scope_preserves_manifest_cartesian_product_and_coverage_invariants
         assert (
             sum(
                 counts[state]
-                for state in ("ready", "partial", "stale", "failed", "blocked", "unavailable")
+                for state in (
+                    "ready",
+                    "ready_unverified",
+                    "partial",
+                    "stale",
+                    "failed",
+                    "blocked",
+                    "unavailable",
+                )
             )
             == counts["applicable"]
         )
@@ -323,7 +332,8 @@ def test_health_matrix_joins_receipts_to_a_qfq_free_profile_cell(tmp_path: Path)
         for item in snapshot["cells"]
         if item["display_symbol"] == "600519" and item["timeframe"] == "15m"
     )
-    assert cell["status"] == "partial"
+    assert cell["status"] == "ready_unverified"
+    assert cell["status_reason"] == "entitlement_unverified"
     assert cell["technical_status"] == "ready"
     assert cell["row_count"] == 1
     assert cell["policy"]["source_identity"]["selected_source"] == "tencent"

--- a/tests/test_health_ui.py
+++ b/tests/test_health_ui.py
@@ -23,5 +23,7 @@ def test_health_ui_is_browser_visible():
     assert "AbortController" in response.text
     assert "cache:'no-store'" in response.text
     assert "授权阻塞" in response.text
+    assert "ready_unverified" in response.text
+    assert "数据正常·授权未认证" in response.text
     assert "阻塞 ${blocked}" in response.text
     assert "重试" not in response.text


### PR DESCRIPTION
## What
- Add `ready_unverified` for technically healthy cells whose only caveat is missing commercial entitlement verification.
- Count that state as data-healthy in matrix and combined coverage while preserving the explicit `entitlement_unverified` reason.
- Add a distinct Chinese label, visual treatment, and filter; all real partial/stale/failed/blocked states retain their existing severity.
- Add tests for all-unverified healthy aggregation and mixed genuine partial degradation.
- Update decision log and REGISTRY.

## Why
Folding healthy free-source data into the same yellow `partial` bucket as real quality/watermark failures made the dashboard permanently noisy and easy to ignore.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` → 337 passed
- Targeted Ruff → passed
- gitleaks → no leaks found
- No provider, entitlement mechanism, Screening manifest/runner, or or quality-gate ordering changed.

Closes #133
