### PR TITLE
Harden HK provenance and market grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,10 @@ Screening + Watchlist，并可按数据集筛选。合并视图需要同时配�
 路径。`source_identity.served_from` 与 `query_served_from` 会标出真实查询后端，
 `/api/health.query_backend` 汇总命中、回退和原因。默认 `legacy` 模式保持原行为。
 
+Watchlist 的韩国上市公司目前保留 `us_stock` API asset class 以兼容既有请求；健康面板和
+registry provenance 通过 `WATCH.KR.*` identity 与 `registry_market=KR` 单独归类为韩股。
+未来若需要公开独立 `kr_stock` 路由，应另立迁移合同。
+
 ### 参数
 
 | 参数 | 类型 | 默认值 | 说明 |

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -33,3 +33,4 @@
 - 完成 #115 的 24 小时调度锚点/开盘缓冲真实验收后，再按已批准顺序实施 #116；#118 不切换当前 #115 observer build，也不启动 #71 正式计时。
 - Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
 - 当前 Watchlist registry 主线（#139→#142）已完成：107 项名单、HK source、日线持久化、健康面板和 8100 双源运行均已落地；后续增量应以新的 registry pin/独立 issue 推进，不扩大本里程碑。
+- Sonnet review 后的 #147 hardening 已补上 HK provider 并发状态回归和 HK/KR 健康分组断言；KR 保留 `us_stock` API 兼容身份，面板以 `WATCH.KR.*`/registry metadata 单独显示韩股。

--- a/decision-log.md
+++ b/decision-log.md
@@ -475,3 +475,13 @@ consumers can use without direct exchange or private SQLite access.
   18171, Human Review and consumer code were untouched.
 - The combined aggregate can still say failed because Screening retains its independent blocked
   cells; the Watchlist-filtered view is healthy. Final canonical plist consolidation follows merge.
+
+## 2026-09-04 - Harden HK provenance and market grouping after Sonnet review
+
+- The Sonnet review found no P0/P1 issue. The valid P2 concern was provider identity state under
+  future direct concurrency; #147 now serializes `HKStockProvider` state and verifies the public
+  adapter seam with interleaved requests.
+- HK remains a truthful `hk_stock` source. KR deliberately remains `us_stock` at the public API for
+  backward compatibility, while `WATCH.KR.*` and `registry_market=KR` keep health grouping truthful.
+- Health tests now pin HK at 4 instruments/20 cells and KR at 1 instrument/5 cells, including commit
+  and source-hash provenance. No runtime restart or data mutation was needed for this hardening.

