### PR TITLE
Move Watchlist collection to 08:15 and catch up commodities

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -34,3 +34,4 @@
 - Watchlist 数据和独立双库健康面板已上线；下一步是重新设计消费者切换 spec，先纠正 ADR 0004 的“只换 db_path”错误假设，再做 Newsletter/Human Review 的逐字节切换验收。未经新 issue 批准不实施切换。
 - 当前 Watchlist registry 主线（#139→#142）已完成：107 项名单、HK source、日线持久化、健康面板和 8100 双源运行均已落地；后续增量应以新的 registry pin/独立 issue 推进，不扩大本里程碑。
 - Sonnet review 后的 #147 hardening 已补上 HK provider 并发状态回归和 HK/KR 健康分组断言；KR 保留 `us_stock` API 兼容身份，面板以 `WATCH.KR.*`/registry metadata 单独显示韩股。
+- #149 已将 Watchlist 工作日 daily trigger 从 07:15 调整到 08:15 北京时间，并完成 Gold/Silver/WTI 定向补采：3/3 quality pass、receipt/watermark 齐全、429/403/5xx/timeout/unclassified 均为 0。07:15 旧任务形成状态被保留为证据，后续自动轮次使用 08:15。

--- a/decision-log.md
+++ b/decision-log.md
@@ -485,3 +485,12 @@ consumers can use without direct exchange or private SQLite access.
   backward compatibility, while `WATCH.KR.*` and `registry_market=KR` keep health grouping truthful.
 - Health tests now pin HK at 4 instruments/20 cells and KR at 1 instrument/5 cells, including commit
   and source-hash provenance. No runtime restart or data mutation was needed for this hardening.
+
+## 2026-09-04 - Move Watchlist daily trigger to 08:15 and catch up commodities
+
+- #149 moves the weekday Watchlist trigger from 07:15 to 08:15 Beijing time. The earlier scheduled
+  run correctly found Gold, Silver and WTI still forming at 07:15 because the Yahoo continuous-future
+  daily bar closes at the UTC-day boundary.
+- A targeted post-close run selected only `WATCH.CROSS.GOLD`, `WATCH.CROSS.SILVER` and
+  `WATCH.CROSS.WTI`. All three passed quality, wrote 3 observations/receipts/watermarks and promoted
+  12 candles; rate-limit/403/5xx/timeout/unclassified counts were all zero, P95 2,362.5ms.

--- a/docs/verification/watchlist-commodity-catchup-2026-09-04.md
+++ b/docs/verification/watchlist-commodity-catchup-2026-09-04.md
@@ -1,0 +1,21 @@
+# Watchlist commodity post-close catch-up — 2026-09-04
+
+## Directly measured
+
+- Targeted identities: `WATCH.CROSS.GOLD` (`GC=F`), `WATCH.CROSS.SILVER` (`SI=F`),
+  `WATCH.CROSS.WTI` (`CL=F`). No other Watchlist identity was selected.
+- Run: `watchlist-20260904T012031Z-001`, one batch, three attempts.
+- Result: 3/3 success; 3 observations; 3 quality receipts; 3 watermarks; 12 promoted candles.
+- Quality: all three `pass`, zero forming/blocked issues.
+- Rate-limit, forbidden, server, timeout and unclassified errors: all zero.
+- P95 provider latency: 2,362.5 ms.
+- Latest persisted closed daily bars: 2026-09-03 for Gold, Silver and WTI.
+
+The preceding 07:15 scheduled run had correctly recorded these three bars as forming. The targeted
+post-close run was performed after 08:15 Beijing time and promoted the same-day closed bars without
+relaxing the quality gate.
+
+## Boundaries
+
+The catch-up reused the canonical Market Data Database and Watchlist lock. It did not touch Screening,
+#115, 18171, 18172, 8100, manifest membership, source mappings, or consumer repositories.

--- a/ops/com.wendy.datafeed.watchlist-daily.plist.example
+++ b/ops/com.wendy.datafeed.watchlist-daily.plist.example
@@ -43,11 +43,11 @@
     </dict>
     <key>StartCalendarInterval</key>
     <array>
-        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>15</integer></dict>
-        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>15</integer></dict>
-        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>15</integer></dict>
-        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>15</integer></dict>
-        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>15</integer></dict>
+        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>8</integer><key>Minute</key><integer>15</integer></dict>
+        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>8</integer><key>Minute</key><integer>15</integer></dict>
+        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>8</integer><key>Minute</key><integer>15</integer></dict>
+        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>8</integer><key>Minute</key><integer>15</integer></dict>
+        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>8</integer><key>Minute</key><integer>15</integer></dict>
     </array>
     <key>ProcessType</key>
     <string>Background</string>

