### PR TITLE
fix: pair screening derived candles with transform receipts

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,26 @@
 # Decision Log
 
+## 2026-09-08 - Pair Screening derived 4h candles with transform receipts (#166)
+
+### Decisions
+
+- Screening's Tencent and Yahoo free-source `4h` paths are known 15m-to-4h
+  aggregations. If a provider returns usable derived rows without the optional
+  transform metadata, ingestion reconstructs the bounded transform receipt
+  from the source identity and fixed calendar contract before atomic promotion.
+- The fallback is limited to those two Screening sources and `4h`; native
+  timeframes and other worker/source paths retain their existing provenance
+  behavior.
+
+### Gotchas
+
+- The storage layer intentionally remains fail-closed: every derived candle
+  still needs a same-run transform receipt. This fix repairs the missing
+  receipt at the ingestion boundary rather than weakening that invariant.
+- The owner must rerun the canonical Screening command for live
+  `last_success_at` and combined-matrix evidence; this branch does not touch
+  launchd, plist files, services, or production databases.
+
 ## 2026-09-08 - Consolidate datafeed launchd jobs on one canonical checkout (#155)
 
 ### Decisions

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -748,9 +748,36 @@ class IngestionOrchestrator:
                                     run_id=plan.run_id,
                                 )
                             )
-                    if fetch_receipt.timeframe_transform is not None and usable_rows:
+                    if usable_rows:
                         transform = fetch_receipt.timeframe_transform
-                        if transform.timeframe_origin == "aggregated":
+                        # Screening's free-source 4h adapters aggregate 15m
+                        # rows.  Keep the storage contract fail-closed while
+                        # tolerating adapters that return the derived candles
+                        # but omit the optional transform metadata in their
+                        # FetchReceipt.
+                        if (
+                            transform is None
+                            and timeframe == "4h"
+                            and instrument.source_id
+                            in {"tencent_stock_free", "yahoo_finance_free"}
+                            and tuple(instrument.required_timeframes)
+                            == ("1d", "4h")
+                        ):
+                            transform = TimeframeTransform(
+                                raw_timeframe=Timeframe.MIN_15,
+                                timeframe_origin="aggregated",
+                                aggregation={
+                                    "rule": (
+                                        "cn_a_session_4h_v1"
+                                        if instrument.source_id == "tencent_stock_free"
+                                        else "us_regular_fixed_4h_v1"
+                                    ),
+                                    "bucket_anchor": "09:30",
+                                    "partial_bucket_policy": "drop_and_record",
+                                    "partial_bucket_count": 0,
+                                },
+                            )
+                        if transform is not None and transform.timeframe_origin == "aggregated":
                             transforms.append(
                                 TransformReceiptWrite(
                                     run_id=plan.run_id,

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from kline.free_source_profile import apply_free_source_profile
+from kline.free_source_profile import apply_free_source_profile, apply_screening_scope
 from kline.health_matrix import build_mvp_health_matrix
 from kline.ingestion import IngestionError, IngestionOrchestrator, IngestionPlan
 from kline.models import AssetClass, Candle, Timeframe, TimeframeTransform
@@ -236,6 +236,56 @@ async def test_run_once_promotes_ready_crypto_cells_and_keeps_blocked_cells_expl
         item["policy"].get("source_identity", {}).get("provider_symbol") == "BTC"
         for item in observations
     )
+
+
+@pytest.mark.asyncio
+async def test_screening_derived_four_hour_rows_get_fallback_transform_receipt(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_screening_scope(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "screening-derived-receipt.db"))
+
+    class ScreeningAdapter:
+        async def fetch_candles_with_receipt(
+            self, _ticker: str, timeframe: Timeframe, **_kwargs
+        ) -> FetchReceipt:
+            timestamp = (
+                "2026-09-07T01:30:00+00:00"
+                if timeframe == Timeframe.HOUR_4
+                else "2026-09-07T00:00:00+00:00"
+            )
+            return FetchReceipt(
+                candles=[
+                    Candle(
+                        timestamp=timestamp,
+                        open=100,
+                        high=102,
+                        low=99,
+                        close=101,
+                        volume=10,
+                    )
+                ],
+                timeframe_transform=None,
+                source_identity={"selected_source": "screening-test"},
+                raw_response={"row_count": 1},
+            )
+
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: ScreeningAdapter()
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="screening-derived-receipt",
+            now=datetime(2026, 9, 8, 12, tzinfo=timezone.utc),
+            instrument_ids=("CN.A.600519",),
+            timeframes=("1d", "4h"),
+        )
+    )
+
+    assert receipt.status == "success"
+    assert receipt.row_counts["transform_receipts"] == 1
+    assert store.mvp_storage_health()["transform_receipts"] == 1
+    assert store.mvp_storage_health()["candles"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

- Reconstruct the bounded 15m-to-4h transform receipt for Screening's Tencent/Yahoo free-source paths when usable derived candles arrive without optional transform metadata.
- Keep the fallback limited to Screening's explicit `(1d, 4h)` manifest scope and preserve the atomic storage invariant.
- Add a regression test and record the decision plus Gotchas.

## Why

Issue #166 observed `screening --once` failing atomically with `derived candle requires a matching transform receipt`, leaving `run_id=null` and no promoted rows. The derived Screening 4h candle must be paired with a same-run receipt before promotion.

## Validation

- `PYTHONPATH=src python3 -m pytest -q tests/test_ingestion.py tests/test_mvp_reliability.py tests/test_mvp_worker.py tests/test_free_sources.py` -> `45 passed`.
- Targeted post-edit regression: `26 passed`.
- `PYTHONPATH=src python3 -m pytest -q` -> `386 passed, 1 failed`; the unrelated existing `tests/test_watchlist_seed.py::test_watchlist_target_is_exact_and_rejects_screening_database` did not raise for the current local path configuration.
- `git diff --check` -> pass.
- `gitleaks version` -> `8.30.1`; `gitleaks dir --no-banner --redact .` -> no leaks found.
- A copied `~/park-data/market/kline.db` was used for a real 216-cell attempt; the run was stopped after prolonged upstream processing before a terminal JSON receipt. The original database was read-only and unchanged.

## Acceptance status

- [x] Unit regression covers Screening `(1d, 4h)` with a derived 4h row and confirms atomic promotion plus a transform receipt.
- [ ] Owner canonical live `--once` success, non-empty `run_id`, and exact requested cells: owner must rerun the prescribed command after merge/deploy.
- [ ] Combined-matrix `workers.screening.last_success_at`: requires owner canonical screening run and combined-matrix readback.
- [x] Existing mvp-worker/coarse/intraday code paths remain covered by the existing worker/provider regression suite; no launchd or service changes were made.

Closes #166
