### PR TITLE
Persist and schedule the 107-member Watchlist

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -23,6 +23,7 @@
 - #134 已为 8100 增加 Watchlist-only 的 identity-aware 双库查询层：旧 `klines` 继续承担显式 legacy/upstream，已验证且历史充分的 Watchlist 日线从只读 Market Data Database 提供，响应和 `/api/health` 明确标记真实后端。10 条日线已回填 14,603 根；实际 Newsletter 31/31 ready（9 market/22 legacy），Human Review 的主请求为 6 market/28 legacy。切换→回滚→再切换已真实演练，未改消费者、Screening、#115、18171 或 18172。Market 命中 15/15 byte-identical；全 69 实时重复请求因 Yahoo/Tencent 上游自身变化只能得到 61/69，未伪报为全量逐字节通过，详见 `docs/verification/consumer-market-database-cutover-2026-09-03.md`。
 - #139 已将 `zinan92/watchlist` 的 pinned snapshot（commit `29ce3c0`）编译为离线、可复现的 107 项 Price Universe：16 个 assets + 91 家 listed company（CN38/US48/HK4/KR1）。多赛道重复只保留一次采集身份但保留 registry provenance；已有 16 个 cross-market identity/source/proxy 字段逐项保持。#139 只建立编译/校验合同，尚未切换当前 58 项运行 manifest、provider、调度或面板；下一步按依赖进入 #140。
 - #140 已为 4 个港股注册 truthful `hk_stock` Yahoo 日线 source：`00100→0100.HK`、`02513→2513.HK`、`00700→0700.HK`、`09988→9988.HK`，使用香港时区和 HKEX provenance。四个 symbol 的真实 Yahoo preflight 均返回 3 根已闭合日线；#140 未切换当前 58 项 manifest、调度、面板或 8100。下一步进入 #141。
+- #141 已将 pinned registry 的 107 项日线全部写入 Market Data Database：11/11 批次成功、107/107 current-ready、107 receipt/quality/watermark、1,630 promoted candles、P95 1,854.8ms，429/403/5xx/timeout/unclassified 均为 0。首轮暴露并修正 `hk_equities` calendar，四个港股最终全部成功；13 个旧本地 Watchlist identity 历史行保留但退出当前分母。调度、面板和 8100 仍由 #142 激活。
 
 ## 下一步
 - #69 中文 3+3 Health Matrix、#70 全量 216×5 矩阵和交互、#71 可靠性 runner、#81 免费 source 路由、#83 混合状态文案、#85 剩余 97+97 批处理器、#87 美股粗粒度源调整、#89 分阶段恢复、#91 Yahoo 点号 ticker 兼容、#93 空响应终止重试、#95 fallback 404 终止重试、#97 水位倒退保护、#99 provider 硬超时、#101 免费源 HTTP 超时上限、#103 Yahoo 历史请求线程化、#105 Yahoo 修复请求线程化、#107 Yahoo ISO intraday 窗口兼容、#111 Yahoo 美股全时间级别主源已合并；真实全量股票 seed 首轮已完成，Yahoo-only 首轮已验证 100 只美股五级别，DHR 两个粗粒度格按 fail-closed 记录，A 股开盘 forming-bar partial 按规则记录，601989 仍是已知缺口；全量常驻 worker 已切换为 100+100、4 小时刷新并保持 running。美股五级别统一 Yahoo，A 股继续 Tencent→Tonghuashun；日/周优先、日内失败降级、请求间隔/重试退避、P95/限流统计、水位不倒退、provider 超时和同步请求可取消已锁定。#71 七天验收仍开放且 blocked，#54 真实 30-day database acceptance 仍未开始。
@@ -30,4 +31,4 @@
 - 保持 canonical envelope 向后兼容并持续验证 Binance execution-venue 新鲜度；若走 API 外卖路线,先立商业化合同(对外发布风险轴归 Park)。
 - 完成 #115 的 24 小时调度锚点/开盘缓冲真实验收后，再按已批准顺序实施 #116；#118 不切换当前 #115 observer build，也不启动 #71 正式计时。
 - Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
-- 当前 Watchlist 主线：#139 registry compiler、#140 HK source contract 已完成，下一张可启动票为 #141；随后按 #142 激活 107 项日线采集并更新面板/8100。
+- 当前 Watchlist 主线：#139 registry compiler、#140 HK source contract、#141 107 项日线持久化已完成，下一张可启动票为 #142；随后激活面板/8100。

