### PR TITLE
fix: keep empty MVP rows as unavailable receipts

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,36 @@
 # Decision Log
 
+## 2026-09-07 - Empty MVP rows remain an explicit unavailable cell
+
+Objective: prevent one provider response with zero rows from terminating the
+MVP worker cycle while preserving truthful quality and health receipts.
+
+### Decisions
+
+- Reuse the already-derived `instrument + timeframe + manifest` series key at
+  the ingestion call site when `_quality_receipt` receives no rows.
+- Persist an existing `missing` quality status for an empty response, retain
+  the `missing` issue detail and blocked-cell count, and expose the cell as
+  `unavailable` in the run and health matrix. No candle or watermark is
+  promoted.
+- Treat an empty upstream response as an observed attempt for health read-model
+  purposes, so the persisted cell is `unavailable` rather than a whole-run
+  `failed` status. Other cells in the same run continue normally.
+
+### Gotchas
+
+- The real two-cycle launchd acceptance remains owner-owned: this worktree did
+  not restart or reload `com.wendy.datafeed.mvp-worker` and cannot claim fresh
+  stderr or launchd-run evidence.
+- `missing` is a quality-receipt status, while `unavailable` is the dashboard
+  cell status; they are intentionally distinct layers of the contract.
+
+### Verification
+
+- `PYTHONPATH=src uv run pytest -q tests/test_ingestion.py tests/test_mvp_storage.py tests/test_health_matrix.py` -> 38 passed.
+- See `docs/verification/issue-153-empty-rows-receipt-2026-09-07.md` for the
+  local regression evidence and owner deployment command.
+
 ## 2026-07-09 - Trading live data path
 
 Objective: make datafeed reusable as a standard market-data layer while keeping research/cache data clearly separated from trading/live data.

--- a/docs/verification/issue-153-empty-rows-receipt-2026-09-07.md
+++ b/docs/verification/issue-153-empty-rows-receipt-2026-09-07.md
@@ -1,0 +1,64 @@
+# Issue #153 empty-rows receipt verification — 2026-09-07
+
+## Contract and boundary
+
+Issue: [#153](https://github.com/zinan92/datafeed/issues/153).
+
+The reported pre-fix evidence was 275 identical tracebacks in
+`com.wendy.datafeed.mvp-worker` stderr and `launchd runs = 277`; the failure
+was `rows[0].key` in `_quality_receipt` after a provider returned zero rows.
+This worktree only changes the ingestion receipt path, the accepted quality
+receipt statuses, and regression tests. It does not change the 8100 HTTP API,
+data sources, DB paths, live/real-money paths, launchd plists, or running
+workers.
+
+## Local post-fix regression evidence
+
+Command:
+
+```sh
+PYTHONPATH=src uv run pytest -q \
+  tests/test_ingestion.py \
+  tests/test_mvp_storage.py \
+  tests/test_health_matrix.py
+```
+
+Result: `38 passed`.
+
+The new regression exercises one run containing BTC with zero provider rows
+and ETH with one valid candle. Observed assertions:
+
+| Evidence | Result |
+| --- | --- |
+| Empty BTC run cell | `unavailable` |
+| Empty BTC quality receipt | `missing`, `blocked_cells=1`, issue `missing` |
+| ETH in the same run | `ready`, one candle promoted |
+| Health matrix BTC cell | `unavailable` |
+| Health matrix ETH cell | `ready_unverified` (technical status remains ready) |
+| Existing non-empty ingestion/storage/health tests | Included in 38 passed |
+
+This is deterministic local evidence, not a substitute for the required
+post-deployment two-cycle observation.
+
+## Required owner deployment evidence — pending
+
+Status: **待 owner 部署后验证**. This turn did not restart or reload the
+worker, so there is no honest post-fix two-cycle stderr/run-count result here.
+
+After deploying the PR to `~/datafeed-runtime-issue-115`, the owner should
+capture a baseline, observe two natural 4-hour cycles, and record the output:
+
+```sh
+RUNTIME="$HOME/datafeed-runtime-issue-115"
+LOG="$HOME/Library/Logs/datafeed/mvp-worker.stderr.log"
+launchctl print "gui/$(id -u)/com.wendy.datafeed.mvp-worker" \
+  | rg 'state =|runs =|path =|program|stdout path|stderr path'
+tail -n 0 -F "$LOG"
+```
+
+At each cycle boundary, record the worker `runs` value and the new stderr
+lines. Acceptance is met only if two consecutive 4-hour cycles add no new
+traceback and `runs` does not increase once per cycle; the health UI/API must
+show the affected cell as `unavailable`, not an overall `failed` round. Append
+the two-cycle before/after values and the original health URL to this document
+after owner-side deployment.

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -376,7 +376,11 @@ class IngestionOrchestrator:
 
     @staticmethod
     def _quality_receipt(
-        run_id: str, rows: Sequence[MvpCandle], quality: QualityResult
+        run_id: str,
+        rows: Sequence[MvpCandle],
+        quality: QualityResult,
+        *,
+        key: CandleSeriesKey,
     ) -> QualityReceiptWrite:
         counts = {
             status: sum(issue.status == status for issue in quality.issues)
@@ -390,14 +394,12 @@ class IngestionOrchestrator:
                 "partial",
             }
         }
