### PR TITLE
Serve Watchlist consumers from the Market Data Database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,10 @@ TUSHARE_TOKEN=your_tushare_pro_token
 # Optional: database path (default: data/kline.db)
 # KLINE_DB_PATH=data/kline.db
 
+# Optional: identity-aware Watchlist consumer cutover. Legacy remains default.
+# KLINE_QUERY_BACKEND=market_first
+# KLINE_MARKET_DB_PATH=/Users/wendy/park-data/market/kline.db
+# KLINE_MARKET_MIN_ROWS=600
+
 # Optional: server port (default: 8100)
 # KLINE_PORT=8100

--- a/README.md
+++ b/README.md
@@ -413,6 +413,13 @@ Operator 面板：`/health-ui` 保留 Screening 观察；`/health-ui?view=combin
 Screening + Watchlist，并可按数据集筛选。合并视图需要同时配置
 `KLINE_DB_PATH` 与 `KLINE_MARKET_DB_PATH`，且应启用 `KLINE_READ_ONLY=true`。
 
+8100 消费者切换使用独立的 identity-aware 查询层，而不是把旧 `klines` 数据库路径
+直接替换成 `mvp_candles` 数据库。`KLINE_QUERY_BACKEND=market_first` 时，Watchlist
+中已验证且覆盖足够历史窗口的日线先从 `KLINE_MARKET_DB_PATH` 只读获取；未持久化的
+日内周期、成交量语义不兼容或未通过窗口验证的 cell 明确走现有 legacy/upstream
+路径。`source_identity.served_from` 与 `query_served_from` 会标出真实查询后端，
+`/api/health.query_backend` 汇总命中、回退和原因。默认 `legacy` 模式保持原行为。
+
 ### 参数
 
 | 参数 | 类型 | 默认值 | 说明 |
@@ -508,7 +515,9 @@ kline/
 |------|------|------|--------|
 | `KLINE_TUSHARE_TOKEN` | TuShare Pro token（非 Phase 1 A-share equity 可选） | 否 | — |
 | `KLINE_DB_PATH` | SQLite 数据库路径 | 否 | `data/kline.db` |
-| `KLINE_MARKET_DB_PATH` | Combined Health 使用的 Market Data Database 路径 | 仅合并面板 | — |
+| `KLINE_MARKET_DB_PATH` | Combined Health 或 `market_first` 使用的 Market Data Database 路径 | 按模式 | — |
+| `KLINE_QUERY_BACKEND` | 8100 查询后端模式：`legacy` / `market_first` | 否 | `legacy` |
+| `KLINE_MARKET_MIN_ROWS` | 新库序列允许服务前的最少历史行数；请求 limit 更大时以 limit 为准 | 否 | `600` |
 | `KLINE_READ_ONLY` | 使用 SQLite `mode=ro` + `query_only`，禁止建表、迁移和数据写入；SQLite 仍可能维护只读锁所需的 `-shm`/空 `-wal` sidecar | 否 | `false` |
 | `KLINE_PORT` | 服务端口 | 否 | `8100` |
 | `KLINE_REQUEST_TIMEOUT` | 上游请求超时 (秒) | 否 | `30` |

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -20,6 +20,7 @@
 - #128 已上线独立双库只读健康面板：`http://127.0.0.1:18172/health-ui?view=combined&dataset=watchlist`。Watchlist 视图真实显示 58 个资产/290 个 cell、日线 58/58 有技术数据、跨市场 16/16；Screening/Market Data 两库使用 `mode=ro + query_only`，请求前后 SHA-256 不变。18171/#115 与 resident 8100 未重启或改配置；证据见 `docs/verification/combined-health-dashboard-2026-09-03.md`。
 - #132 已统一 Watchlist proxy metadata：SPX/SPY、NDX/QQQ、DXY/UUP 均使用 `identity_role=proxy + proxy_for`；VIX/^VIX 保持真实指数身份。只改 manifest/validator/test，不改历史 K 线、source 路由、provider 或 runner。
 - #133 已新增 `ready_unverified`，把“数据/质量/水位正常但免费源商业授权未认证”与真实 `partial/stale/failed/blocked` 分开。该状态计入数据健康覆盖但不冒充已认证 ready；真实质量闸和错误强度未放松。
+- #134 已为 8100 增加 Watchlist-only 的 identity-aware 双库查询层：旧 `klines` 继续承担显式 legacy/upstream，已验证且历史充分的 Watchlist 日线从只读 Market Data Database 提供，响应和 `/api/health` 明确标记真实后端。10 条日线已回填 14,603 根；实际 Newsletter 31/31 ready（9 market/22 legacy），Human Review 的主请求为 6 market/28 legacy。切换→回滚→再切换已真实演练，未改消费者、Screening、#115、18171 或 18172。Market 命中 15/15 byte-identical；全 69 实时重复请求因 Yahoo/Tencent 上游自身变化只能得到 61/69，未伪报为全量逐字节通过，详见 `docs/verification/consumer-market-database-cutover-2026-09-03.md`。
 
 ## 下一步
 - #69 中文 3+3 Health Matrix、#70 全量 216×5 矩阵和交互、#71 可靠性 runner、#81 免费 source 路由、#83 混合状态文案、#85 剩余 97+97 批处理器、#87 美股粗粒度源调整、#89 分阶段恢复、#91 Yahoo 点号 ticker 兼容、#93 空响应终止重试、#95 fallback 404 终止重试、#97 水位倒退保护、#99 provider 硬超时、#101 免费源 HTTP 超时上限、#103 Yahoo 历史请求线程化、#105 Yahoo 修复请求线程化、#107 Yahoo ISO intraday 窗口兼容、#111 Yahoo 美股全时间级别主源已合并；真实全量股票 seed 首轮已完成，Yahoo-only 首轮已验证 100 只美股五级别，DHR 两个粗粒度格按 fail-closed 记录，A 股开盘 forming-bar partial 按规则记录，601989 仍是已知缺口；全量常驻 worker 已切换为 100+100、4 小时刷新并保持 running。美股五级别统一 Yahoo，A 股继续 Tencent→Tonghuashun；日/周优先、日内失败降级、请求间隔/重试退避、P95/限流统计、水位不倒退、provider 超时和同步请求可取消已锁定。#71 七天验收仍开放且 blocked，#54 真实 30-day database acceptance 仍未开始。
@@ -27,4 +28,4 @@
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。
 - 完成 #115 的 24 小时调度锚点/开盘缓冲真实验收后，再按已批准顺序实施 #116；#118 不切换当前 #115 observer build，也不启动 #71 正式计时。
 - Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
-- Dev Queue 下一项为 #134：先枚举 Newsletter 与 Human Review 的真实运行时请求集并回帖 issue，再实施 8100 双源消费者切换、逐字节验收和切换→回滚→再验证演练。
+- 当前 Watchlist 消费者切换主链已完成；后续若要消除剩余 legacy 比例，应分别为 30m/4h/1h 持久化、微型合约纳入与 UUP 历史缺口建立新合同，不回头扩大 #134。

--- a/decision-log.md
+++ b/decision-log.md
@@ -399,3 +399,25 @@ consumers can use without direct exchange or private SQLite access.
 - The Chinese UI gives `ready_unverified` its own filter, label, and visual treatment. A fully
   healthy Watchlist can show `数据正常（授权未认证）`; mixed real problems remain partial/failed.
 - No provider, entitlement mechanism, Screening manifest/runner, or quality-gate ordering changes.
+
+## 2026-09-03 - Serve Watchlist consumers through an identity-aware dual-store query layer
+
+- #134 corrects ADR 0004's disproved “change only `db_path`” assumption. The resident service keeps
+  the legacy `klines` database and adds a read-only `mvp_candles` adapter behind
+  `KLINE_QUERY_BACKEND=market_first`; the public 8100 request and response contract remains stable.
+- The exact runtime denominator is 69 logical requests: Newsletter 28 after owner-excluded Treasury,
+  Human Review 34 primary and seven conditional 1h fallbacks. Only Watchlist daily identities may
+  resolve to the Market Data Database; Screening is not queried by the adapter.
+- Ten eligible daily histories were explicitly backfilled from 2021 with the canonical Watchlist
+  lock. Both real runs passed 10/10 quality cells and promoted 14,603 candles with no blocked cells.
+- Fail-closed routing keeps intraday, two dated micro contracts, insufficient history,
+  `volume_semantics=not_applicable`, and UUP's intermittently missing 2026-08-28 history on the
+  visible legacy path. No candle or volume is synthesized.
+- The switched Market Data Database set was byte-identical 15/15 in the final same-build lockstep
+  replay. Literal 69/69 live bytes are not a valid oracle for the remaining upstream routes: eight
+  adjacent Yahoo/Tencent calls returned different provider data despite identical build, URL,
+  cutoff and policy. This limitation is preserved in the verification record rather than reported
+  as a pass.
+- The real rollback drill used `bootout → bootstrap`: candidate → byte-identical legacy plist →
+  candidate. A real Newsletter source bundle was 31/31 ready (9 market / 22 legacy); Human Review
+  returned 16 assets with six Market Data Database and 28 legacy primary identities.

--- a/docs/adr/0004-query-service-interface-preserved.md
+++ b/docs/adr/0004-query-service-interface-preserved.md
@@ -1,0 +1,58 @@
+# ADR 0004: Preserve the Query Service HTTP contract with an identity-aware dual-store adapter
+
+- Status: Accepted
+- Date: 2026-09-03
+- Decision owner: Park
+- Scope: Watchlist consumers on `127.0.0.1:8100`
+
+## Context
+
+The earlier version of this ADR assumed that consumer migration required only changing
+`KLINE_DB_PATH`. Runtime inspection disproved that assumption:
+
+- the legacy database exposes `klines` keyed by ticker;
+- the Market Data Database exposes `mvp_candles` keyed by source-aware `instrument_id`,
+  `manifest_version`, timeframe and adjustment basis;
+- changing the path alone makes the existing Query Service query a table that does not exist.
+
+Newsletter and Human K-line Review must keep their existing routes, request policies and response
+shape. They cannot be changed as part of this migration. Treasury level/spread series are not Candle
+Instruments and remain outside this database and this cutover.
+
+## Decision
+
+The resident Query Service keeps `KLINE_DB_PATH` for its legacy cache and adds a read-only
+Market Data Database input configured by `KLINE_MARKET_DB_PATH`. The default
+`KLINE_QUERY_BACKEND=legacy` changes nothing. `market_first` enables an identity-aware adapter:
+
+1. Resolve only Watchlist identities, preferring `display_symbol` and then `provider_symbol`.
+2. Permit the five measured legacy asset-class aliases only: UUP, SPY, QQQ, SCHD and `^VIX`
+   requested as `us_stock`.
+3. Serve only persisted native daily series with a watermark, sufficient history for both the
+   configured minimum and requested limit, and compatible volume semantics.
+4. Route every miss through the unchanged legacy cache/upstream path. The response explicitly
+   records `source_identity.served_from`, `query_served_from`, and a stable miss reason.
+5. Keep the public top-level `served_from` contract unchanged because Newsletter validates it.
+   The exact storage origin is nested in `source_identity`.
+
+The adapter also preserves the provider observation identity persisted with the Market Data
+Database receipt. It does not fabricate volume, synthesize missing rows or relax any quality gate.
+Series with `volume_semantics=not_applicable` remain legacy-served for byte compatibility. DXY/UUP
+also remains legacy-served because its longer Yahoo history intermittently omits 2026-08-28; this is
+reported as `market_window_unverified`, not hidden.
+
+## Consequences
+
+- Newsletter and Human Review can use Market Data Database rows without code changes.
+- Intraday cells, the two dated micro contracts, insufficient histories and unverified series remain
+  explicit legacy/upstream reads.
+- `/api/health.query_backend` reports market hits, misses, unique legacy cells and miss reasons
+  without exposing database paths.
+- Rollback is configuration-only: restore the backed-up legacy plist with `bootout` then
+  `bootstrap`; no database rewrite or code revert is required.
+- Screening Universe routing, #115, 18171 and 18172 are unaffected.
+
+## Rejected alternative
+
+Pointing `KLINE_DB_PATH` directly at the Market Data Database was rejected because it breaks on the
+schema boundary and discards source-aware identity and provenance.