--- a/src/kline/providers/hk.py
+++ b/src/kline/providers/hk.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from kline.models import Candle, Timeframe
 from kline.providers.us import USStockProvider
 
 
 class HKStockProvider(USStockProvider):
     """Reuse Yahoo OHLC parsing while stamping Hong Kong market provenance."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._hk_fetch_lock = asyncio.Lock()
 
     async def fetch(
         self,
@@ -18,16 +24,17 @@ class HKStockProvider(USStockProvider):
         end: str | None = None,
         limit: int = 500,
     ) -> list[Candle]:
-        candles = await super().fetch(
-            ticker,
-            timeframe,
-            start=start,
-            end=end,
-            limit=limit,
-        )
-        self.source_identity = {
-            **self.source_identity,
-            "market": "HK",
-            "listing_venue": "HKEX",
-        }
-        return candles
+        async with self._hk_fetch_lock:
+            candles = await super().fetch(
+                ticker,
+                timeframe,
+                start=start,
+                end=end,
+                limit=limit,
+            )
+            self.source_identity = {
+                **self.source_identity,
+                "market": "HK",
+                "listing_venue": "HKEX",
+            }
+            return candles

--- a/tests/test_combined_health.py
+++ b/tests/test_combined_health.py
@@ -119,6 +119,22 @@ def test_combined_health_matrix_merges_screening_and_watchlist_stores(tmp_path) 
     assert snapshot["coverage"]["1d"]["ready_unverified"] == 1
     assert spx["quality"]["status"] == "pass"
     assert spx["watermark"]["run_id"] == "watchlist-spx-test"
+    hk_cells = [
+        cell
+        for cell in watchlist_cells
+        if cell["instrument_id"].startswith("WATCH.HK.")
+    ]
+    kr_cells = [
+        cell
+        for cell in watchlist_cells
+        if cell["instrument_id"].startswith("WATCH.KR.")
+    ]
+    assert len(hk_cells) == 4 * 5
+    assert len(kr_cells) == 1 * 5
+    assert {cell["metadata"]["registry_market"] for cell in hk_cells} == {"HK"}
+    assert {cell["metadata"]["registry_market"] for cell in kr_cells} == {"KR"}
+    assert all(len(cell["metadata"]["registry_commit"]) == 40 for cell in hk_cells + kr_cells)
+    assert all(len(cell["metadata"]["registry_source_sha256"]) == 64 for cell in hk_cells + kr_cells)
     assert snapshot["manifest_versions"] == {
         "screening": "mvp_universe_v1",
         "watchlist": "watchlist_universe_v1",

--- a/tests/test_hk_source.py
+++ b/tests/test_hk_source.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
+import pytest
+
 from kline.config import Settings
-from kline.models import AssetClass, Timeframe
+from kline.models import AssetClass, Candle, Timeframe
+from kline.ports import FetchReceipt, ProviderBackedMarketDataAdapter
 from kline.provenance import canonical_ticker_for_source, source_manifest
+from kline.providers.hk import HKStockProvider
 from kline.providers.us import _source_timezone
 from kline.registry import get_adapter_for_source, init
 
@@ -32,3 +37,45 @@ def test_hong_kong_adapter_is_registered_without_changing_us_adapter(tmp_path: P
     assert hk.manifest.asset_class is AssetClass.HK_STOCK
     assert hk.manifest.source_id == "yahoo_finance_hk"
     assert us.manifest.asset_class is AssetClass.US_STOCK
+
+
+@pytest.mark.asyncio
+async def test_hong_kong_adapter_serializes_shared_provider_state(monkeypatch) -> None:
+    active = 0
+    max_active = 0
+
+    async def fake_us_fetch(self, ticker, timeframe, *, start=None, end=None, limit=500):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        self.source_identity = {"provider_symbol": ticker}
+        active -= 1
+        return [
+            Candle(
+                timestamp="2026-09-03",
+                open=100,
+                high=102,
+                low=99,
+                close=101,
+                volume=10,
+            )
+        ]
+
+    monkeypatch.setattr("kline.providers.us.USStockProvider.fetch", fake_us_fetch)
+    adapter = ProviderBackedMarketDataAdapter(
+        source_manifest("yahoo_finance_hk", AssetClass.HK_STOCK),
+        HKStockProvider(),
+    )
+    first, second = await asyncio.gather(
+        adapter.fetch_candles_with_receipt("0100.HK", Timeframe.DAY, limit=1),
+        adapter.fetch_candles_with_receipt("2513.HK", Timeframe.DAY, limit=1),
+    )
+
+    assert isinstance(first, FetchReceipt)
+    assert isinstance(second, FetchReceipt)
+    assert max_active == 1
+    assert first.source_identity["provider_symbol"] == "0100.HK"
+    assert second.source_identity["provider_symbol"] == "2513.HK"
+    assert first.source_identity["market"] == "HK"
+    assert second.source_identity["listing_venue"] == "HKEX"


### PR DESCRIPTION
## What
- serialize HK provider provenance state for direct concurrent use
- add a public adapter-seam concurrency regression
- assert HK 4-instrument/20-cell and KR 1-instrument/5-cell grouping with registry provenance
- document the intentional KR `us_stock` API compatibility identity

## Why
The claude-sonnet-5 review found no P0/P1 findings and one valid P2 maintainability risk: HK provider identity was stored on a shared provider instance. The adapter already serialized production ingestion, but the invariant was implicit; this patch makes it explicit and testable.

## Validation
- Claude Code CLI `claude-sonnet-5` review: verified_success, receipt `/Users/wendy/.codex/cc-receipts/2026-09-03/20260903T165553Z_79f502a8-7cf7-4834-83e1-7637c01d69fe.json`
- `TZ=UTC PYTHONPATH=src python3 -m pytest -q` — 360 passed
- changed-file Ruff — passed
- gitleaks — no leaks
- no registry membership, database, scheduler, 8100/18172, consumer, Screening or #115 changes

Closes #147