--- a/decision-log.md
+++ b/decision-log.md
@@ -448,3 +448,15 @@ consumers can use without direct exchange or private SQLite access.
 - Real Yahoo preflight returned three closed daily candles for all four symbols on 2026-09-04; each
   required one yfinance repair pass for the current row, and none was synthesized. The active 58-item
   Watchlist and scheduled runtime remain unchanged until #141/#142.
+
+## 2026-09-04 - Persist the 107-member Watchlist daily universe
+
+- #141 ran the compiled pinned manifest against the canonical Market Data Database in 11 batches.
+  The final rerun recorded 107/107 current-ready, 107 observations, 107 quality receipts, 107
+  watermarks and 1,630 promoted candles; P95 attempt latency was 1,854.8 ms.
+- Final rate-limit, forbidden, server, timeout and unclassified error counters were all zero. Four
+  HK cells failed only in the first run because the calendar declaration had not yet been wired;
+  after the calendar fix they passed and the original failed receipt remains preserved.
+- The database now contains all 107 active registry identities; the 13 old local-only identities
+  remain as retained historical rows and are excluded by current membership. The 07:15 scheduler and
+  health/8100 deployment remain for #142.

--- a/docs/verification/watchlist-107-ingestion-2026-09-04.md
+++ b/docs/verification/watchlist-107-ingestion-2026-09-04.md
@@ -1,0 +1,34 @@
+# Watchlist 107-member daily ingestion verification — 2026-09-04
+
+## Directly measured
+
+- Manifest: pinned `watchlist@29ce3c0`, `watchlist_universe_v1`, hash
+  `cc422784b5716ec82ebac80f5c559e62cbe288a34270d0d246fe5fe06b0a04f9`.
+- Run: `watchlist-20260903T162416Z-001` through `-011` (11 batches, 107 attempts).
+- Configured members: 107; active members with persisted closed daily data: 107/107.
+- Batch status: 11/11 success; current failures: 0; remaining after: 0.
+- Promoted candles in the verification run: 1,630; observations: 107; quality receipts: 107;
+  watermarks: 107.
+- Rate-limit/forbidden/server/timeout/unclassified error counters: all 0.
+- P95 attempt latency: 1,854.8 ms.
+- Duplicate storage keys: 0; future timestamps: 0.
+- HK rows persisted under `yahoo_finance_hk`: 4 instruments, 1,321 total daily rows; latest closed
+  bar 2026-09-03.
+
+The first scheduled-shaped run exposed the missing `hk_equities` calendar and correctly recorded all
+four HK cells as failed. After adding the calendar and rerunning, all four passed; the failed first
+receipt remains preserved as evidence and was not overwritten.
+
+## Retention check
+
+The database contains 107 active registry identities plus 13 retired identities from the prior local
+58-member Watchlist. Retired rows were retained and are excluded only by the active manifest; no
+historical row was deleted.
+
+## Boundaries
+
+The real run used the canonical Market Data Database and dedicated Watchlist lock. The active launchd
+schedule, health UI and 8100 runtime were not reloaded in this ticket; scheduler activation and
+consumer/runtime deployment are completed by #142.
+
+Automated validation: 357 tests passed under `TZ=UTC`; changed-file Ruff passed; gitleaks passed.

--- a/ops/com.wendy.datafeed.watchlist-daily.plist.example
+++ b/ops/com.wendy.datafeed.watchlist-daily.plist.example
@@ -10,7 +10,7 @@
         <string>-m</string>
         <string>ops.watchlist_seed</string>
         <string>--manifest</string>
-        <string>/Users/wendy/datafeed-runtime-watchlist/configs/watchlist_manifest.json</string>
+        <string>/Users/wendy/datafeed-runtime-watchlist/configs/watchlist_registry_manifest.json</string>
         <string>--db</string>
         <string>/Users/wendy/park-data/market/kline.db</string>
         <string>--lock</string>

--- a/src/kline/market_calendar.py
+++ b/src/kline/market_calendar.py
@@ -127,6 +127,17 @@ _CALENDARS = {
         four_hour_rule="kr_regular_fixed_4h_v1",
         four_hour_anchor=time(9, 0),
     ),