--- a/docs/verification/consumer-market-database-cutover-2026-09-03.md
+++ b/docs/verification/consumer-market-database-cutover-2026-09-03.md
@@ -1,0 +1,114 @@
+# Consumer Market Data Database cutover verification — 2026-09-03
+
+Status: **partial — implementation and rollback verified; literal 69/69 live byte equality blocked by upstream nondeterminism**
+
+## Scope and request denominator
+
+The request set was enumerated from the installed Newsletter and Human K-line Review code before
+implementation and posted to issue #134. Treasury is owner-excluded.
+
+- Newsletter: 28 in-scope requests.
+- Human Review: 34 primary requests plus 7 conditional 1h fallbacks.
+- Total acceptance denominator: 69 requests.
+- Three unsupported 4h requests are rejected before the query-backend seam, as before.
+
+`ops/verify_consumer_cutover.py` records the exact consumer file SHA-256 values, uses the real
+request policies and limits, and compares HTTP status, canonical response bytes, candle bytes and
+candle count. Only `age_seconds`, top-level `instrument_id`, and the newly declared backend/proxy
+metadata are excluded from the canonical byte digest.
+
+## Real history backfill
+
+The bounded one-shot runner used the canonical Watchlist lock and database. It did not alter either
+scheduler.
+
+| Observation | Result |
+|---|---:|
+| selected daily series | 10 |
+| quality pass | 10/10 |
+| promoted candles | 14,603 |
+| blocked cells | 0 |
+| rate-limit/entitlement failures | 0 |
+
+Receipt: `/Users/wendy/park-data/market/consumer-cutover-backfill-134.json`.
+
+UUP/DXY was subsequently held on the explicit legacy path because Yahoo intermittently omitted the
+2026-08-28 row from otherwise identical history fetches. The service reports
+`market_window_unverified`; no row was synthesized.
+
+## Isolated same-build comparison
+
+Two services ran from `e60857910f3858a5c931b4f97f9873e2e71e0284`:
+
+- `127.0.0.1:18174`: `query_backend=legacy`
+- `127.0.0.1:8100`: `query_backend=market_first`
+
+The final closed-window lockstep comparison produced:
+
+| Result | Count |
+|---|---:|
+| total requests | 69 |
+| exact canonical matches | 61 |
+| Market Data Database routes | 15 |
+| Market-routed candle mismatches | **0** |
+| explicit legacy routes | 51 |
+| pre-query unsupported requests | 3 |
+| legacy/upstream live mismatches | 8 |
+
+All eight differences were on legacy/upstream routes: dated micro-contract 30m/1h, QQQ/SPY 30m,
+WTI 30m, and one Tencent STAR50 request. Repeating the unchanged legacy service also changed these
+responses; Yahoo revised returned bars between adjacent calls and Tencent intermittently returned an
+empty response. These are not Market Data Database rows and the candidate exercised the same
+provider code, source and request policy.
+
+Evidence:
+
+- `/Users/wendy/park-data/market/cutover-134-final-baseline.json`
+- `/Users/wendy/park-data/market/cutover-134-final-candidate.json`
+- `/Users/wendy/park-data/market/cutover-134-final-comparison.json`
+
+Therefore the literal full-set 69/69 live byte criterion is not claimed as passed. The materially
+switched set is 15/15 exact; the remaining eight differences demonstrate why two separate live
+upstream fetches cannot be used as a deterministic byte oracle.
+
+## Real consumer probes
+
+With the candidate on 8100:
+
+- Newsletter built its real `market-regime-daily-source-bundle-v2`: 31/31 ready (the product still
+  requests its three owner-excluded Treasury panels), with 9 Market Data Database and 22 explicit
+  legacy/upstream slots.
+- Human Review `/api/overview?refresh=true` returned 16 assets / 48 timeframe tiles: 33 ready,
+  1 insufficient-history and 14 unavailable; the 34 returned primary backend identities comprised
+  6 Market Data Database and 28 explicit legacy/upstream routes.
+
+No consumer repository file was changed.
+
+## Cutover and rollback drill
+
+The original plist was backed up byte-identically:
+
+`f3b8d6aca99cca7b79c05e511fc5a404240ed3c31e87c8129d055edcb7461f1d`
+
+The drill used only `launchctl bootout` then `launchctl bootstrap`:
+
+1. legacy build `752698e` on 8100 → candidate `market_first` build `e608579`;
+2. candidate → byte-identical rollback plist, restoring build `752698e` and a successful real SPY
+   response;
+3. rollback → candidate, restoring `market_first` and proving a Market DB SPY response plus an
+   explicit legacy BTC 4h response.
+
+The first bootstrap attempts immediately after `bootout` encountered launchd's transient I/O error
+while the prior label was still terminating. The label and port were inspected before retrying; no
+`kickstart -k` was used.
+
+#115 API/worker, 18171, 18172 and the Human Review process retained their original PIDs/builds
+throughout the drill.
+
+## Automated validation
+
+- Full suite after the final envelope change: 349 passed.
+- Ruff on every changed Python file: passed.
+- Gitleaks: no leaks.
+- Whole-repository Ruff still reports the pre-existing unrelated unused `timedelta` import in
+  `src/kline/providers/binance_usdm.py`; this issue did not change that provider.

--- a/ops/com.wendy.datafeed.market-first.plist.example
+++ b/ops/com.wendy.datafeed.market-first.plist.example
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wendy.datafeed</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/python3</string>
+        <string>-m</string>
+        <string>uvicorn</string>
+        <string>kline.app:create_app</string>
+        <string>--factory</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>8100</string>
+        <string>--log-level</string>
+        <string>info</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/wendy/datafeed-runtime-market-cutover</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>/Users/wendy/datafeed-runtime-market-cutover/src</string>
+        <key>KLINE_RUNTIME_ROOT</key>
+        <string>/Users/wendy/datafeed-runtime-market-cutover</string>
+        <key>KLINE_DB_PATH</key>
+        <string>/Users/wendy/datafeed/data/kline.db</string>
+        <key>KLINE_MARKET_DB_PATH</key>
+        <string>/Users/wendy/park-data/market/kline.db</string>
+        <key>KLINE_QUERY_BACKEND</key>
+        <string>market_first</string>
+        <key>KLINE_MARKET_MIN_ROWS</key>
+        <string>600</string>
+        <key>KLINE_LOAD_ENTRYPOINT_ADAPTERS</key>
+        <string>false</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/resident.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/wendy/Library/Logs/datafeed/resident.stderr.log</string>
+</dict>
+</plist>