-        key = rows[0].key if rows else None
-        if key is None:
-            raise IngestionError("quality receipt requires a series key")
+        receipt_key = rows[0].key if rows else key
         details = {"issues": [issue.__dict__ for issue in quality.issues]}
         return QualityReceiptWrite(
             run_id=run_id,
-            key=key,
-            status=quality.status,
+            key=receipt_key,
+            status="missing" if not rows else quality.status,
             gaps=counts["gap"],
             duplicates=counts["duplicate"],
             invalid_rows=counts["malformed"],
@@ -648,7 +650,9 @@ class IngestionOrchestrator:
                         market_open_buffer_minutes=plan.market_open_buffer_minutes,
                     )
                     quality_counts[quality.status] = quality_counts.get(quality.status, 0) + 1
-                    quality_receipt = self._quality_receipt(plan.run_id, mvp_rows, quality)
+                    quality_receipt = self._quality_receipt(
+                        plan.run_id, mvp_rows, quality, key=key
+                    )
                     qualities.append(quality_receipt)
                     response_hash = None
                     if fetch_receipt.raw_response is not None:
@@ -658,7 +662,7 @@ class IngestionOrchestrator:
                         SourceObservationWrite(
                             run_id=plan.run_id,
                             key=key,
-                            success=quality.status != "fail",
+                            success=quality.status != "fail" or not mvp_rows,
                             request_start=request_start,
                             request_end=end,
                             response_hash=response_hash,
@@ -736,7 +740,13 @@ class IngestionOrchestrator:
                                     ),
                                 )
                             )
-                    status = "ready" if quality.status == "pass" else quality.status
+                    status = (
+                        "ready"
+                        if quality.status == "pass"
+                        else "unavailable"
+                        if not mvp_rows
+                        else quality.status
+                    )
                     cell_error = None if quality.status != "fail" else "quality gate failed"
                     if source_attempts[-1].get("watermark_regression_suppressed"):
                         status = "partial"

--- a/src/kline/store.py
+++ b/src/kline/store.py
@@ -539,7 +539,7 @@ class KlineStore:
             if identity in quality_keys:
                 raise StorageError("duplicate quality receipt identity in one run")
             quality_keys.add(identity)
-            if quality.status not in {"pass", "partial", "blocked", "fail"}:
+            if quality.status not in {"pass", "partial", "blocked", "fail", "missing"}:
                 raise StorageError("quality receipt status is invalid")
             for field_name in ("gaps", "duplicates", "invalid_rows", "blocked_cells"):
                 value = getattr(quality, field_name)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from kline.free_source_profile import apply_free_source_profile
+from kline.health_matrix import build_mvp_health_matrix
 from kline.ingestion import IngestionError, IngestionOrchestrator, IngestionPlan
 from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import load_manifest
@@ -235,6 +236,71 @@ async def test_run_once_promotes_ready_crypto_cells_and_keeps_blocked_cells_expl
         item["policy"].get("source_identity", {}).get("provider_symbol") == "BTC"
         for item in observations
     )