+    "hk_equities": CalendarSpec(
+        calendar_id="hk_equities",
+        timezone="Asia/Hong_Kong",
+        sessions=(
+            SessionWindow(time(9, 30), time(12, 0)),
+            SessionWindow(time(13, 0), time(16, 0)),
+        ),
+        continuous=False,
+        four_hour_rule="hk_regular_fixed_4h_v1",
+        four_hour_anchor=time(9, 30),
+    ),
 }
 
 

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -59,6 +59,15 @@ def test_manifest_cells_resolve_to_matching_calendar_specs() -> None:
         assert spec.timezone == instrument.timezone
 
 
+def test_hong_kong_calendar_uses_hong_kong_sessions() -> None:
+    spec = calendar_spec("hk_equities")
+    assert spec.timezone == "Asia/Hong_Kong"
+    assert [(window.open_time.isoformat(), window.close_time.isoformat()) for window in spec.sessions] == [
+        ("09:30:00", "12:00:00"),
+        ("13:00:00", "16:00:00"),
+    ]
+
+
 def test_cn_a_4h_joins_morning_and_afternoon_without_lunch_bars() -> None:
     key = _key(instrument_id="CN.A.300308", display_symbol="300308")
     session_date = date(2026, 8, 31)

--- a/tests/test_watchlist_launchd.py
+++ b/tests/test_watchlist_launchd.py
@@ -22,7 +22,7 @@ def test_watchlist_launchd_contract_is_daily_isolated_and_fail_closed() -> None:
     arguments = payload["ProgramArguments"]
     assert arguments[:3] == ["/usr/local/bin/python3", "-m", "ops.watchlist_seed"]
     assert arguments[arguments.index("--manifest") + 1] == (
-        f"{RUNTIME}/configs/watchlist_manifest.json"
+        f"{RUNTIME}/configs/watchlist_registry_manifest.json"
     )
     assert arguments[arguments.index("--db") + 1] == DATABASE
     assert arguments[arguments.index("--lock") + 1] == LOCK

--- a/tests/test_watchlist_seed.py
+++ b/tests/test_watchlist_seed.py
@@ -20,6 +20,7 @@ from ops.watchlist_seed import (
 
 
 MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "watchlist_manifest.json"
+REGISTRY_MANIFEST_PATH = Path(__file__).parents[1] / "configs" / "watchlist_registry_manifest.json"
 
 
 class _DailyAdapter:
@@ -139,6 +140,29 @@ async def test_watchlist_runner_persists_all_daily_members_without_screening_pro
     }
     assert {row["manifest_version"] for row in persisted} == {manifest.version}
     assert {row["timeframe"] for row in persisted} == {"1d"}
+
+
+@pytest.mark.asyncio
+async def test_watchlist_runner_persists_all_107_registry_members(tmp_path: Path) -> None:
+    manifest = load_watchlist_manifest(REGISTRY_MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "watchlist-107.db"))
+
+    report = await execute_watchlist_batches(
+        manifest=manifest,
+        store=store,
+        lock_path=tmp_path / "watchlist-107.lock",
+        adapter_resolver=lambda _instrument: _DailyAdapter(),
+        now=datetime(2026, 9, 4, 12, tzinfo=timezone.utc),
+        batch_size=10,
+        request_interval_seconds=0,
+    )
+
+    assert report["status"] == "success"
+    assert report["instrument_count"] == 107
+    assert report["persisted_instrument_count"] == 107
+    assert report["remaining_after"] == []
+    assert report["batch_count"] == 11
+    assert len(store.mvp_latest_closed_bars()) == 107
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
- run the existing Watchlist daily pipeline against the compiled 107-member registry manifest
- add the HK market calendar required for persisted Hong Kong daily bars
- point the scheduled-shaped plist contract at the compiled 107-member manifest
- record real receipt, watermark, rate-limit, latency, retention, and duplicate checks

## Why
The pinned Park Exposure Registry is now the Watchlist authority. Without a full persistence run, the new 91 listed companies and four HK symbols would exist only in configuration and not in the Market Data Database.

## Validation
- `TZ=UTC PYTHONPATH=src python3 -m pytest -q` — 359 passed
- changed-file Ruff — passed
- gitleaks — no leaks
- real 107-member run: 11/11 batches success, 107/107 current-ready, 107 observations/quality receipts/watermarks, 1,630 promoted candles
- real errors: 0 rate-limit, 0 forbidden, 0 server, 0 timeout, 0 unclassified; P95 1,854.8ms
- duplicate keys: 0; future timestamps: 0; HK persisted 4/4 symbols
- prior first run failure preserved; retry after calendar fix passed all four HK cells
- no health/8100 deployment; that is #142

Closes #141