### PR TITLE
Add truthful Hong Kong Yahoo daily source

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -22,6 +22,7 @@
 - #133 已新增 `ready_unverified`，把“数据/质量/水位正常但免费源商业授权未认证”与真实 `partial/stale/failed/blocked` 分开。该状态计入数据健康覆盖但不冒充已认证 ready；真实质量闸和错误强度未放松。
 - #134 已为 8100 增加 Watchlist-only 的 identity-aware 双库查询层：旧 `klines` 继续承担显式 legacy/upstream，已验证且历史充分的 Watchlist 日线从只读 Market Data Database 提供，响应和 `/api/health` 明确标记真实后端。10 条日线已回填 14,603 根；实际 Newsletter 31/31 ready（9 market/22 legacy），Human Review 的主请求为 6 market/28 legacy。切换→回滚→再切换已真实演练，未改消费者、Screening、#115、18171 或 18172。Market 命中 15/15 byte-identical；全 69 实时重复请求因 Yahoo/Tencent 上游自身变化只能得到 61/69，未伪报为全量逐字节通过，详见 `docs/verification/consumer-market-database-cutover-2026-09-03.md`。
 - #139 已将 `zinan92/watchlist` 的 pinned snapshot（commit `29ce3c0`）编译为离线、可复现的 107 项 Price Universe：16 个 assets + 91 家 listed company（CN38/US48/HK4/KR1）。多赛道重复只保留一次采集身份但保留 registry provenance；已有 16 个 cross-market identity/source/proxy 字段逐项保持。#139 只建立编译/校验合同，尚未切换当前 58 项运行 manifest、provider、调度或面板；下一步按依赖进入 #140。
+- #140 已为 4 个港股注册 truthful `hk_stock` Yahoo 日线 source：`00100→0100.HK`、`02513→2513.HK`、`00700→0700.HK`、`09988→9988.HK`，使用香港时区和 HKEX provenance。四个 symbol 的真实 Yahoo preflight 均返回 3 根已闭合日线；#140 未切换当前 58 项 manifest、调度、面板或 8100。下一步进入 #141。
 
 ## 下一步
 - #69 中文 3+3 Health Matrix、#70 全量 216×5 矩阵和交互、#71 可靠性 runner、#81 免费 source 路由、#83 混合状态文案、#85 剩余 97+97 批处理器、#87 美股粗粒度源调整、#89 分阶段恢复、#91 Yahoo 点号 ticker 兼容、#93 空响应终止重试、#95 fallback 404 终止重试、#97 水位倒退保护、#99 provider 硬超时、#101 免费源 HTTP 超时上限、#103 Yahoo 历史请求线程化、#105 Yahoo 修复请求线程化、#107 Yahoo ISO intraday 窗口兼容、#111 Yahoo 美股全时间级别主源已合并；真实全量股票 seed 首轮已完成，Yahoo-only 首轮已验证 100 只美股五级别，DHR 两个粗粒度格按 fail-closed 记录，A 股开盘 forming-bar partial 按规则记录，601989 仍是已知缺口；全量常驻 worker 已切换为 100+100、4 小时刷新并保持 running。美股五级别统一 Yahoo，A 股继续 Tencent→Tonghuashun；日/周优先、日内失败降级、请求间隔/重试退避、P95/限流统计、水位不倒退、provider 超时和同步请求可取消已锁定。#71 七天验收仍开放且 blocked，#54 真实 30-day database acceptance 仍未开始。
@@ -29,4 +30,4 @@
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。
 - 完成 #115 的 24 小时调度锚点/开盘缓冲真实验收后，再按已批准顺序实施 #116；#118 不切换当前 #115 observer build，也不启动 #71 正式计时。
 - Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
-- 当前 Watchlist 主线：#139 registry compiler 已完成，#140 HK source contract 是下一张可启动票；随后按 #141 → #142 顺序激活 107 项日线采集并更新面板/8100。
+- 当前 Watchlist 主线：#139 registry compiler、#140 HK source contract 已完成，下一张可启动票为 #141；随后按 #142 激活 107 项日线采集并更新面板/8100。