+
+
+@pytest.mark.asyncio
+async def test_empty_provider_rows_write_missing_receipt_and_continue_other_cells(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "empty-rows.db"))
+    populated = FakeCryptoAdapter()
+
+    class EmptyRowsAdapter:
+        async def fetch_candles_with_receipt(
+            self, ticker, timeframe, *, start, end, limit
+        ) -> FetchReceipt:
+            if ticker == "BTC":
+                return FetchReceipt(
+                    candles=[],
+                    timeframe_transform=None,
+                    source_identity={"provider_symbol": ticker},
+                    raw_response={"row_count": 0},
+                )
+            return await populated.fetch_candles_with_receipt(
+                ticker, timeframe, start=start, end=end, limit=limit
+            )
+
+    receipt = await IngestionOrchestrator(
+        store,
+        adapter_resolver=lambda _instrument: EmptyRowsAdapter(),
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-empty-rows",
+            now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+            instrument_ids=("CRYPTO.PERP.BTC", "CRYPTO.PERP.ETH"),
+            timeframes=("1d",),
+            fetch_limit=10,
+        )
+    )
+
+    statuses = {cell.instrument_id: cell.status for cell in receipt.requested_cells}
+    assert receipt.status == "partial"
+    assert statuses == {"CRYPTO.PERP.BTC": "unavailable", "CRYPTO.PERP.ETH": "ready"}
+    assert receipt.row_counts["quality_receipts"] == 2
+    assert receipt.row_counts["promoted_candles"] == 1
+    quality = {
+        item["instrument_id"]: item for item in store.latest_mvp_quality_receipts()
+    }
+    assert quality["CRYPTO.PERP.BTC"]["status"] == "missing"
+    assert quality["CRYPTO.PERP.BTC"]["blocked_cells"] == 1
+    assert quality["CRYPTO.PERP.BTC"]["details"]["issues"][0]["status"] == "missing"
+    assert quality["CRYPTO.PERP.ETH"]["status"] == "pass"
+    matrix = build_mvp_health_matrix(
+        manifest,
+        store,
+        now=datetime(2026, 9, 1, 12, tzinfo=timezone.utc),
+        instrument_ids=("CRYPTO.PERP.BTC", "CRYPTO.PERP.ETH"),
+        free_source_ids={"hyperliquid_perpetual_public"},
+    )
+    daily_cells = {
+        cell["instrument_id"]: cell
+        for cell in matrix["cells"]
+        if cell["timeframe"] == "1d"
+    }
+    assert daily_cells["CRYPTO.PERP.BTC"]["status"] == "unavailable"
+    assert daily_cells["CRYPTO.PERP.ETH"]["status"] in {"ready", "ready_unverified"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

- Derive the quality receipt series key from the manifest instrument/timeframe key when a provider returns zero rows.
- Persist the existing `missing` quality semantic and expose the affected ingestion/health cell as `unavailable`.
- Keep the cycle running so other instruments continue; add regression coverage and verification evidence.

## Why

`mvp_rows` could be empty after a provider returned zero rows. `_quality_receipt` then indexed `rows[0].key`, raised an uncaught `IngestionError`, and terminated the full 4-hour worker cycle. This preserves the empty cell as explicit unavailable data instead of crashing the run.

## Validation

- `PYTHONPATH=src .venv/bin/pytest -q tests/test_ingestion.py tests/test_mvp_storage.py tests/test_health_matrix.py` -> `38 passed`.
- `.venv/bin/ruff check --select E9,F src/kline/ingestion.py src/kline/store.py tests/test_ingestion.py` -> `All checks passed!`.
- `gitleaks detect --source . --no-banner --redact=100` -> no leaks found.
- `git diff --check` -> passed.
- Full suite: `373 passed, 1 failed`; the failure is the pre-existing date-sensitive Binance daily test `test_binance_daily_excludes_current_active_bar_and_validates_ohlc`, which uses `date.today()` and failed with `No closed data returned for BTCUSDT (1d)`; unrelated to this change.
- Real post-deployment two-cycle worker evidence is not claimed. It is documented as owner-pending in `docs/verification/issue-153-empty-rows-receipt-2026-09-07.md`; no worker or launchd service was restarted.

Closes #153
