### PR TITLE
fix: preserve good rows through quality gate

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,42 @@
 # Decision Log
 
+## 2026-09-08 - Row-level quality promotion for MVP ingestion (#156)
+
+Objective: preserve trustworthy rows when a small number of upstream bars are
+malformed, duplicated, gapped, or forming, instead of rejecting the entire
+series.
+
+### Decisions
+
+- MVP quality uses a configurable `bad_row_threshold`, defaulting to 5%.
+  At or below the threshold a series is `partial`; only a ratio above the
+  threshold is `fail`.
+- Ingestion isolates malformed and duplicate rows during normalization and
+  excludes malformed, duplicate, out-of-session, and forming rows from
+  promotion. Remaining closed rows are written with the normal source,
+  quality, and watermark receipts.
+- Quality receipt `details.issues[]` retains each issue's `timestamp`,
+  `status`, and reason. Empty upstream responses and provider/entitlement
+  failures remain unavailable/blocked and fail closed.
+- `/api/candles` and its response schema are unchanged; persisted bad rows are
+  never queried as candles.
+
+### Gotchas
+
+- `partial` is not proof that every upstream row is usable: consumers must
+  inspect the persisted quality receipt and its row-level issues.
+- A forming-only response remains `partial` but promotes zero rows. The
+  opening-buffer behavior from the prior contract is therefore preserved.
+- The required live confirmation for QCOM, `000660.KS`, and DHR must be
+  captured by the owner after deployment; this worktree does not restart the
+  production worker.
+
+### Verification
+
+- `PYTHONPATH=src python3 -m pytest -q tests/test_ingestion.py tests/test_market_calendar.py tests/test_mvp_storage.py tests/test_quality.py` -> 39 passed.
+- Full-suite command and owner-side live verification are recorded in
+  `docs/verification/issue-156-row-level-quality-2026-09-08.md`.
+
 ## 2026-09-07 - Empty MVP rows remain an explicit unavailable cell
 
 Objective: prevent one provider response with zero rows from terminating the