--- a/decision-log.md
+++ b/decision-log.md
@@ -438,3 +438,13 @@ consumers can use without direct exchange or private SQLite access.
   snapshot provenance, so membership upgrades do not fork candle identity or duplicate history.
 - HK instruments use a truthful `hk_stock` declaration and exact Yahoo symbols (`0100.HK`, `2513.HK`,
   `0700.HK`, `9988.HK`). No provider adapter or live HK request was added in this ticket.
+
+## 2026-09-04 - Add truthful Hong Kong Yahoo daily routing
+
+- #140 registers `hk_stock` as a distinct public asset class and maps the four pinned registry codes
+  to exact Yahoo symbols: `00100→0100.HK`, `02513→2513.HK`, `00700→0700.HK`, `09988→9988.HK`.
+- HK daily cutoff uses `Asia/Hong_Kong`; provider receipts expose `market=HK` and `listing_venue=HKEX`.
+  Existing US, KR, CN, cross-market and Screening source registrations are unchanged.
+- Real Yahoo preflight returned three closed daily candles for all four symbols on 2026-09-04; each
+  required one yfinance repair pass for the current row, and none was synthesized. The active 58-item
+  Watchlist and scheduled runtime remain unchanged until #141/#142.

--- a/docs/verification/hong-kong-source-preflight-2026-09-04.md
+++ b/docs/verification/hong-kong-source-preflight-2026-09-04.md
@@ -1,0 +1,16 @@
+# Hong Kong Yahoo source preflight — 2026-09-04
+
+| Registry code | Yahoo symbol | Asset class | Result | Candles | Latest closed bar |
+|---|---|---|---|---:|---|
+| 00100 | 0100.HK | hk_stock | pass | 3 | 2026-09-03 |
+| 02513 | 2513.HK | hk_stock | pass | 3 | 2026-09-03 |
+| 00700 | 0700.HK | hk_stock | pass | 3 | 2026-09-03 |
+| 09988 | 9988.HK | hk_stock | pass | 3 | 2026-09-03 |
+
+The production-shaped probe used the registered Yahoo HK adapter and daily timeframe. All four
+responses carried `market=HK` and `listing_venue=HKEX`; each current row required the provider's
+existing one-row repair path. No row or volume was synthesized.
+
+Automated validation: 357 tests passed under `TZ=UTC`; changed-file Ruff passed. This ticket did not
+run the Watchlist worker, write the Market Data Database, reload the scheduler, update the health UI,
+deploy 8100, touch Screening/#115, or modify any consumer repository.