--- a/ops/consumer_cutover_backfill.py
+++ b/ops/consumer_cutover_backfill.py
@@ -1,0 +1,144 @@
+"""One-shot history backfill for Watchlist series eligible for consumer cutover.
+
+This runner deliberately targets only the canonical Market Data Database and
+reuses the Watchlist worker lock.  It does not change either scheduler and it
+does not touch the Screening universe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from kline.config import Settings
+from kline.ingestion import IngestionOrchestrator, IngestionPlan
+from kline.mvp_worker import _SingleRunLock
+from kline.registry import init
+from kline.store import KlineStore
+from kline.watchlist_manifest import load_watchlist_manifest
+from ops.watchlist_seed import (
+    DEFAULT_MANIFEST,
+    MARKET_DATA_DB,
+    WATCHLIST_LOCK,
+    validate_watchlist_target,
+)
+
+
+CONSUMER_DAILY_INSTRUMENT_IDS = (
+    "WATCH.CROSS.DXY",
+    "WATCH.CROSS.SPX",
+    "WATCH.CROSS.NDX",
+    "WATCH.CROSS.SCHD",
+    "WATCH.CROSS.BTC",
+    "WATCH.CROSS.ETH",
+    "WATCH.CROSS.HYPE",
+    "WATCH.CROSS.WTI",
+    "WATCH.CROSS.GOLD",
+    "WATCH.CROSS.SILVER",
+)
+DEFAULT_HISTORY_START = "2021-01-01T00:00:00+00:00"
+DEFAULT_RECEIPT = Path("/Users/wendy/park-data/market/consumer-cutover-backfill.json")
+
+
+async def run_consumer_cutover_backfill(
+    *,
+    manifest_path: str | Path = DEFAULT_MANIFEST,
+    db_path: str | Path = MARKET_DATA_DB,
+    lock_path: str | Path = WATCHLIST_LOCK,
+    history_start: str = DEFAULT_HISTORY_START,
+    fetch_limit: int = 2000,
+    request_interval_seconds: float = 2.0,
+    max_retries: int = 2,
+    retry_backoff_seconds: float = 2.0,
+    provider_timeout_seconds: float = 45.0,
+) -> dict[str, Any]:
+    database, lock_file = validate_watchlist_target(db_path, lock_path)
+    manifest = load_watchlist_manifest(manifest_path)
+    manifest_ids = {item.instrument_id for item in manifest.instruments}
+    missing = sorted(set(CONSUMER_DAILY_INSTRUMENT_IDS) - manifest_ids)
+    if missing:
+        raise ValueError(f"consumer backfill identities missing from Watchlist: {missing}")
+    if fetch_limit < 1008:
+        raise ValueError("consumer backfill fetch_limit must cover Human Review's 1008-row request")
+
+    init(Settings(db_path=str(database), load_entrypoint_adapters=False))
+    store = KlineStore(str(database))
+    now = datetime.now(timezone.utc)
+    with _SingleRunLock(lock_file):
+        receipt = await IngestionOrchestrator(store).run_once(
+            IngestionPlan(
+                manifest=manifest,
+                run_id=f"consumer-cutover-backfill-{now.strftime('%Y%m%dT%H%M%SZ')}",
+                now=now,
+                history_start=history_start,
+                force_history_start=True,
+                fetch_limit=fetch_limit,
+                max_retries=max_retries,
+                retry_backoff_seconds=retry_backoff_seconds,
+                instrument_ids=CONSUMER_DAILY_INSTRUMENT_IDS,
+                timeframes=("1d",),
+                request_interval_seconds=request_interval_seconds,
+                provider_timeout_seconds=provider_timeout_seconds,
+                policy={
+                    "runner": "consumer_cutover_backfill",
+                    "universe": "watchlist",
+                    "timeframes": ["1d"],
+                    "history_start": history_start,
+                    "force_history_start": True,
+                    "fetch_limit": fetch_limit,
+                },
+            )
+        )
+    payload = receipt.to_dict()
+    payload["eligible_instrument_ids"] = list(CONSUMER_DAILY_INSTRUMENT_IDS)
+    payload["database_path"] = "canonical_market_data_database"
+    payload["lock_path"] = "canonical_watchlist_worker_lock"
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Backfill consumer-eligible Watchlist daily history"
+    )
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--db", default=str(MARKET_DATA_DB))
+    parser.add_argument("--lock", default=str(WATCHLIST_LOCK))
+    parser.add_argument("--history-start", default=DEFAULT_HISTORY_START)
+    parser.add_argument("--fetch-limit", type=int, default=2000)
+    parser.add_argument("--request-interval", type=float, default=2.0)
+    parser.add_argument("--max-retries", type=int, default=2)
+    parser.add_argument("--retry-backoff", type=float, default=2.0)
+    parser.add_argument("--provider-timeout", type=float, default=45.0)
+    parser.add_argument("--receipt", default=str(DEFAULT_RECEIPT))
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = asyncio.run(
+        run_consumer_cutover_backfill(
+            manifest_path=args.manifest,
+            db_path=args.db,
+            lock_path=args.lock,
+            history_start=args.history_start,
+            fetch_limit=args.fetch_limit,
+            request_interval_seconds=args.request_interval,
+            max_retries=args.max_retries,
+            retry_backoff_seconds=args.retry_backoff,
+            provider_timeout_seconds=args.provider_timeout,
+        )
+    )
+    rendered = json.dumps(report, ensure_ascii=False, sort_keys=True)
+    print(rendered)
+    receipt_path = Path(args.receipt).expanduser().resolve()
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["status"] == "success" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/verify_consumer_cutover.py
+++ b/ops/verify_consumer_cutover.py
@@ -1,0 +1,471 @@
+"""Capture and byte-diff the real Newsletter and Human Review request set."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.error import HTTPError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+NEWSLETTER_FILES = (
+    Path(
+        "/Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/"
+        "market_regime_daily_source.py"
+    ),
+    Path(
+        "/Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/"
+        "market_regime_weekly_contract.py"
+    ),
+    Path(
+        "/Users/wendy/Library/Application Support/ParkKlineDaily/app/product/data_core/"
+        "market_regime_weekly_datafeed.py"
+    ),
+)
+HUMAN_REVIEW_FILES = (
+    Path(
+        "/Users/wendy/Library/Application Support/HumanKlineReview/app/"
+        "human_kline_review/datafeed_source.py"
+    ),
+    Path(
+        "/Users/wendy/Library/Application Support/HumanKlineReview/app/"
+        "human_kline_review/history.py"
+    ),
+    Path(
+        "/Users/wendy/Library/Application Support/HumanKlineReview/app/"
+        "human_kline_review/universe.py"
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ConsumerRequest:
+    consumer: str
+    asset_key: str
+    asset_class: str
+    ticker: str
+    timeframe: str
+    source: str
+    limit: int
+    quality: str
+    fallback_sources: tuple[str, ...] = ()
+    conditional: bool = False
+
+    @property
+    def request_id(self) -> str:
+        suffix = ":conditional" if self.conditional else ""
+        return (
+            f"{self.consumer}:{self.asset_key}:{self.asset_class}:{self.ticker}:"
+            f"{self.timeframe}{suffix}"
+        )
+
+
+def _newsletter_requests() -> list[ConsumerRequest]:
+    daily = (
+        ("dxy", "etf", "UUP", "yahoo_finance_etf", ()),
+        ("sp500", "etf", "SPY", "yahoo_finance_etf", ()),
+        ("nasdaq", "etf", "QQQ", "yahoo_finance_etf", ()),
+        ("us_dividend", "etf", "SCHD", "yahoo_finance_etf", ()),
+        ("vix", "index", "^VIX", "yahoo_finance_index", ()),
+        ("shanghai", "index", "sh000001", "tencent_kline", ("sina_index",)),
+        ("star50", "index", "sh000688", "tencent_kline", ("sina_index",)),
+        ("china_dividend", "index", "sh000015", "tencent_kline", ("sina_index",)),
+        ("nikkei", "index", "^N225", "yahoo_finance_index", ()),
+        ("kospi", "index", "^KS11", "yahoo_finance_index", ()),
+    )
+    multi = (
+        ("bitcoin", "crypto", "BTC", "hyperliquid_perpetual_public"),
+        ("ethereum", "crypto", "ETH", "hyperliquid_perpetual_public"),
+        ("hype", "crypto", "HYPE", "hyperliquid_perpetual_public"),
+        ("wti", "commodity", "CL=F", "yahoo_finance_futures"),
+        ("gold", "commodity", "GC=F", "yahoo_finance_futures"),
+        ("silver", "commodity", "SI=F", "yahoo_finance_futures"),
+    )
+    requests = [
+        ConsumerRequest("newsletter", key, asset_class, ticker, "1d", source, 300, "strict", fallbacks)
+        for key, asset_class, ticker, source, fallbacks in daily
+    ]
+    requests.extend(
+        ConsumerRequest("newsletter", key, asset_class, ticker, timeframe, source, 300, "strict")
+        for key, asset_class, ticker, source in multi
+        for timeframe in ("1d", "4h", "30m")
+    )
+    return requests
+
+
+def _human_requests() -> list[ConsumerRequest]:
+    primary = (
+        ("dxy", "us_stock", "UUP", "auto", ("1d", "30m")),
+        ("sp500", "us_stock", "SPY", "auto", ("1d", "30m")),
+        ("nasdaq", "us_stock", "QQQ", "auto", ("1d", "30m")),
+        ("us_dividend", "us_stock", "SCHD", "auto", ("1d", "30m")),
+        ("vix", "us_stock", "^VIX", "auto", ("1d", "4h", "30m")),
+        ("bitcoin", "crypto", "BTC", "hyperliquid_perpetual_public", ("1d", "4h", "30m")),
+        ("ethereum", "crypto", "ETH", "hyperliquid_perpetual_public", ("1d", "4h", "30m")),
+        ("hype", "crypto", "HYPE", "hyperliquid_perpetual_public", ("1d", "4h", "30m")),
+        ("shanghai", "index", "sh000001", "tencent_kline", ("1d",)),
+        ("star50", "index", "sh000688", "tencent_kline", ("1d",)),
+        ("china_dividend", "index", "sh000015", "tencent_kline", ("1d",)),
+        ("nikkei", "index", "^N225", "auto", ("1d",)),
+        ("kospi", "index", "^KS11", "auto", ("1d",)),
+        ("wti", "commodity", "CL=F", "auto", ("1d", "4h", "30m")),
+        ("gold", "us_stock", "MGCV26.CMX", "yahoo_finance", ("1d", "4h", "30m")),
+        ("silver", "us_stock", "SILZ26.CMX", "yahoo_finance", ("1d", "4h", "30m")),
+    )
+    factor = {"1d": 1, "4h": 4, "30m": 1}
+    requests = [
+        ConsumerRequest(
+            "human_review",
+            key,
+            asset_class,
+            ticker,
+            timeframe,
+            source,
+            1000 * factor[timeframe] + 8,
+            "standard",
+        )
+        for key, asset_class, ticker, source, timeframes in primary
+        for timeframe in timeframes
+    ]
+    for key, asset_class, ticker, source in (
+        ("vix", "us_stock", "^VIX", "auto"),
+        ("bitcoin", "crypto", "BTC", "hyperliquid_perpetual_public"),
+        ("ethereum", "crypto", "ETH", "hyperliquid_perpetual_public"),
+        ("hype", "crypto", "HYPE", "hyperliquid_perpetual_public"),
+        ("wti", "commodity", "CL=F", "auto"),
+        ("gold", "us_stock", "MGCV26.CMX", "yahoo_finance"),
+        ("silver", "us_stock", "SILZ26.CMX", "yahoo_finance"),
+    ):
+        requests.append(
+            ConsumerRequest(
+                "human_review",
+                key,
+                asset_class,
+                ticker,
+                "1h",
+                source,
+                4008,
+                "standard",
+                conditional=True,
+            )
+        )
+    return requests
+
+
+def consumer_requests() -> tuple[ConsumerRequest, ...]:
+    requests = (*_newsletter_requests(), *_human_requests())
+    ids = [item.request_id for item in requests]
+    if len(ids) != len(set(ids)):
+        raise RuntimeError("consumer request ids must be unique")
+    return requests
+
+
+def _file_hashes(paths: Sequence[Path]) -> dict[str, str]:
+    return {
+        str(path): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in paths
+        if path.is_file()
+    }
+
+
+def _request_url(base_url: str, item: ConsumerRequest, cutoff: str) -> str:
+    deterministic_start = {
+        "1d": "2021-01-01",
+        "4h": "2024-09-03",
+        "1h": "2024-09-03",
+        "30m": "2026-07-06",
+    }[item.timeframe]
+    fallback_policy = "explicit" if item.fallback_sources else "none"
+    params: list[tuple[str, str]] = [
+        ("timeframe", item.timeframe),
+        ("source", item.source),
+        ("cache_policy", "bypass"),
+        ("quality", item.quality),
+        ("fallback_policy", fallback_policy),
+        ("limit", str(item.limit)),
+        ("start", deterministic_start),
+        ("end", cutoff),
+    ]
+    params.extend(("fallback_sources", value) for value in item.fallback_sources)
+    return (
+        f"{base_url.rstrip('/')}/api/candles/{quote(item.asset_class, safe='')}/"
+        f"{quote(item.ticker, safe='')}?{urlencode(params)}"
+    )
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _normalized_payload(payload: Any) -> Any:
+    if not isinstance(payload, Mapping):
+        return payload
+    result = dict(payload)
+    result.pop("age_seconds", None)
+    result.pop("instrument_id", None)
+    identity = result.get("source_identity")
+    if isinstance(identity, Mapping):
+        cleaned = dict(identity)
+        for key in (
+            "served_from",
+            "query_served_from",
+            "market_data_miss_reason",
+            "instrument_id",
+            "display_symbol",
+            "market_data_source_id",
+            "manifest_version",
+            "adjustment_basis",
+            "volume_semantics",
+            "stored_asset_class",
+            "requested_asset_class",
+            "requested_ticker",
+            "identity_role",
+            "proxy_for",
+        ):
+            cleaned.pop(key, None)
+        result["source_identity"] = cleaned
+    detail = result.get("detail")
+    if isinstance(detail, Mapping):
+        result["detail"] = _normalized_payload(detail)
+    return result
+
+
+def _capture_one(base_url: str, item: ConsumerRequest, cutoff: str, timeout: float) -> dict[str, Any]:
+    url = _request_url(base_url, item, cutoff)
+    request = Request(url, headers={"Accept": "application/json"}, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = int(response.status)
+            raw = response.read()
+    except HTTPError as error:
+        status = int(error.code)
+        raw = error.read()
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        payload = {"unparseable_body_sha256": hashlib.sha256(raw).hexdigest()}
+    normalized = _normalized_payload(payload)
+    candles = payload.get("candles") if isinstance(payload, Mapping) else None
+    identity = payload.get("source_identity") if isinstance(payload, Mapping) else None
+    if not isinstance(identity, Mapping) and isinstance(payload, Mapping):
+        detail = payload.get("detail")
+        identity = detail.get("source_identity") if isinstance(detail, Mapping) else None
+    return {
+        "request_id": item.request_id,
+        "consumer": item.consumer,
+        "asset_key": item.asset_key,
+        "asset_class": item.asset_class,
+        "ticker": item.ticker,
+        "timeframe": item.timeframe,
+        "source": item.source,
+        "limit": item.limit,
+        "quality": item.quality,
+        "conditional": item.conditional,
+        "url": url,
+        "http_status": status,
+        "raw_sha256": hashlib.sha256(raw).hexdigest(),
+        "normalized_sha256": hashlib.sha256(_canonical(normalized)).hexdigest(),
+        "candles_sha256": hashlib.sha256(_canonical(candles)).hexdigest()
+        if isinstance(candles, list)
+        else None,
+        "candle_count": len(candles) if isinstance(candles, list) else 0,
+        "query_served_from": identity.get("query_served_from")
+        if isinstance(identity, Mapping)
+        else None,
+        "payload": payload,
+    }
+
+
+def capture_snapshot(
+    *, base_url: str, cutoff: str, timeout: float = 60.0, workers: int = 4
+) -> dict[str, Any]:
+    requests = consumer_requests()
+    results: dict[str, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=max(1, workers), thread_name_prefix="cutover-verify") as pool:
+        futures = {
+            pool.submit(_capture_one, base_url, item, cutoff, timeout): item
+            for item in requests
+        }
+        for future in as_completed(futures):
+            item = futures[future]
+            try:
+                results[item.request_id] = future.result()
+            except Exception as error:  # pragma: no cover - evidence boundary
+                results[item.request_id] = {
+                    "request_id": item.request_id,
+                    "transport_error": f"{type(error).__name__}:{error}",
+                }
+    ordered = [results[item.request_id] for item in requests]
+    return {
+        "schema_version": "consumer-cutover-snapshot-v1",
+        "captured_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "base_url": base_url,
+        "cutoff": cutoff,
+        "request_count": len(requests),
+        "newsletter_request_count": sum(item.consumer == "newsletter" for item in requests),
+        "human_primary_request_count": sum(
+            item.consumer == "human_review" and not item.conditional for item in requests
+        ),
+        "human_conditional_request_count": sum(item.conditional for item in requests),
+        "consumer_file_sha256": {
+            **_file_hashes(NEWSLETTER_FILES),
+            **_file_hashes(HUMAN_REVIEW_FILES),
+        },
+        "requests": ordered,
+    }
+
+
+def capture_paired_snapshots(
+    *,
+    baseline_url: str,
+    candidate_url: str,
+    cutoff: str,
+    timeout: float = 60.0,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Replay each cell against both services at the same instant."""
+
+    requests = consumer_requests()
+    baseline_rows: list[dict[str, Any]] = []
+    candidate_rows: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="cutover-pair") as pool:
+        for item in requests:
+            baseline_future = pool.submit(
+                _capture_one, baseline_url, item, cutoff, timeout
+            )
+            candidate_future = pool.submit(
+                _capture_one, candidate_url, item, cutoff, timeout
+            )
+            baseline_rows.append(baseline_future.result())
+            candidate_rows.append(candidate_future.result())
+
+    common = {
+        "schema_version": "consumer-cutover-snapshot-v1",
+        "captured_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "cutoff": cutoff,
+        "request_count": len(requests),
+        "newsletter_request_count": 28,
+        "human_primary_request_count": 34,
+        "human_conditional_request_count": 7,
+        "consumer_file_sha256": {
+            **_file_hashes(NEWSLETTER_FILES),
+            **_file_hashes(HUMAN_REVIEW_FILES),
+        },
+    }
+    baseline = {**common, "base_url": baseline_url, "requests": baseline_rows}
+    candidate = {**common, "base_url": candidate_url, "requests": candidate_rows}
+    return baseline, candidate, compare_snapshots(baseline, candidate)
+
+
+def compare_snapshots(baseline: Mapping[str, Any], candidate: Mapping[str, Any]) -> dict[str, Any]:
+    baseline_rows = {row["request_id"]: row for row in baseline.get("requests", ())}
+    candidate_rows = {row["request_id"]: row for row in candidate.get("requests", ())}
+    all_ids = sorted(set(baseline_rows) | set(candidate_rows))
+    differences: list[dict[str, Any]] = []
+    market_hits = 0
+    legacy_fallbacks = 0
+    for request_id in all_ids:
+        before = baseline_rows.get(request_id)
+        after = candidate_rows.get(request_id)
+        if after:
+            if after.get("query_served_from") == "market_data_database":
+                market_hits += 1
+            elif str(after.get("query_served_from") or "").startswith("legacy_"):
+                legacy_fallbacks += 1
+        if before is None or after is None:
+            differences.append({"request_id": request_id, "reason": "request_set_changed"})
+            continue
+        changed: list[str] = []
+        for field in ("http_status", "normalized_sha256", "candles_sha256", "candle_count"):
+            if before.get(field) != after.get(field):
+                changed.append(field)
+        if changed:
+            differences.append({"request_id": request_id, "changed": changed})
+    return {
+        "schema_version": "consumer-cutover-comparison-v1",
+        "baseline_cutoff": baseline.get("cutoff"),
+        "candidate_cutoff": candidate.get("cutoff"),
+        "request_count": len(all_ids),
+        "exact_match_count": len(all_ids) - len(differences),
+        "difference_count": len(differences),
+        "market_database_requests": market_hits,
+        "legacy_requests": legacy_fallbacks,
+        "differences": differences,
+    }
+
+
+def _write_json(path: str | Path, payload: Mapping[str, Any]) -> None:
+    target = Path(path).expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Capture or compare consumer cutover evidence")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    capture = subparsers.add_parser("capture")
+    capture.add_argument("--base-url", default="http://127.0.0.1:8100")
+    capture.add_argument("--cutoff", default=None)
+    capture.add_argument("--timeout", type=float, default=60.0)
+    capture.add_argument("--workers", type=int, default=4)
+    capture.add_argument("--output", required=True)
+    compare = subparsers.add_parser("compare")
+    compare.add_argument("--baseline", required=True)
+    compare.add_argument("--candidate", required=True)
+    compare.add_argument("--output", required=True)
+    paired = subparsers.add_parser("paired")
+    paired.add_argument("--baseline-url", required=True)
+    paired.add_argument("--candidate-url", required=True)
+    paired.add_argument("--cutoff", default=None)
+    paired.add_argument("--timeout", type=float, default=60.0)
+    paired.add_argument("--baseline-output", required=True)
+    paired.add_argument("--candidate-output", required=True)
+    paired.add_argument("--comparison-output", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "capture":
+        cutoff = args.cutoff or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        payload = capture_snapshot(
+            base_url=args.base_url,
+            cutoff=cutoff,
+            timeout=args.timeout,
+            workers=args.workers,
+        )
+        _write_json(args.output, payload)
+        print(json.dumps({key: payload[key] for key in ("cutoff", "request_count")}, sort_keys=True))
+        return 0 if not any("transport_error" in row for row in payload["requests"]) else 2
+    if args.command == "paired":
+        cutoff = args.cutoff or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        baseline, candidate, comparison = capture_paired_snapshots(
+            baseline_url=args.baseline_url,
+            candidate_url=args.candidate_url,
+            cutoff=cutoff,
+            timeout=args.timeout,
+        )
+        _write_json(args.baseline_output, baseline)
+        _write_json(args.candidate_output, candidate)
+        _write_json(args.comparison_output, comparison)
+        print(json.dumps(comparison, ensure_ascii=False, sort_keys=True))
+        return 0 if comparison["difference_count"] == 0 else 2
+    baseline = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
+    candidate = json.loads(Path(args.candidate).read_text(encoding="utf-8"))
+    payload = compare_snapshots(baseline, candidate)
+    _write_json(args.output, payload)
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0 if payload["difference_count"] == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/verify_consumer_cutover.py
+++ b/ops/verify_consumer_cutover.py
@@ -329,21 +329,18 @@ def capture_paired_snapshots(
     cutoff: str,
     timeout: float = 60.0,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    """Replay each cell against both services at the same instant."""
+    """Replay each cell against both services in lockstep.
+
+    Sequential calls avoid doubling Yahoo/Tencent concurrency while still
+    keeping the two observations adjacent in time.
+    """
 
     requests = consumer_requests()
     baseline_rows: list[dict[str, Any]] = []
     candidate_rows: list[dict[str, Any]] = []
-    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="cutover-pair") as pool:
-        for item in requests:
-            baseline_future = pool.submit(
-                _capture_one, baseline_url, item, cutoff, timeout
-            )
-            candidate_future = pool.submit(
-                _capture_one, candidate_url, item, cutoff, timeout
-            )
-            baseline_rows.append(baseline_future.result())
-            candidate_rows.append(candidate_future.result())
+    for item in requests:
+        baseline_rows.append(_capture_one(baseline_url, item, cutoff, timeout))
+        candidate_rows.append(_capture_one(candidate_url, item, cutoff, timeout))
 
     common = {
         "schema_version": "consumer-cutover-snapshot-v1",

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -458,19 +458,28 @@ def _market_database_response(
 ) -> CandleResponse:
     candles = list(result.candles)
     report = analyze_candles(candles, timeframe, meta, strict=policy.strict_quality)
-    _block_if_quality_rejected(
-        report=report,
-        meta=meta,
-        policy=policy,
-        served_from="market_data_database",
-        timeframe=timeframe,
-        timeframe_transform=result.timeframe_transform,
-        source_identity={
+    if report.reject_reason:
+        source_identity = {
             **dict(result.source_identity or {}),
             "requested_ticker": requested_ticker,
-        },
-        provider_symbol=result.provider_symbol or requested_ticker,
-    )
+        }
+        raise _error(
+            status_code=503,
+            error="data_blocked",
+            detail="All explicitly selected sources failed quality checks",
+            meta=meta,
+            served_from="upstream",
+            policy=policy,
+            report=report,
+            reject_reason=report.reject_reason,
+            access_issues=[f"{policy.source}: {report.reject_reason}"],
+            attempted_sources=[policy.source],
+            timeframe=timeframe,
+            timeframe_transform=result.timeframe_transform,
+            source_identity=source_identity,
+            selected_source=policy.source,
+            provider_symbol=result.provider_symbol or requested_ticker,
+        )
     return _build_response(
         result.provider_symbol or requested_ticker,
         asset_class,

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -22,6 +22,12 @@ from kline.models import (
     InstrumentDefinition,
 )
 from kline.combined_health import build_combined_health_matrix
+from kline.market_query import (
+    MarketQueryReader,
+    MarketQueryResult,
+    get_market_query_reader,
+    query_backend_status,
+)
 from kline.free_source_profile import apply_free_source_profile
 from kline.health_matrix import (
     MATRIX_SCOPE_DEMO,
@@ -420,6 +426,10 @@ def _block_if_quality_rejected(
     meta: ProviderMeta,
     policy: RequestPolicy,
     served_from: str,
+    timeframe: Timeframe | None = None,
+    timeframe_transform: TimeframeTransform | Mapping[str, Any] | None = None,
+    source_identity: Mapping[str, Any] | None = None,
+    provider_symbol: str | None = None,
 ) -> None:
     if report.reject_reason:
         raise _error(
@@ -430,7 +440,119 @@ def _block_if_quality_rejected(
             served_from=served_from,
             policy=policy,
             report=report,
+            timeframe=timeframe,
+            timeframe_transform=timeframe_transform,
+            source_identity=source_identity,
+            provider_symbol=provider_symbol,
         )
+
+
+def _market_database_response(
+    result: MarketQueryResult,
+    *,
+    requested_ticker: str,
+    asset_class: AssetClass,
+    timeframe: Timeframe,
+    meta: ProviderMeta,
+    policy: RequestPolicy,
+) -> CandleResponse:
+    candles = list(result.candles)
+    report = analyze_candles(candles, timeframe, meta, strict=policy.strict_quality)
+    _block_if_quality_rejected(
+        report=report,
+        meta=meta,
+        policy=policy,
+        served_from="market_data_database",
+        timeframe=timeframe,
+        timeframe_transform=result.timeframe_transform,
+        source_identity={
+            **dict(result.source_identity or {}),
+            "requested_ticker": requested_ticker,
+        },
+        provider_symbol=result.provider_symbol or requested_ticker,
+    )
+    return _build_response(
+        result.provider_symbol or requested_ticker,
+        asset_class,
+        timeframe,
+        candles,
+        meta,
+        # Keep the established consumer contract. The more precise storage
+        # origin is explicit inside source_identity.query_served_from.
+        served_from="upstream",
+        policy=policy,
+        selected_source=policy.source,
+        attempted_sources=[policy.source],
+        instrument_id=result.instrument_id,
+        timeframe_transform=result.timeframe_transform,
+        source_identity={
+            **dict(result.source_identity or {}),
+            "requested_ticker": requested_ticker,
+        },
+    )
+
+
+def _annotate_legacy_response(
+    response: CandleResponse,
+    *,
+    reader: MarketQueryReader,
+    miss: MarketQueryResult,
+    requested_ticker: str,
+    asset_class: AssetClass,
+    timeframe: Timeframe,
+) -> CandleResponse:
+    query_served_from = (
+        "legacy_cache" if response.served_from == "cache" else "legacy_upstream"
+    )
+    miss_reason = miss.miss_reason or "market_data_unavailable"
+    reader.record_legacy_fallback(
+        asset_class=asset_class,
+        ticker=requested_ticker,
+        timeframe=timeframe,
+        miss_reason=miss_reason,
+    )
+    return response.model_copy(
+        update={
+            "source_identity": {
+                **dict(response.source_identity),
+                "served_from": query_served_from,
+                "query_served_from": query_served_from,
+                "market_data_miss_reason": miss_reason,
+            }
+        }
+    )
+
+
+def _annotate_legacy_error(
+    error: HTTPException,
+    *,
+    reader: MarketQueryReader,
+    miss: MarketQueryResult,
+    requested_ticker: str,
+    asset_class: AssetClass,
+    timeframe: Timeframe,
+) -> HTTPException:
+    detail = dict(error.detail) if isinstance(error.detail, Mapping) else {"detail": error.detail}
+    top_level_origin = str(detail.get("served_from") or "upstream")
+    query_served_from = (
+        "legacy_cache" if top_level_origin == "cache" else "legacy_upstream"
+    )
+    miss_reason = miss.miss_reason or "market_data_unavailable"
+    reader.record_legacy_fallback(
+        asset_class=asset_class,
+        ticker=requested_ticker,
+        timeframe=timeframe,
+        miss_reason=miss_reason,
+    )
+    identity = detail.get("source_identity")
+    detail["source_identity"] = {
+        **(dict(identity) if isinstance(identity, Mapping) else {}),
+        "served_from": query_served_from,
+        "query_served_from": query_served_from,
+        "market_data_miss_reason": miss_reason,
+    }
+    error.detail = detail
+    return error
 
 
 async def _fetch_upstream_candles(
@@ -774,6 +896,43 @@ async def get_candles(
             access_issues=[f"unsupported symbol/timeframe: {ticker}/{timeframe.value}"],
         )
 
+    try:
+        market_reader = get_market_query_reader()
+    except RuntimeError as error:
+        raise _error(
+            status_code=503,
+            error="market_query_unavailable",
+            detail="Market Data Database query backend is not configured",
+            meta=meta,
+            served_from="market_data_database",
+            policy=policy,
+            timeframe=timeframe,
+            provider_symbol=ticker,
+            reject_reason="market_query_configuration_missing",
+            access_issues=[type(error).__name__],
+        ) from error
+    market_miss: MarketQueryResult | None = None
+    if market_reader is not None and not policy.require_execution_venue:
+        market_result = market_reader.read(
+            asset_class=asset_class,
+            ticker=requested_ticker,
+            timeframe=timeframe,
+            requested_source="auto" if policy.requested_source == "auto" else policy.source,
+            limit=limit,
+            start=start,
+            end=end,
+        )
+        if market_result.hit:
+            return _market_database_response(
+                market_result,
+                requested_ticker=requested_ticker,
+                asset_class=asset_class,
+                timeframe=timeframe,
+                meta=meta,
+                policy=policy,
+            )
+        market_miss = market_result
+
     store = get_store()
 
     if policy.cache_policy in (CachePolicy.ALLOW, CachePolicy.REQUIRE):
@@ -788,14 +947,26 @@ async def get_candles(
         )
         if cached:
             report = analyze_candles(cached, timeframe, meta, strict=policy.strict_quality)
-            _block_if_quality_rejected(
-                report=report,
-                meta=meta,
-                policy=policy,
-                served_from="cache",
-            )
+            try:
+                _block_if_quality_rejected(
+                    report=report,
+                    meta=meta,
+                    policy=policy,
+                    served_from="cache",
+                )
+            except HTTPException as error:
+                if market_reader is not None and market_miss is not None:
+                    raise _annotate_legacy_error(
+                        error,
+                        reader=market_reader,
+                        miss=market_miss,
+                        requested_ticker=requested_ticker,
+                        asset_class=asset_class,
+                        timeframe=timeframe,
+                    ) from error
+                raise
             if timeframe in (Timeframe.DAY, Timeframe.HOUR_4, Timeframe.WEEK):
-                raise _error(
+                error = _error(
                     status_code=503,
                     error="data_blocked",
                     detail="Cached timeframe transformation metadata is unavailable",
@@ -810,7 +981,17 @@ async def get_candles(
                     reject_reason="timeframe_transform_missing",
                     access_issues=["legacy cache row has no timeframe transformation receipt"],
                 )
-            return _build_response(
+                if market_reader is not None and market_miss is not None:
+                    raise _annotate_legacy_error(
+                        error,
+                        reader=market_reader,
+                        miss=market_miss,
+                        requested_ticker=requested_ticker,
+                        asset_class=asset_class,
+                        timeframe=timeframe,
+                    )
+                raise error
+            response = _build_response(
                 ticker,
                 asset_class,
                 timeframe,
@@ -822,8 +1003,20 @@ async def get_candles(
                     policy.source, asset_class
                 ).canonical_instrument_id(requested_ticker),
             )
+            return (
+                _annotate_legacy_response(
+                    response,
+                    reader=market_reader,
+                    miss=market_miss,
+                    requested_ticker=requested_ticker,
+                    asset_class=asset_class,
+                    timeframe=timeframe,
+                )
+                if market_reader is not None and market_miss is not None
+                else response
+            )
         if policy.cache_policy == CachePolicy.REQUIRE:
-            raise _error(
+            error = _error(
                 status_code=404,
                 error="cache_miss",
                 detail="cache_policy=require but no cached candles were found",
@@ -838,16 +1031,50 @@ async def get_candles(
                 attempted_sources=[policy.source],
                 provider_symbol=ticker,
             )
+            if market_reader is not None and market_miss is not None:
+                raise _annotate_legacy_error(
+                    error,
+                    reader=market_reader,
+                    miss=market_miss,
+                    requested_ticker=requested_ticker,
+                    asset_class=asset_class,
+                    timeframe=timeframe,
+                )
+            raise error
 
-    return await _fetch_upstream_candles(
-        asset_class=asset_class,
-        timeframe=timeframe,
-        start=start,
-        end=end,
-        limit=limit,
-        meta=meta,
-        policy=policy,
-        ticker=requested_ticker,
+    try:
+        response = await _fetch_upstream_candles(
+            asset_class=asset_class,
+            timeframe=timeframe,
+            start=start,
+            end=end,
+            limit=limit,
+            meta=meta,
+            policy=policy,
+            ticker=requested_ticker,
+        )
+    except HTTPException as error:
+        if market_reader is not None and market_miss is not None:
+            raise _annotate_legacy_error(
+                error,
+                reader=market_reader,
+                miss=market_miss,
+                requested_ticker=requested_ticker,
+                asset_class=asset_class,
+                timeframe=timeframe,
+            ) from error
+        raise
+    return (
+        _annotate_legacy_response(
+            response,
+            reader=market_reader,
+            miss=market_miss,
+            requested_ticker=requested_ticker,
+            asset_class=asset_class,
+            timeframe=timeframe,
+        )
+        if market_reader is not None and market_miss is not None
+        else response
     )
 
 
@@ -1121,6 +1348,7 @@ async def health() -> dict:
         "storage": get_store().storage_health(),
         "storage_coverage": coverage,
         "latest_observations": get_store().latest_source_observations(),
+        "query_backend": query_backend_status(),
     }
 
 

--- a/src/kline/config.py
+++ b/src/kline/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     # Database
     db_path: str = "data/kline.db"
     read_only: bool = False
+    market_db_path: str = ""
+    query_backend: str = "legacy"
+    market_min_rows: int = 600
 
     # Server
     port: int = 8100

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -53,6 +53,7 @@ class IngestionPlan:
     run_id: str
     now: datetime | None = None
     history_start: str | None = None
+    force_history_start: bool = False
     overlap_bars: int = 2
     fetch_limit: int = 500
     max_retries: int = 2
@@ -430,6 +431,8 @@ class IngestionOrchestrator:
             raise IngestionError("request_interval_seconds must be non-negative")
         if plan.provider_timeout_seconds <= 0:
             raise IngestionError("provider_timeout_seconds must be positive")
+        if plan.force_history_start and not plan.history_start:
+            raise IngestionError("force_history_start requires history_start")
         selected_ids = set(plan.instrument_ids) if plan.instrument_ids is not None else None
         if selected_ids is not None:
             known_ids = {instrument.instrument_id for instrument in manifest.instruments}
@@ -558,8 +561,14 @@ class IngestionOrchestrator:
                     quality_counts["fail"] += 1
                     continue
                 key = self._key(instrument, timeframe, manifest)
-                request_start = self._overlap_start(
-                    key, history_start=plan.history_start, overlap_bars=plan.overlap_bars
+                request_start = (
+                    plan.history_start
+                    if plan.force_history_start
+                    else self._overlap_start(
+                        key,
+                        history_start=plan.history_start,
+                        overlap_bars=plan.overlap_bars,
+                    )
                 )
                 adapter = self._adapter_resolver(instrument)
                 request_count += 1

--- a/src/kline/market_query.py
+++ b/src/kline/market_query.py
@@ -1,0 +1,364 @@
+"""Identity-aware, read-only serving adapter for the Market Data Database."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import threading
+from typing import Any
+
+from kline.config import get_settings
+from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
+from kline.mvp_manifest import ManifestInstrument
+from kline.storage import CandleSeriesKey
+from kline.store import KlineReadOnlyStore
+from kline.watchlist_manifest import WatchlistManifest, load_watchlist_manifest
+
+
+QUERY_BACKEND_ENV = "KLINE_QUERY_BACKEND"
+MARKET_DB_ENV = "KLINE_MARKET_DB_PATH"
+MARKET_FIRST = "market_first"
+LEGACY = "legacy"
+
+_LEGACY_ASSET_CLASS_COMPATIBILITY = {
+    (AssetClass.US_STOCK.value, "UUP"): "WATCH.CROSS.DXY",
+    (AssetClass.US_STOCK.value, "SPY"): "WATCH.CROSS.SPX",
+    (AssetClass.US_STOCK.value, "QQQ"): "WATCH.CROSS.NDX",
+    (AssetClass.US_STOCK.value, "SCHD"): "WATCH.CROSS.SCHD",
+    (AssetClass.US_STOCK.value, "^VIX"): "WATCH.CROSS.VIX",
+}
+
+# Yahoo intermittently returns UUP's 2026-08-28 row.  Until a later quality
+# ticket fixes and re-verifies that historical gap, every DXY-proxy request
+# stays on the explicit legacy path rather than serving a divergent series.
+_FORCED_LEGACY_IDENTITIES = {"WATCH.CROSS.DXY": "market_window_unverified"}
+
+
+@dataclass(frozen=True)
+class MarketQueryResult:
+    hit: bool
+    miss_reason: str | None = None
+    candles: tuple[Candle, ...] = ()
+    instrument_id: str | None = None
+    provider_symbol: str | None = None
+    source_id: str | None = None
+    stored_asset_class: str | None = None
+    source_identity: dict[str, Any] | None = None
+    timeframe_transform: TimeframeTransform | None = None
+
+
+class MarketQueryReader:
+    """Resolve public query identities to exact Watchlist series and read them safely."""
+
+    def __init__(
+        self,
+        manifest_path: str | Path,
+        database_path: str | Path,
+        *,
+        minimum_series_rows: int = 600,
+    ) -> None:
+        if minimum_series_rows < 1:
+            raise ValueError("minimum_series_rows must be positive")
+        self.manifest: WatchlistManifest = load_watchlist_manifest(manifest_path)
+        self.store = KlineReadOnlyStore(str(database_path))
+        self.minimum_series_rows = minimum_series_rows
+        self._series_counts = {
+            (
+                str(row.get("source_id")),
+                str(row.get("instrument_id")),
+                str(row.get("timeframe")),
+                str(row.get("adjustment_basis")),
+                str(row.get("manifest_version")),
+            ): int(row.get("row_count", 0))
+            for row in self.store.mvp_latest_closed_bars()
+        }
+        self._source_identities = {
+            (
+                str(row.get("source_id")),
+                str(row.get("instrument_id")),
+                str(row.get("timeframe")),
+                str(row.get("manifest_version")),
+            ): dict(row.get("policy", {}).get("source_identity", {}))
+            for row in self.store.latest_mvp_source_observations()
+            if isinstance(row.get("policy"), dict)
+            and isinstance(row.get("policy", {}).get("source_identity"), dict)
+        }
+        self._lock = threading.Lock()
+        self._market_hits = 0
+        self._market_misses = 0
+        self._legacy_fallbacks = 0
+        self._miss_reasons: Counter[str] = Counter()
+        self._legacy_cells: set[str] = set()
+
+    def _class_compatible(
+        self,
+        item: ManifestInstrument,
+        *,
+        asset_class: AssetClass,
+        ticker: str,
+    ) -> bool:
+        if item.asset_class == asset_class.value:
+            return True
+        expected = _LEGACY_ASSET_CLASS_COMPATIBILITY.get(
+            (asset_class.value, ticker.upper())
+        )
+        return expected == item.instrument_id
+
+    def resolve_identity(
+        self,
+        *,
+        asset_class: AssetClass,
+        ticker: str,
+        requested_source: str,
+    ) -> ManifestInstrument | None:
+        normalized = ticker.upper().strip()
+        display_matches = [
+            item
+            for item in self.manifest.instruments
+            if item.display_symbol.upper() == normalized
+        ]
+        provider_matches = [
+            item
+            for item in self.manifest.instruments
+            if item.provider_symbol.upper() == normalized
+        ]
+        for item in (*display_matches, *provider_matches):
+            if not self._class_compatible(item, asset_class=asset_class, ticker=ticker):
+                continue
+            if requested_source != "auto" and item.source_id != requested_source:
+                continue
+            return item
+        return None
+
+    def _miss(self, reason: str) -> MarketQueryResult:
+        with self._lock:
+            self._market_misses += 1
+            self._miss_reasons[reason] += 1
+        return MarketQueryResult(hit=False, miss_reason=reason)
+
+    @staticmethod
+    def _exclusive_end(value: str | None) -> str | None:
+        """Convert the public provider-style exclusive end into a DB bound."""
+
+        if value is None:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return (parsed.astimezone(timezone.utc) - timedelta(microseconds=1)).isoformat()
+
+    def read(
+        self,
+        *,
+        asset_class: AssetClass,
+        ticker: str,
+        timeframe: Timeframe,
+        requested_source: str,
+        limit: int,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> MarketQueryResult:
+        item = self.resolve_identity(
+            asset_class=asset_class,
+            ticker=ticker,
+            requested_source=requested_source,
+        )
+        if item is None:
+            return self._miss("identity_not_found")
+        if timeframe.value not in item.required_timeframes:
+            return self._miss("timeframe_not_persisted")
+        if item.volume_semantics == "not_applicable":
+            return self._miss("volume_semantics_incompatible")
+        forced_legacy_reason = _FORCED_LEGACY_IDENTITIES.get(item.instrument_id)
+        if forced_legacy_reason is not None:
+            return self._miss(forced_legacy_reason)
+        key = CandleSeriesKey(
+            instrument_id=item.instrument_id,
+            display_symbol=item.display_symbol,
+            provider_symbol=item.provider_symbol,
+            source_id=item.source_id,
+            asset_class=item.asset_class,
+            timeframe=timeframe.value,
+            adjustment_basis=item.adjustment_basis,
+            manifest_version=self.manifest.version,
+        )
+        available_rows = self._series_counts.get(
+            (
+                key.source_id,
+                key.instrument_id,
+                key.timeframe,
+                key.adjustment_basis,
+                key.manifest_version,
+            ),
+            0,
+        )
+        if available_rows < max(self.minimum_series_rows, limit):
+            return self._miss("insufficient_market_history")
+        rows = self.store.query_mvp_candles(
+            key,
+            start=start,
+            end=self._exclusive_end(end),
+            limit=limit,
+        )
+        if not rows:
+            return self._miss("market_rows_missing")
+        watermark = self.store.get_mvp_watermark(key)
+        if watermark is None:
+            return self._miss("market_watermark_missing")
+        preserve_timestamp = item.source_id == "hyperliquid_perpetual_public"
+        candles = tuple(
+            Candle(
+                timestamp=(row.timestamp if preserve_timestamp else row.timestamp[:10]),
+                open=row.open,
+                high=row.high,
+                low=row.low,
+                close=row.close,
+                volume=float(row.volume or 0),
+                amount=row.amount,
+            )
+            for row in rows
+        )
+        metadata = {
+            key: item.metadata[key]
+            for key in ("identity_role", "proxy_for")
+            if key in item.metadata
+        }
+        persisted_identity = self._source_identities.get(
+            (
+                key.source_id,
+                key.instrument_id,
+                key.timeframe,
+                key.manifest_version,
+            ),
+            {},
+        )
+        source_identity = {
+            **persisted_identity,
+            "served_from": "market_data_database",
+            "query_served_from": "market_data_database",
+            "instrument_id": item.instrument_id,
+            "display_symbol": item.display_symbol,
+            "provider_symbol": item.provider_symbol,
+            "market_data_source_id": item.source_id,
+            "manifest_version": self.manifest.version,
+            "adjustment_basis": item.adjustment_basis,
+            "volume_semantics": item.volume_semantics,
+            "stored_asset_class": item.asset_class,
+            "requested_asset_class": asset_class.value,
+            **metadata,
+        }
+        with self._lock:
+            self._market_hits += 1
+        return MarketQueryResult(
+            hit=True,
+            candles=candles,
+            instrument_id=item.instrument_id,
+            provider_symbol=item.provider_symbol,
+            source_id=item.source_id,
+            stored_asset_class=item.asset_class,
+            source_identity=source_identity,
+            timeframe_transform=TimeframeTransform(
+                raw_timeframe=timeframe,
+                timeframe_origin="native",
+                aggregation={"kind": "none", "rule": "native_passthrough"},
+            ),
+        )
+
+    def record_legacy_fallback(
+        self,
+        *,
+        asset_class: AssetClass,
+        ticker: str,
+        timeframe: Timeframe,
+        miss_reason: str,
+    ) -> None:
+        cell = f"{asset_class.value}:{ticker}:{timeframe.value}"
+        with self._lock:
+            self._legacy_fallbacks += 1
+            self._legacy_cells.add(cell)
+            self._miss_reasons.setdefault(miss_reason, 0)
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "mode": MARKET_FIRST,
+                "market_database_path": "redacted",
+                "manifest_version": self.manifest.version,
+                "minimum_series_rows": self.minimum_series_rows,
+                "market_hits": self._market_hits,
+                "market_misses": self._market_misses,
+                "legacy_fallbacks": self._legacy_fallbacks,
+                "legacy_unique_cells": len(self._legacy_cells),
+                "miss_reasons": dict(self._miss_reasons),
+            }
+
+
+_reader_lock = threading.Lock()
+_reader_cache: dict[tuple[str, str, int], MarketQueryReader] = {}
+
+
+def query_backend_mode() -> str:
+    value = get_settings().query_backend.strip().casefold()
+    if value not in {LEGACY, MARKET_FIRST}:
+        raise RuntimeError(f"unsupported {QUERY_BACKEND_ENV}")
+    return value
+
+
+def get_market_query_reader() -> MarketQueryReader | None:
+    if query_backend_mode() != MARKET_FIRST:
+        return None
+    settings = get_settings()
+    database = settings.market_db_path.strip()
+    if not database:
+        raise RuntimeError(f"{MARKET_DB_ENV} is required for market_first")
+    manifest = Path(__file__).resolve().parents[2] / "configs" / "watchlist_manifest.json"
+    cache_key = (
+        str(manifest.resolve()),
+        str(Path(database).expanduser().resolve()),
+        settings.market_min_rows,
+    )
+    with _reader_lock:
+        if cache_key not in _reader_cache:
+            try:
+                _reader_cache[cache_key] = MarketQueryReader(
+                    cache_key[0],
+                    cache_key[1],
+                    minimum_series_rows=cache_key[2],
+                )
+            except Exception as error:
+                raise RuntimeError("market query backend unavailable") from error
+        return _reader_cache[cache_key]
+
+
+def query_backend_status() -> dict[str, Any]:
+    try:
+        reader = get_market_query_reader()
+    except RuntimeError as error:
+        return {
+            "mode": "invalid",
+            "status": "failed",
+            "detail": type(error).__name__,
+            "market_database_path": "redacted",
+            "market_hits": 0,
+            "market_misses": 0,
+            "legacy_fallbacks": 0,
+            "legacy_unique_cells": 0,
+            "miss_reasons": {},
+        }
+    if reader is None:
+        return {
+            "mode": LEGACY,
+            "status": "ready",
+            "market_database_path": "not_configured",
+            "market_hits": 0,
+            "market_misses": 0,
+            "legacy_fallbacks": 0,
+            "legacy_unique_cells": 0,
+            "miss_reasons": {},
+        }
+    return {"status": "ready", **reader.status()}

--- a/tests/test_consumer_cutover_backfill.py
+++ b/tests/test_consumer_cutover_backfill.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ops.consumer_cutover_backfill import (
+    CONSUMER_DAILY_INSTRUMENT_IDS,
+    MARKET_DATA_DB,
+    WATCHLIST_LOCK,
+    run_consumer_cutover_backfill,
+)
+
+
+def test_consumer_cutover_backfill_targets_only_approved_watchlist_daily_series() -> None:
+    assert len(CONSUMER_DAILY_INSTRUMENT_IDS) == 10
+    assert len(set(CONSUMER_DAILY_INSTRUMENT_IDS)) == 10
+    assert all(value.startswith("WATCH.CROSS.") for value in CONSUMER_DAILY_INSTRUMENT_IDS)
+    assert "WATCH.CROSS.VIX" not in CONSUMER_DAILY_INSTRUMENT_IDS
+    assert not any("TREASURY" in value for value in CONSUMER_DAILY_INSTRUMENT_IDS)
+
+
+@pytest.mark.asyncio
+async def test_consumer_cutover_backfill_rejects_noncanonical_database(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="persistent Market Data Database"):
+        await run_consumer_cutover_backfill(
+            db_path=tmp_path / "wrong.db",
+            lock_path=WATCHLIST_LOCK,
+        )
+
+
+@pytest.mark.asyncio
+async def test_consumer_cutover_backfill_rejects_short_history_request() -> None:
+    with pytest.raises(ValueError, match="1008-row request"):
+        await run_consumer_cutover_backfill(
+            db_path=MARKET_DATA_DB,
+            lock_path=WATCHLIST_LOCK,
+            fetch_limit=1007,
+        )

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -217,6 +217,68 @@ async def test_run_once_uses_watermark_overlap_and_is_idempotent(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_explicit_history_backfill_bypasses_existing_watermark(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "history-backfill.db"))
+
+    class RecordingAdapter(FakeCryptoAdapter):
+        def __init__(self) -> None:
+            self.starts: list[str | None] = []
+
+        async def fetch_candles_with_receipt(self, ticker, timeframe, *, start, end, limit):
+            self.starts.append(start)
+            return await super().fetch_candles_with_receipt(
+                ticker,
+                timeframe,
+                start=start,
+                end=end,
+                limit=limit,
+            )
+
+    adapter = RecordingAdapter()
+    orchestrator = IngestionOrchestrator(store, adapter_resolver=lambda _instrument: adapter)
+    await orchestrator.run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="watermark-first",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d",),
+        )
+    )
+    await orchestrator.run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="forced-history-backfill",
+            now=datetime(2026, 9, 2, 12, tzinfo=timezone.utc),
+            history_start="2021-01-01T00:00:00+00:00",
+            force_history_start=True,
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d",),
+        )
+    )
+
+    assert adapter.starts[-1] == "2021-01-01T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_explicit_history_backfill_requires_history_start(tmp_path: Path) -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "history-backfill-missing-start.db"))
+
+    with pytest.raises(IngestionError, match="requires history_start"):
+        await IngestionOrchestrator(store).run_once(
+            IngestionPlan(
+                manifest=manifest,
+                run_id="forced-history-backfill-missing-start",
+                force_history_start=True,
+                instrument_ids=("CRYPTO.PERP.BTC",),
+                timeframes=("1d",),
+            )
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_once_atomic_failure_leaves_rerun_point(tmp_path: Path) -> None:
     manifest = load_manifest(MANIFEST_PATH)
     store = KlineStore(str(tmp_path / "failure.db"))

--- a/tests/test_market_query.py
+++ b/tests/test_market_query.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from kline.app import create_app
+from kline.market_query import MarketQueryReader
+from kline.models import AssetClass, CachePolicy, Candle, QualityPolicy, Timeframe
+from kline.storage import (
+    CandleSeriesKey,
+    MvpCandle,
+    MvpRunWrite,
+    QualityReceiptWrite,
+    SourceObservationWrite,
+    WatermarkWrite,
+)
+from kline.store import KlineStore
+
+
+MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "watchlist_manifest.json"
+
+
+def _seed_spy(store: KlineStore, *, rows: int = 2) -> None:
+    key = CandleSeriesKey(
+        instrument_id="WATCH.CROSS.SPX",
+        display_symbol="SPX",
+        provider_symbol="SPY",
+        source_id="yahoo_finance_etf",
+        asset_class="etf",
+        timeframe="1d",
+        adjustment_basis="raw_unadjusted",
+        manifest_version="watchlist_universe_v1",
+    )
+    candles = tuple(
+        MvpCandle(
+            key=key,
+            timestamp=f"2026-09-0{index + 1}T00:00:00+00:00",
+            open=100 + index,
+            high=102 + index,
+            low=99 + index,
+            close=101 + index,
+            volume=1000 + index,
+        )
+        for index in range(rows)
+    )
+    run_id = "market-query-spy"
+    store.commit_mvp_run(
+        MvpRunWrite(
+            run_id=run_id,
+            manifest_version=key.manifest_version,
+            manifest_hash="a" * 64,
+            started_at="2026-09-03T07:00:00+00:00",
+            completed_at="2026-09-03T07:01:00+00:00",
+            window_start=None,
+            window_end="2026-09-03T07:00:00+00:00",
+            policy={},
+            candles=candles,
+            source_observations=(
+                SourceObservationWrite(
+                    run_id=run_id,
+                    key=key,
+                    success=True,
+                    request_start=None,
+                    request_end="2026-09-03T07:00:00+00:00",
+                    response_hash="b" * 64,
+                    policy={
+                        "source_identity": {
+                            "provider_symbol": "SPY",
+                            "repair_attempted": False,
+                        }
+                    },
+                    candle_count=len(candles),
+                    latest_timestamp=candles[-1].timestamp,
+                    observed_at="2026-09-03T07:01:00+00:00",
+                ),
+            ),
+            quality_receipts=(QualityReceiptWrite(run_id=run_id, key=key, status="pass"),),
+            watermarks=(
+                WatermarkWrite(
+                    key=key,
+                    last_closed_timestamp=candles[-1].timestamp,
+                    cursor=None,
+                    run_id=run_id,
+                ),
+            ),
+        )
+    )
+
+
+def test_resolver_maps_display_and_provider_aliases_without_generic_class_ignoring(
+    tmp_path: Path,
+) -> None:
+    market_db = tmp_path / "market.db"
+    KlineStore(str(market_db))
+    reader = MarketQueryReader(MANIFEST_PATH, market_db, minimum_series_rows=1)
+
+    expected = {
+        (AssetClass.ETF, "SPY", "yahoo_finance_etf"): "WATCH.CROSS.SPX",
+        (AssetClass.ETF, "QQQ", "yahoo_finance_etf"): "WATCH.CROSS.NDX",
+        (AssetClass.ETF, "UUP", "yahoo_finance_etf"): "WATCH.CROSS.DXY",
+        (AssetClass.INDEX, "^VIX", "yahoo_finance_index"): "WATCH.CROSS.VIX",
+        (AssetClass.US_STOCK, "SPY", "auto"): "WATCH.CROSS.SPX",
+        (AssetClass.US_STOCK, "QQQ", "auto"): "WATCH.CROSS.NDX",
+        (AssetClass.US_STOCK, "UUP", "auto"): "WATCH.CROSS.DXY",
+        (AssetClass.US_STOCK, "^VIX", "auto"): "WATCH.CROSS.VIX",
+    }
+    for (asset_class, ticker, source), instrument_id in expected.items():
+        resolved = reader.resolve_identity(
+            asset_class=asset_class,
+            ticker=ticker,
+            requested_source=source,
+        )
+        assert resolved is not None
+        assert resolved.instrument_id == instrument_id
+
+    assert reader.resolve_identity(
+        asset_class=AssetClass.COMMODITY,
+        ticker="SPY",
+        requested_source="auto",
+    ) is None
+    assert reader.resolve_identity(
+        asset_class=AssetClass.US_STOCK,
+        ticker="UNKNOWN",
+        requested_source="auto",
+    ) is None
+
+    dxy_long_window = reader.read(
+        asset_class=AssetClass.US_STOCK,
+        ticker="UUP",
+        timeframe=Timeframe.DAY,
+        requested_source="auto",
+        limit=1008,
+    )
+    assert dxy_long_window.hit is False
+    assert dxy_long_window.miss_reason == "market_window_unverified"
+    assert MarketQueryReader(MANIFEST_PATH, market_db, minimum_series_rows=1).read(
+        asset_class=AssetClass.ETF,
+        ticker="UUP",
+        timeframe=Timeframe.DAY,
+        requested_source="yahoo_finance_etf",
+        limit=300,
+    ).miss_reason == "market_window_unverified"
+
+
+def test_market_reader_returns_native_daily_data_and_explicit_misses(tmp_path: Path) -> None:
+    market_db = tmp_path / "market.db"
+    store = KlineStore(str(market_db))
+    _seed_spy(store)
+    store._engine.dispose()
+    reader = MarketQueryReader(MANIFEST_PATH, market_db, minimum_series_rows=1)
+
+    hit = reader.read(
+        asset_class=AssetClass.ETF,
+        ticker="SPY",
+        timeframe=Timeframe.DAY,
+        requested_source="yahoo_finance_etf",
+        limit=2,
+    )
+    assert hit.hit is True
+    assert [candle.timestamp for candle in hit.candles] == ["2026-09-01", "2026-09-02"]
+    assert hit.source_identity["query_served_from"] == "market_data_database"
+    assert hit.source_identity["instrument_id"] == "WATCH.CROSS.SPX"
+    assert hit.source_identity["identity_role"] == "proxy"
+    assert hit.source_identity["repair_attempted"] is False
+
+    exclusive_end = reader.read(
+        asset_class=AssetClass.ETF,
+        ticker="SPY",
+        timeframe=Timeframe.DAY,
+        requested_source="yahoo_finance_etf",
+        limit=1,
+        end="2026-09-02",
+    )
+    assert exclusive_end.hit is True
+    assert [candle.timestamp for candle in exclusive_end.candles] == ["2026-09-01"]
+
+    intraday = reader.read(
+        asset_class=AssetClass.ETF,
+        ticker="SPY",
+        timeframe=Timeframe.MIN_30,
+        requested_source="yahoo_finance_etf",
+        limit=2,
+    )
+    assert intraday.hit is False
+    assert intraday.miss_reason == "timeframe_not_persisted"
+
+    insufficient = MarketQueryReader(
+        MANIFEST_PATH, market_db, minimum_series_rows=3
+    ).read(
+        asset_class=AssetClass.ETF,
+        ticker="SPY",
+        timeframe=Timeframe.DAY,
+        requested_source="yahoo_finance_etf",
+        limit=3,
+    )
+    assert insufficient.hit is False
+    assert insufficient.miss_reason == "insufficient_market_history"
+
+    request_exceeds_history = reader.read(
+        asset_class=AssetClass.ETF,
+        ticker="SPY",
+        timeframe=Timeframe.DAY,
+        requested_source="yahoo_finance_etf",
+        limit=3,
+    )
+    assert request_exceeds_history.hit is False
+    assert request_exceeds_history.miss_reason == "insufficient_market_history"
+
+
+def test_market_first_api_preserves_envelope_and_marks_both_backends(
+    monkeypatch, tmp_path: Path
+) -> None:
+    legacy_db = tmp_path / "legacy.db"
+    market_db = tmp_path / "market.db"
+    legacy = KlineStore(str(legacy_db))
+    legacy.save(
+        "AAPL",
+        AssetClass.US_STOCK,
+        Timeframe.MIN_15,
+        [Candle(timestamp="2026-09-03T10:00:00+00:00", open=100, high=102, low=99, close=101, volume=10)],
+        source_id="yahoo_finance",
+    )
+    _seed_spy(KlineStore(str(market_db)), rows=1)
+    monkeypatch.setenv("KLINE_DB_PATH", str(legacy_db))
+    monkeypatch.setenv("KLINE_MARKET_DB_PATH", str(market_db))
+    monkeypatch.setenv("KLINE_QUERY_BACKEND", "market_first")
+    monkeypatch.setenv("KLINE_MARKET_MIN_ROWS", "1")
+    monkeypatch.setenv("KLINE_LOAD_ENTRYPOINT_ADAPTERS", "false")
+
+    with TestClient(create_app()) as client:
+        market = client.get(
+            "/api/candles/etf/SPY",
+            params={
+                "timeframe": "1d",
+                "source": "yahoo_finance_etf",
+                "cache_policy": CachePolicy.BYPASS.value,
+                "quality": QualityPolicy.STANDARD.value,
+                "limit": 1,
+            },
+        )
+        legacy_response = client.get(
+            "/api/candles/us_stock/AAPL",
+            params={
+                "timeframe": "15m",
+                "source": "yahoo_finance",
+                "cache_policy": CachePolicy.ALLOW.value,
+                "quality": QualityPolicy.STANDARD.value,
+                "limit": 1,
+            },
+        )
+        health = client.get("/api/health")
+        legacy_error = client.get(
+            "/api/candles/us_stock/MSFT",
+            params={
+                "timeframe": "1d",
+                "source": "yahoo_finance",
+                "cache_policy": CachePolicy.REQUIRE.value,
+                "quality": QualityPolicy.STANDARD.value,
+                "limit": 1,
+            },
+        )
+
+    assert market.status_code == 200
+    market_payload = market.json()
+    assert market_payload["ticker"] == "SPY"
+    assert market_payload["asset_class"] == "etf"
+    assert market_payload["served_from"] == "upstream"
+    assert market_payload["instrument_id"] == "WATCH.CROSS.SPX"
+    assert market_payload["source_identity"]["query_served_from"] == "market_data_database"
+
+    assert legacy_response.status_code == 200
+    legacy_payload = legacy_response.json()
+    assert legacy_payload["served_from"] == "cache"
+    assert legacy_payload["source_identity"]["query_served_from"] == "legacy_cache"
+    assert legacy_payload["source_identity"]["served_from"] == "legacy_cache"
+    assert legacy_payload["source_identity"]["market_data_miss_reason"] == (
+        "timeframe_not_persisted"
+    )
+
+    query_health = health.json()["query_backend"]
+    assert query_health["mode"] == "market_first"
+    assert query_health["market_hits"] == 1
+    assert query_health["legacy_fallbacks"] == 1
+    assert query_health["market_database_path"] == "redacted"
+
+    assert legacy_error.status_code == 404
+    legacy_error_identity = legacy_error.json()["detail"]["source_identity"]
+    assert legacy_error_identity["served_from"] == "legacy_cache"
+    assert legacy_error_identity["query_served_from"] == "legacy_cache"
+    assert legacy_error_identity["market_data_miss_reason"] == "identity_not_found"
+
+
+def test_market_first_missing_database_fails_closed_without_path(
+    monkeypatch, tmp_path: Path
+) -> None:
+    legacy_db = tmp_path / "legacy.db"
+    missing_market_db = tmp_path / "secret-market-location.db"
+    KlineStore(str(legacy_db))
+    monkeypatch.setenv("KLINE_DB_PATH", str(legacy_db))
+    monkeypatch.setenv("KLINE_MARKET_DB_PATH", str(missing_market_db))
+    monkeypatch.setenv("KLINE_QUERY_BACKEND", "market_first")
+    monkeypatch.setenv("KLINE_LOAD_ENTRYPOINT_ADAPTERS", "false")
+
+    with TestClient(create_app()) as client:
+        response = client.get(
+            "/api/candles/etf/SPY",
+            params={"timeframe": "1d", "source": "yahoo_finance_etf"},
+        )
+        health = client.get("/api/health")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "market_query_unavailable"
+    assert str(missing_market_db) not in response.text
+    assert health.json()["query_backend"] == {
+        "mode": "invalid",
+        "status": "failed",
+        "detail": "RuntimeError",
+        "market_database_path": "redacted",
+        "market_hits": 0,
+        "market_misses": 0,
+        "legacy_fallbacks": 0,
+        "legacy_unique_cells": 0,
+        "miss_reasons": {},
+    }
+
+
+def test_legacy_mode_remains_default_and_does_not_add_cutover_markers(
+    monkeypatch, tmp_path: Path
+) -> None:
+    legacy_db = tmp_path / "legacy-only.db"
+    legacy = KlineStore(str(legacy_db))
+    legacy.save(
+        "AAPL",
+        AssetClass.US_STOCK,
+        Timeframe.MIN_15,
+        [
+            Candle(
+                timestamp="2026-09-03T10:00:00+00:00",
+                open=100,
+                high=102,
+                low=99,
+                close=101,
+                volume=10,
+            )
+        ],
+        source_id="yahoo_finance",
+    )
+    monkeypatch.setenv("KLINE_DB_PATH", str(legacy_db))
+    monkeypatch.delenv("KLINE_QUERY_BACKEND", raising=False)
+    monkeypatch.delenv("KLINE_MARKET_DB_PATH", raising=False)
+    monkeypatch.setenv("KLINE_LOAD_ENTRYPOINT_ADAPTERS", "false")
+
+    with TestClient(create_app()) as client:
+        response = client.get(
+            "/api/candles/us_stock/AAPL",
+            params={
+                "timeframe": "15m",
+                "source": "yahoo_finance",
+                "cache_policy": "allow",
+            },
+        )
+        health = client.get("/api/health")
+
+    assert response.status_code == 200
+    assert "query_served_from" not in response.json()["source_identity"]
+    assert health.json()["query_backend"]["mode"] == "legacy"

--- a/tests/test_verify_consumer_cutover.py
+++ b/tests/test_verify_consumer_cutover.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from ops.verify_consumer_cutover import compare_snapshots, consumer_requests
+
+
+def test_consumer_request_set_matches_enumerated_runtime_contract() -> None:
+    requests = consumer_requests()
+    assert len(requests) == 69
+    assert sum(item.consumer == "newsletter" for item in requests) == 28
+    assert sum(
+        item.consumer == "human_review" and not item.conditional for item in requests
+    ) == 34
+    assert sum(item.conditional for item in requests) == 7
+    assert not any(item.ticker in {"DGS2", "DGS10", "T10Y2Y", "MES=F", "MNQ=F"} for item in requests)
+
+
+def test_snapshot_comparison_allows_only_pre_normalized_backend_metadata() -> None:
+    baseline = {
+        "cutoff": "2026-09-03T10:00:00+00:00",
+        "requests": [
+            {
+                "request_id": "one",
+                "http_status": 200,
+                "normalized_sha256": "a",
+                "candles_sha256": "b",
+                "candle_count": 2,
+            }
+        ],
+    }
+    candidate = {
+        "cutoff": baseline["cutoff"],
+        "requests": [
+            {
+                "request_id": "one",
+                "http_status": 200,
+                "normalized_sha256": "a",
+                "candles_sha256": "b",
+                "candle_count": 2,
+                "query_served_from": "market_data_database",
+            }
+        ],
+    }
+    result = compare_snapshots(baseline, candidate)
+    assert result["difference_count"] == 0
+    assert result["exact_match_count"] == 1
+    assert result["market_database_requests"] == 1


### PR DESCRIPTION
## What
- add an identity-aware, read-only Market Data Database query adapter behind the existing 8100 contract
- preserve explicit legacy/upstream fallback with per-response provenance and health counters
- add bounded Watchlist history backfill and a 69-cell consumer cutover verification harness
- correct ADR 0004; keep Treasury, Screening, #115, 18171, and 18172 out of scope

## Why
The legacy `klines` and Market Data Database `mvp_candles` schemas are incompatible, so changing only `KLINE_DB_PATH` would break the live Query Service. The adapter preserves the HTTP contract while making every storage origin observable and reversible.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` — 349 passed
- scoped Ruff on every changed Python file — passed
- `gitleaks detect --no-banner --redact --source . --no-git` — passed
- real history backfill — 10/10 cells passed, 14,603 promoted rows, zero blocked cells
- Market DB-routed live diff — 15/15 exact; full live set 61/69 because eight unchanged Yahoo/Tencent upstream requests differed across adjacent calls (documented, not claimed as pass)
- real Newsletter — 31/31 ready, 9 market / 22 legacy
- real Human Review — 16 assets, primary routes 6 market / 28 legacy
- real cutover → rollback → final cutover with `bootout → bootstrap` — passed

Closes #134