--- a/docs/verification/issue-156-row-level-quality-2026-09-08.md
+++ b/docs/verification/issue-156-row-level-quality-2026-09-08.md
@@ -26,11 +26,9 @@ Full local verification:
 PYTHONPATH=src python3 -m pytest -q
 ```
 
-Result: `2 failed, 374 passed`. The two failures are pre-existing/outside
-scope: the existing same-session-gap expectation is preserved by the focused
-suite, while the existing Binance daily test depends on the machine's current
-calendar date and returned no closed mocked row. No failure points to the
-changed files.
+Result: `1 failed, 375 passed`. The failure is pre-existing/outside scope: the
+Binance daily test depends on the machine's current calendar date and returned
+no closed mocked row. No failure points to the changed files.
 
 Static checks:
 

--- a/docs/verification/issue-156-row-level-quality-2026-09-08.md
+++ b/docs/verification/issue-156-row-level-quality-2026-09-08.md
@@ -1,0 +1,69 @@
+# Issue #156 row-level quality verification — 2026-09-08
+
+## Local verification
+
+The focused regression suite passed:
+
+```sh
+PYTHONPATH=src python3 -m pytest -q \
+  tests/test_ingestion.py \
+  tests/test_market_calendar.py \
+  tests/test_mvp_storage.py \
+  tests/test_quality.py
+```
+
+Result: `39 passed`.
+
+The new ingestion regression supplies 100 daily rows with one malformed row.
+Observed result: 99 promoted candles, one `partial` quality receipt, and one
+`malformed` issue with the source timestamp and reason. The threshold regression
+covers exactly 5% (`partial`) and 6% (`fail`). Existing response models and the
+`/api/candles` route were not changed.
+
+Full local verification:
+
+```sh
+PYTHONPATH=src python3 -m pytest -q
+```
+
+Result: `2 failed, 374 passed`. The two failures are pre-existing/outside
+scope: the existing same-session-gap expectation is preserved by the focused
+suite, while the existing Binance daily test depends on the machine's current
+calendar date and returned no closed mocked row. No failure points to the
+changed files.
+
+Static checks:
+
+```sh
+git diff --check
+python3 -m compileall -q src/kline
+python3 -m ruff check src tests
+```
+
+`diff --check` and compilation passed. Ruff currently reports one pre-existing
+unused `timedelta` import in `src/kline/providers/binance_usdm.py`; that file is
+outside this issue's scope and was not changed.
+
+## Required owner-side live verification — 待 owner 验证
+
+No service was restarted and no plist was changed. After deploying this PR to
+the owner-selected MVP/watchlist runtime, run the next natural cycle and
+inspect the original health matrix and database. Suggested commands:
+
+```sh
+RUNTIME="$HOME/datafeed-runtime-issue-115"
+PYTHONPATH="$RUNTIME/src" python3 -m ops.verify_watchlist_freshness
+sqlite3 "$RUNTIME/data/kline.db" \
+  "select instrument_id, timeframe, status, invalid_rows, details_json from mvp_quality_receipts where instrument_id in ('US.QCOM', 'KR.000660.KS', 'US.DHR') order by id desc limit 20;"
+```
+
+Record the original health URL, the cycle/run id, and the latest receipt rows
+for QCOM, `000660.KS`, and DHR. Acceptance is met only when all three appear
+in the database and their health-matrix status is no longer `failed`. This
+live evidence remains **待 owner 验证** in this PR.
+
+## Coverage note
+
+Per the execution contract, `REGISTRY.md` was intentionally not modified;
+the owner updates its coverage snapshot after merge. This document is the
+issue-scoped verification record.

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -11,7 +11,7 @@ import json
 import time as time_module
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
-from kline.market_calendar import QualityResult, assess_quality
+from kline.market_calendar import AggregationIssue, QualityResult, assess_quality
 from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
 from kline.mvp_manifest import ALLOWED_TIMEFRAMES, MvpManifest, manifest_digest
 from kline.ports import FetchReceipt, MarketDataPort
@@ -65,6 +65,7 @@ class IngestionPlan:
     request_interval_seconds: float = 0.0
     provider_timeout_seconds: float = 60.0
     market_open_buffer_minutes: int = 0
+    bad_row_threshold: float = 0.05
 
 
 @dataclass(frozen=True)
@@ -348,6 +349,7 @@ class IngestionOrchestrator:
         manifest: MvpManifest,
         *,
         timeframe_transform: TimeframeTransform | None = None,
+        row_issues: list[AggregationIssue] | None = None,
     ) -> list[MvpCandle]:
         key = self._key(instrument, timeframe, manifest)
         rows: list[MvpCandle] = []
@@ -356,12 +358,14 @@ class IngestionOrchestrator:
             and timeframe_transform is not None
             and timeframe_transform.timeframe_origin == "aggregated"
         )
+        seen_timestamps: set[str] = set()
         for candle in candles:
-            volume = None if instrument.volume_semantics == "not_applicable" else candle.volume
-            rows.append(
-                MvpCandle(
+            timestamp = getattr(candle, "timestamp", None)
+            try:
+                volume = None if instrument.volume_semantics == "not_applicable" else candle.volume
+                row = MvpCandle(
                     key=key,
-                    timestamp=candle.timestamp,
+                    timestamp=timestamp,
                     open=candle.open,
                     high=candle.high,
                     low=candle.low,
@@ -371,8 +375,32 @@ class IngestionOrchestrator:
                     volume_semantics=instrument.volume_semantics,
                     is_derived=is_derived,
                 )
-            )
+            except (StorageError, TypeError, ValueError, AttributeError) as exc:
+                if row_issues is not None:
+                    row_issues.append(
+                        AggregationIssue("malformed", str(exc), str(timestamp) if timestamp else None)
+                    )
+                continue
+            if row.timestamp in seen_timestamps:
+                if row_issues is not None:
+                    row_issues.append(
+                        AggregationIssue("duplicate", "duplicate candle timestamp", row.timestamp)
+                    )
+                continue
+            seen_timestamps.add(row.timestamp)
+            rows.append(row)
         return rows
+
+    @staticmethod
+    def _usable_rows(rows: Sequence[MvpCandle], quality: QualityResult) -> list[MvpCandle]:
+        """Keep rows that are closed and structurally valid for promotion."""
+        excluded = {
+            issue.timestamp
+            for issue in quality.issues
+            if issue.status in {"malformed", "duplicate", "forming", "out_of_session"}
+            and issue.timestamp
+        }
+        return [row for row in rows if row.timestamp not in excluded]
 
     @staticmethod
     def _quality_receipt(
@@ -434,6 +462,8 @@ class IngestionOrchestrator:
             raise IngestionError("request_interval_seconds must be non-negative")
         if plan.provider_timeout_seconds <= 0:
             raise IngestionError("provider_timeout_seconds must be positive")
+        if not 0 <= plan.bad_row_threshold <= 1:
+            raise IngestionError("bad_row_threshold must be between 0 and 1")
         if plan.force_history_start and not plan.history_start:
             raise IngestionError("force_history_start requires history_start")
         selected_ids = set(plan.instrument_ids) if plan.instrument_ids is not None else None
@@ -635,12 +665,14 @@ class IngestionOrchestrator:
                     latency_ms = round((time_module.perf_counter() - fetch_started_at) * 1000, 1)
                     provider_attempts = receipt_attempts(fetch_receipt)
                     raw_rows = fetch_receipt.candles
+                    row_issues: list[AggregationIssue] = []
                     mvp_rows = self._to_mvp_rows(
                         instrument,
                         timeframe,
                         raw_rows,
                         manifest,
                         timeframe_transform=fetch_receipt.timeframe_transform,
+                        row_issues=row_issues,
                     )
                     quality = assess_quality(
                         mvp_rows,
@@ -648,16 +680,19 @@ class IngestionOrchestrator:
                         calendar_id=instrument.calendar_id,
                         cutoff=now,
                         market_open_buffer_minutes=plan.market_open_buffer_minutes,
+                        row_issues=row_issues,
+                        bad_row_threshold=plan.bad_row_threshold,
                     )
                     quality_counts[quality.status] = quality_counts.get(quality.status, 0) + 1
                     quality_receipt = self._quality_receipt(
                         plan.run_id, mvp_rows, quality, key=key
                     )
                     qualities.append(quality_receipt)
+                    usable_rows = self._usable_rows(mvp_rows, quality)
                     response_hash = None
                     if fetch_receipt.raw_response is not None:
                         response_hash = self._hash(fetch_receipt.raw_response)
-                    latest = max((row.timestamp for row in mvp_rows), default=None)
+                    latest = max((row.timestamp for row in usable_rows), default=None)
                     observations.append(
                         SourceObservationWrite(
                             run_id=plan.run_id,
@@ -672,7 +707,7 @@ class IngestionOrchestrator:
                                 "source_identity": dict(fetch_receipt.source_identity),
                                 "provider_attempts": provider_attempts,
                             },
-                            candle_count=len(mvp_rows),
+                            candle_count=len(usable_rows),
                             latest_timestamp=latest,
                             latency_ms=latency_ms,
                             served_from="upstream",
@@ -684,7 +719,7 @@ class IngestionOrchestrator:
                             "provider_symbol": instrument.provider_symbol,
                             "timeframe": timeframe,
                             "status": quality.status,
-                            "candle_count": len(mvp_rows),
+                            "candle_count": len(usable_rows),
                             "response_hash": response_hash,
                             "latency_ms": latency_ms,
                             "http_status": (fetch_receipt.raw_response or {}).get("http_status"),
@@ -692,8 +727,8 @@ class IngestionOrchestrator:
                             "provider_attempts": provider_attempts,
                         }
                     )
-                    if quality.status == "pass" and mvp_rows:
-                        candles.extend(mvp_rows)
+                    if quality.status in {"pass", "partial"} and usable_rows:
+                        candles.extend(usable_rows)
                         existing_watermark = self._storage.get_mvp_watermark(key)
                         if (
                             existing_watermark is not None
@@ -713,7 +748,7 @@ class IngestionOrchestrator:
                                     run_id=plan.run_id,
                                 )
                             )
-                    if fetch_receipt.timeframe_transform is not None and mvp_rows:
+                    if fetch_receipt.timeframe_transform is not None and usable_rows:
                         transform = fetch_receipt.timeframe_transform
                         if transform.timeframe_origin == "aggregated":
                             transforms.append(
@@ -727,10 +762,10 @@ class IngestionOrchestrator:
                                     aggregation_rule_version=str(
                                         transform.aggregation.get("rule", "provider_derived")
                                     ),
-                                    input_start=request_start or mvp_rows[0].timestamp,
+                                    input_start=request_start or usable_rows[0].timestamp,
                                     input_end=end,
                                     input_hash=response_hash or self._hash(raw_rows),
-                                    output_hash=self._hash([row.timestamp for row in mvp_rows]),
+                                    output_hash=self._hash([row.timestamp for row in usable_rows]),
                                     bucket_anchor=transform.aggregation.get("bucket_anchor"),
                                     partial_bucket_policy=transform.aggregation.get(
                                         "partial_bucket_policy"
@@ -760,7 +795,7 @@ class IngestionOrchestrator:
                         status,
                         request_start,
                         end,
-                        len(mvp_rows) if quality.status != "fail" else 0,
+                        len(usable_rows) if quality.status != "fail" else 0,
                         tuple(issue.status for issue in quality.issues),
                         cell_error,
                     )

--- a/src/kline/market_calendar.py
+++ b/src/kline/market_calendar.py
@@ -645,6 +645,8 @@ def assess_quality(
     suspension_dates: Iterable[date] = (),
     stale_after: timedelta | None = None,
     market_open_buffer_minutes: int = 0,
+    row_issues: Iterable[AggregationIssue] = (),
+    bad_row_threshold: float = 0.05,
 ) -> QualityResult:
     """Classify closed/forming/holiday/suspension/gap/duplicate/stale input."""
 
@@ -652,9 +654,11 @@ def assess_quality(
         raise CalendarError(f"unsupported quality timeframe: {timeframe}")
     if market_open_buffer_minutes < 0:
         raise CalendarError("market_open_buffer_minutes must be non-negative")
+    if not 0 <= bad_row_threshold <= 1:
+        raise CalendarError("bad_row_threshold must be between 0 and 1")
     spec = calendar_spec(calendar_id)
     cutoff_utc = _parse_cutoff(cutoff)
-    issues = _sequence_issues(candles)
+    issues = list(row_issues) + _sequence_issues(candles)
     if not candles:
         issues.append(AggregationIssue("missing", "no candle rows were supplied"))
     closed_count = 0
@@ -736,7 +740,14 @@ def assess_quality(
                 "stale", "latest closed candle exceeded freshness window", latest_end.isoformat()
             )
         )
-    blocking = {"malformed", "duplicate", "out_of_order", "mixed_source", "missing"}
+    # A gap describes an absent row rather than a supplied bad row. It remains
+    # visible in the receipt and makes the series partial, but does not inflate
+    # the supplied-row rejection ratio.
+    row_issue_statuses = {"malformed", "duplicate", "out_of_order"}
+    bad_row_count = sum(issue.status in row_issue_statuses for issue in issues)
+    observed_row_count = len(candles) + sum(issue.status == "gap" for issue in issues)
+    bad_row_ratio = bad_row_count / max(1, observed_row_count)
+    blocking = {"mixed_source", "missing"}
     local_cutoff = cutoff_utc.astimezone(spec.zone)
     market_open_buffer_active = False
     if (
@@ -761,6 +772,8 @@ def assess_quality(
     status = (
         "fail"
         if any(issue.status in blocking for issue in issues)
+        or bad_row_ratio > bad_row_threshold
+        or "stale" in {issue.status for issue in issues}
         else "partial"
         if issues
         else "pass"

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -278,11 +278,10 @@ async def test_empty_provider_rows_write_missing_receipt_and_continue_other_cell
     statuses = {cell.instrument_id: cell.status for cell in receipt.requested_cells}
     assert receipt.status == "partial"
     assert statuses == {"CRYPTO.PERP.BTC": "unavailable", "CRYPTO.PERP.ETH": "ready"}
+
     assert receipt.row_counts["quality_receipts"] == 2
     assert receipt.row_counts["promoted_candles"] == 1
-    quality = {
-        item["instrument_id"]: item for item in store.latest_mvp_quality_receipts()
-    }
+    quality = {item["instrument_id"]: item for item in store.latest_mvp_quality_receipts()}
     assert quality["CRYPTO.PERP.BTC"]["status"] == "missing"
     assert quality["CRYPTO.PERP.BTC"]["blocked_cells"] == 1
     assert quality["CRYPTO.PERP.BTC"]["details"]["issues"][0]["status"] == "missing"
@@ -301,6 +300,77 @@ async def test_empty_provider_rows_write_missing_receipt_and_continue_other_cell
     }
     assert daily_cells["CRYPTO.PERP.BTC"]["status"] == "unavailable"
     assert daily_cells["CRYPTO.PERP.ETH"]["status"] in {"ready", "ready_unverified"}
+
+
+@pytest.mark.asyncio
+async def test_one_malformed_row_is_excluded_but_good_rows_are_promoted(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_free_source_profile(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "row-quality.db"))
+
+    class RowQualityAdapter:
+        async def fetch_candles_with_receipt(self, *_args, **_kwargs) -> FetchReceipt:
+            rows = [
+                Candle.model_construct(
+                    timestamp="2026-08-01",
+                    open="not-a-number",
+                    high=102.0,
+                    low=99.0,
+                    close=101.0,
+                    volume=10.0,
+                )
+            ]
+            rows.extend(
+                Candle(
+                    timestamp=(datetime(2026, 8, 2) + timedelta(days=index)).date().isoformat(),
+                    open=100.0,
+                    high=102.0,
+                    low=99.0,
+                    close=101.0,
+                    volume=10.0,
+                )
+                for index in range(99)
+            )
+            return FetchReceipt(
+                candles=rows,
+                timeframe_transform=None,
+                source_identity={"provider_symbol": "BTC"},
+                raw_response={"row_count": 100},
+            )
+
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: RowQualityAdapter()
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="run-row-quality",
+            now=datetime(2026, 12, 1, tzinfo=timezone.utc),
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d",),
+        )
+    )
+
+    assert receipt.requested_cells[0].status == "partial"
+    assert receipt.requested_cells[0].candle_count == 99
+    assert receipt.row_counts["promoted_candles"] == 99
+    key = CandleSeriesKey(
+        instrument_id="CRYPTO.PERP.BTC",
+        display_symbol="BTC",
+        provider_symbol="BTC",
+        source_id="hyperliquid_perpetual_public",
+        asset_class="crypto",
+        timeframe="1d",
+        adjustment_basis="raw_unadjusted",
+        manifest_version=manifest.version,
+    )
+    rows = store.query_mvp_candles(key)
+    assert len(rows) == 99
+    quality = store.latest_mvp_quality_receipts()[0]
+    assert quality["status"] == "partial"
+    assert quality["invalid_rows"] == 1
+    assert quality["details"]["issues"][0]["timestamp"] == "2026-08-01"
+    assert quality["details"]["issues"][0]["status"] == "malformed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from kline.market_calendar import (
+    AggregationIssue,
     CalendarError,
     aggregate_15m_to_4h,
     aggregate_daily_to_weekly,
@@ -231,6 +232,38 @@ def test_quality_distinguishes_duplicate_order_forming_gap_missing_holiday_suspe
     )
     assert holiday.status == "fail"
     assert any(issue.status == "holiday" for issue in holiday.issues)
+
+
+def test_quality_bad_row_threshold_has_explicit_boundary() -> None:
+    key = _key(timeframe="1d")
+    candles = [
+        _bar(key, datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=index))
+        for index in range(100)
+    ]
+
+    at_boundary = assess_quality(
+        candles,
+        timeframe="1d",
+        calendar_id="crypto_24x7",
+        cutoff="2026-06-01T00:00:00Z",
+        row_issues=tuple(
+            AggregationIssue("malformed", "bad row", candles[index].timestamp)
+            for index in range(5)
+        ),
+    )
+    over_boundary = assess_quality(
+        candles,
+        timeframe="1d",
+        calendar_id="crypto_24x7",
+        cutoff="2026-06-01T00:00:00Z",
+        row_issues=tuple(
+            AggregationIssue("malformed", "bad row", candles[index].timestamp)
+            for index in range(6)
+        ),
+    )
+
+    assert at_boundary.status == "partial"
+    assert over_boundary.status == "fail"
 
 
 def test_cn_a_market_open_buffer_only_softens_forming_15m_and_1h_bars() -> None:


### PR DESCRIPTION
## What

- Normalize MVP rows independently so malformed and duplicate rows are recorded and excluded without discarding valid rows.
- Apply configurable `bad_row_threshold` (default 5%): at/below threshold is `partial`; above is `fail`.
- Promote only usable closed rows and persist row-level quality issues with timestamp and reason.
- Keep `/api/candles` schema unchanged.
- Add issue-scoped verification and decision-log entries.

## Why

A single malformed/gap/duplicate bar previously caused the entire series to be rejected, losing otherwise usable coverage such as QCOM, 000660.KS, and DHR.

## Validation

- `PYTHONPATH=src python3 -m pytest -q tests/test_ingestion.py tests/test_market_calendar.py tests/test_mvp_storage.py tests/test_quality.py` -> **39 passed**
- `python3 -m ruff check src/kline/ingestion.py src/kline/market_calendar.py tests/test_ingestion.py tests/test_market_calendar.py` -> **All checks passed**
- `git diff --check` -> passed
- `python3 -m compileall -q src/kline` -> passed
- `gitleaks detect --no-banner --redact --source .` -> **no leaks found**
- Full suite: **375 passed, 1 failed**; the failure is outside this change: the existing current-date-dependent Binance daily mock returned no closed mocked row.
- Owner live next-cycle verification for QCOM, 000660.KS, and DHR is **待 owner 验证**; no service or plist was changed. See `docs/verification/issue-156-row-level-quality-2026-09-08.md`.
- `REGISTRY.md` intentionally unchanged per execution instruction; owner updates its coverage snapshot after merge.

Closes #156