--- a/ops/watchlist_commodity_catchup.py
+++ b/ops/watchlist_commodity_catchup.py
@@ -1,0 +1,63 @@
+"""One-shot post-close catch-up for Yahoo continuous-futures daily bars."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Sequence
+
+from ops.watchlist_seed import (
+    DEFAULT_MANIFEST,
+    MARKET_DATA_DB,
+    WATCHLIST_LOCK,
+    run_watchlist_seed_once,
+)
+
+
+COMMODITY_INSTRUMENT_IDS = (
+    "WATCH.CROSS.GOLD",
+    "WATCH.CROSS.SILVER",
+    "WATCH.CROSS.WTI",
+)
+DEFAULT_RECEIPT = Path("/Users/wendy/park-data/market/watchlist-commodity-catchup.json")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Catch up Gold, Silver and WTI daily bars")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--db", default=str(MARKET_DATA_DB))
+    parser.add_argument("--lock", default=str(WATCHLIST_LOCK))
+    parser.add_argument("--receipt", default=str(DEFAULT_RECEIPT))
+    parser.add_argument("--request-interval", type=float, default=2.0)
+    parser.add_argument("--max-retries", type=int, default=2)
+    parser.add_argument("--retry-backoff", type=float, default=5.0)
+    parser.add_argument("--provider-timeout", type=float, default=45.0)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = asyncio.run(
+        run_watchlist_seed_once(
+            manifest_path=args.manifest,
+            db_path=args.db,
+            lock_path=args.lock,
+            request_interval_seconds=args.request_interval,
+            max_retries=args.max_retries,
+            retry_backoff_seconds=args.retry_backoff,
+            provider_timeout_seconds=args.provider_timeout,
+            instrument_ids=COMMODITY_INSTRUMENT_IDS,
+        )
+    )
+    rendered = json.dumps(report, ensure_ascii=False, sort_keys=True)
+    print(rendered)
+    receipt = Path(args.receipt).expanduser().resolve()
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["status"] == "success" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/watchlist_seed.py
+++ b/ops/watchlist_seed.py
@@ -111,18 +111,29 @@ async def execute_watchlist_batches(
     max_retries: int = 2,
     retry_backoff_seconds: float = 2.0,
     provider_timeout_seconds: float = 30.0,
+    instrument_ids: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     if batch_size <= 0:
         raise ValueError("batch_size must be positive")
     if request_interval_seconds < 0:
         raise ValueError("request_interval_seconds must be non-negative")
     manifest_hash = manifest.validated_digest()
+    selected_ids = (
+        tuple(instrument_ids)
+        if instrument_ids is not None
+        else tuple(item.instrument_id for item in manifest.instruments)
+    )
+    known_ids = {item.instrument_id for item in manifest.instruments}
+    unknown_ids = sorted(set(selected_ids) - known_ids)
+    if unknown_ids:
+        raise ValueError(f"Watchlist target identities missing from manifest: {unknown_ids}")
+    if not selected_ids:
+        raise ValueError("Watchlist target selection must not be empty")
     orchestrator = IngestionOrchestrator(store, adapter_resolver=adapter_resolver)
     reports: list[dict[str, Any]] = []
     current_cells: dict[str, Any] = {}
-    instrument_ids = tuple(item.instrument_id for item in manifest.instruments)
     with _SingleRunLock(Path(lock_path)):
-        for batch_index, batch in enumerate(_batches(instrument_ids, batch_size), start=1):
+        for batch_index, batch in enumerate(_batches(selected_ids, batch_size), start=1):
             run_now = now or datetime.now(timezone.utc)
             run_id = (
                 f"watchlist-{run_now.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
@@ -173,37 +184,34 @@ async def execute_watchlist_batches(
         if latency_values
         else None
     )
-    persisted = _persisted_ids(store, manifest)
+    selected_set = set(selected_ids)
+    persisted = _persisted_ids(store, manifest) & selected_set
     remaining = [
-        item.instrument_id for item in manifest.instruments if item.instrument_id not in persisted
+        item_id for item_id in selected_ids if item_id not in persisted
     ]
     current_failed = [
-        item.instrument_id
-        for item in manifest.instruments
-        if current_cells.get(item.instrument_id) is None
-        or current_cells[item.instrument_id].status != "ready"
+        item_id
+        for item_id in selected_ids
+        if current_cells.get(item_id) is None or current_cells[item_id].status != "ready"
     ]
     statuses = {
-        item.instrument_id: {
-            "status": current_cells[item.instrument_id].status
-            if item.instrument_id in current_cells
+        item_id: {
+            "status": current_cells[item_id].status if item_id in current_cells
             else "missing_receipt",
             "reason": (
-                current_cells[item.instrument_id].error or current_cells[item.instrument_id].status
-            )
-            if item.instrument_id in current_cells
-            and current_cells[item.instrument_id].status != "ready"
+                current_cells[item_id].error or current_cells[item_id].status
+            ) if item_id in current_cells and current_cells[item_id].status != "ready"
             else None,
-            "available_in_store": item.instrument_id in persisted,
+            "available_in_store": item_id in persisted,
         }
-        for item in manifest.instruments
+        for item_id in selected_ids
     }
     return {
         "observed_at": (now or datetime.now(timezone.utc)).isoformat(),
         "status": "success" if not current_failed else "partial",
         "manifest_version": manifest.version,
         "manifest_hash": manifest_hash,
-        "instrument_count": len(manifest.instruments),
+        "instrument_count": len(selected_ids),
         "persisted_instrument_count": len(persisted),
         "remaining_after": remaining,
         "current_failed": current_failed,
@@ -236,6 +244,7 @@ async def run_watchlist_seed_once(
     max_retries: int = 2,
     retry_backoff_seconds: float = 2.0,
     provider_timeout_seconds: float = 30.0,
+    instrument_ids: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     database, lock_file = validate_watchlist_target(db_path, lock_path)
     manifest = load_watchlist_manifest(manifest_path)
@@ -249,6 +258,7 @@ async def run_watchlist_seed_once(
         max_retries=max_retries,
         retry_backoff_seconds=retry_backoff_seconds,
         provider_timeout_seconds=provider_timeout_seconds,
+        instrument_ids=instrument_ids,
     )
 
 

--- a/tests/test_watchlist_commodity_catchup.py
+++ b/tests/test_watchlist_commodity_catchup.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from ops.watchlist_commodity_catchup import COMMODITY_INSTRUMENT_IDS
+
+
+def test_commodity_catchup_is_fixed_to_the_three_post_close_instruments() -> None:
+    assert COMMODITY_INSTRUMENT_IDS == (
+        "WATCH.CROSS.GOLD",
+        "WATCH.CROSS.SILVER",
+        "WATCH.CROSS.WTI",
+    )

--- a/tests/test_watchlist_launchd.py
+++ b/tests/test_watchlist_launchd.py
@@ -33,7 +33,7 @@ def test_watchlist_launchd_contract_is_daily_isolated_and_fail_closed() -> None:
     assert payload["StandardOutPath"].endswith("/watchlist-daily.stdout.log")
     assert payload["StandardErrorPath"].endswith("/watchlist-daily.stderr.log")
     assert payload["StartCalendarInterval"] == [
-        {"Weekday": weekday, "Hour": 7, "Minute": 15} for weekday in range(1, 6)
+        {"Weekday": weekday, "Hour": 8, "Minute": 15} for weekday in range(1, 6)
     ]
     for forbidden in ("RunAtLoad", "KeepAlive", "StartInterval"):
         assert forbidden not in payload

--- a/tests/test_watchlist_seed.py
+++ b/tests/test_watchlist_seed.py
@@ -203,6 +203,34 @@ async def test_watchlist_current_failure_is_not_hidden_by_historical_coverage(
 
 
 @pytest.mark.asyncio
+async def test_watchlist_runner_can_target_only_selected_instruments(tmp_path: Path) -> None:
+    manifest = load_watchlist_manifest(REGISTRY_MANIFEST_PATH)
+    store = KlineStore(str(tmp_path / "watchlist-targeted.db"))
+    selected = (
+        "WATCH.CROSS.GOLD",
+        "WATCH.CROSS.SILVER",
+        "WATCH.CROSS.WTI",
+    )
+
+    report = await execute_watchlist_batches(
+        manifest=manifest,
+        store=store,
+        lock_path=tmp_path / "watchlist-targeted.lock",
+        adapter_resolver=lambda _instrument: _DailyAdapter(),
+        now=datetime(2026, 9, 4, 12, tzinfo=timezone.utc),
+        instrument_ids=selected,
+        batch_size=10,
+        request_interval_seconds=0,
+    )
+
+    assert report["status"] == "success"
+    assert report["instrument_count"] == 3
+    assert report["persisted_instrument_count"] == 3
+    assert report["batch_count"] == 1
+    assert {row["instrument_id"] for row in store.mvp_latest_closed_bars()} == set(selected)
+
+
+@pytest.mark.asyncio
 async def test_watchlist_runner_rejects_a_second_full_cycle_while_lock_is_held(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What
- move the weekday Watchlist launchd trigger from 07:15 to 08:15 Beijing time
- add a fixed, safe commodity catch-up runner for Gold, Silver and WTI
- allow the existing Watchlist runner to target a validated subset without changing its full 107-member behavior
- record today\u2019s post-close receipt and quality evidence

## Why
The 07:15 run correctly saw Yahoo continuous-futures daily bars for Gold/Silver/WTI as forming. The UTC-day bar boundary is crossed by 08:00 Beijing; 08:15 gives a small provider-lag buffer while keeping all other Watchlist behavior unchanged.

## Validation
- `TZ=UTC PYTHONPATH=src python3 -m pytest -q` — 362 passed
- changed-file Ruff — passed
- gitleaks — no leaks
- real targeted catch-up: Gold/Silver/WTI 3/3 quality pass, 3 receipts, 3 watermarks, 12 candles, latest 2026-09-03 bars, zero 429/403/5xx/timeout/unclassified, P95 2,362.5ms
- targeted path is fixed to exactly three `WATCH.CROSS.*` commodity IDs and reuses the canonical DB/lock
- no source, manifest membership, 8100, 18172, Screening, #115, 18171 or consumer changes

Closes #149