--- a/src/kline/provenance.py
+++ b/src/kline/provenance.py
@@ -406,6 +406,12 @@ _SOURCE_MANIFESTS: dict[str, SourceManifest] = {
         asset_class=AssetClass.HK_STOCK,
         meta=_PROVIDER_META[AssetClass.HK_STOCK],
         default_for_asset_class=True,
+        ticker_aliases={
+            "00100": "0100.HK",
+            "02513": "2513.HK",
+            "00700": "0700.HK",
+            "09988": "9988.HK",
+        },
         canonical_instrument_ids={
             "0100.HK": "00100",
             "2513.HK": "02513",

--- a/src/kline/providers/hk.py
+++ b/src/kline/providers/hk.py
@@ -1,0 +1,33 @@
+"""Hong Kong equity provider using Yahoo Finance's explicit ``.HK`` symbols."""
+
+from __future__ import annotations
+
+from kline.models import Candle, Timeframe
+from kline.providers.us import USStockProvider
+
+
+class HKStockProvider(USStockProvider):
+    """Reuse Yahoo OHLC parsing while stamping Hong Kong market provenance."""
+
+    async def fetch(
+        self,
+        ticker: str,
+        timeframe: Timeframe,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 500,
+    ) -> list[Candle]:
+        candles = await super().fetch(
+            ticker,
+            timeframe,
+            start=start,
+            end=end,
+            limit=limit,
+        )
+        self.source_identity = {
+            **self.source_identity,
+            "market": "HK",
+            "listing_venue": "HKEX",
+        }
+        return candles

--- a/src/kline/providers/us.py
+++ b/src/kline/providers/us.py
@@ -459,6 +459,8 @@ class USStockProvider:
 
 
 def _source_timezone(ticker: str) -> str:
+    if ticker.upper().endswith(".HK"):
+        return "Asia/Hong_Kong"
     if ticker.upper().endswith(".KS"):
         return "Asia/Seoul"
     return {

--- a/src/kline/registry.py
+++ b/src/kline/registry.py
@@ -20,6 +20,7 @@ from kline.providers.free_ashare import AShareFreeProvider
 from kline.providers.free_ashare_etf import TencentEtfFreeProvider
 from kline.providers.free_us import USFreeProvider
 from kline.providers.hyperliquid import HyperliquidPerpetualProvider
+from kline.providers.hk import HKStockProvider
 from kline.providers.sina import SinaIndexProvider
 from kline.providers.treasury import TreasuryCsvProvider
 from kline.providers.us import USStockProvider
@@ -68,6 +69,12 @@ def init(settings: Settings | None = None) -> None:
         ProviderBackedMarketDataAdapter(
             source_manifest("yahoo_finance", AssetClass.US_STOCK),
             _providers[AssetClass.US_STOCK],
+        )
+    )
+    register_adapter(
+        ProviderBackedMarketDataAdapter(
+            source_manifest("yahoo_finance_hk", AssetClass.HK_STOCK),
+            HKStockProvider(),
         )
     )
     register_adapter(

--- a/tests/test_hk_source.py
+++ b/tests/test_hk_source.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from kline.config import Settings
+from kline.models import AssetClass, Timeframe
+from kline.provenance import canonical_ticker_for_source, source_manifest
+from kline.providers.us import _source_timezone
+from kline.registry import get_adapter_for_source, init
+
+
+def test_hong_kong_source_normalizes_exact_registry_codes() -> None:
+    source = source_manifest("yahoo_finance_hk", AssetClass.HK_STOCK)
+    assert source.asset_class is AssetClass.HK_STOCK
+    assert source.supports_timeframe("00100", Timeframe.DAY)
+    assert source.supports_timeframe("0100.HK", Timeframe.DAY)
+    assert canonical_ticker_for_source("yahoo_finance_hk", AssetClass.HK_STOCK, "00100") == "0100.HK"
+    assert canonical_ticker_for_source("yahoo_finance_hk", AssetClass.HK_STOCK, "02513") == "2513.HK"
+    assert canonical_ticker_for_source("yahoo_finance_hk", AssetClass.HK_STOCK, "00700") == "0700.HK"
+    assert canonical_ticker_for_source("yahoo_finance_hk", AssetClass.HK_STOCK, "09988") == "9988.HK"
+    assert not source.supports_timeframe("00001", Timeframe.DAY)
+
+
+def test_hong_kong_symbols_use_hong_kong_market_timezone() -> None:
+    assert _source_timezone("0100.HK") == "Asia/Hong_Kong"
+
+
+def test_hong_kong_adapter_is_registered_without_changing_us_adapter(tmp_path: Path) -> None:
+    init(Settings(db_path=str(tmp_path / "hk.db"), load_entrypoint_adapters=False))
+    hk = get_adapter_for_source("yahoo_finance_hk", AssetClass.HK_STOCK)
+    us = get_adapter_for_source("yahoo_finance", AssetClass.US_STOCK)
+    assert hk.manifest.asset_class is AssetClass.HK_STOCK
+    assert hk.manifest.source_id == "yahoo_finance_hk"
+    assert us.manifest.asset_class is AssetClass.US_STOCK


### PR DESCRIPTION
## What
- register a distinct `hk_stock` asset class and Yahoo source
- normalize the four pinned registry codes to exact `.HK` symbols
- use Hong Kong timezone and HKEX provenance
- register a dedicated HK provider reusing the existing Yahoo OHLC quality path

## Why
The pinned Watchlist includes four listed Hong Kong companies. Treating them as US stocks would make provenance false; leaving them unregistered would make the 107-member compiler unverifiable.

## Validation
- `TZ=UTC PYTHONPATH=src python3 -m pytest -q` — 357 passed
- changed-file Ruff — passed
- `gitleaks detect --no-banner --redact --source . --no-git` — no leaks
- real Yahoo preflight: 4/4 symbols returned 3 closed daily candles; all carried HK/HKEX identity
- existing US/KR/CN/cross-market source tests passed
- no Watchlist worker, database, scheduler, health UI, 8100, Screening, #115, or consumer deployment changed

Closes #140