### PR TITLE
fix: respect native timeframe provenance in screening

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -11,12 +11,18 @@
 - The fallback is limited to those two Screening sources and `4h`; native
   timeframes and other worker/source paths retain their existing provenance
   behavior.
+- Native `4h` providers such as Hyperliquid must remain `is_derived=false`;
+  timeframe alone is not evidence of aggregation. The ingestion boundary now
+  derives that flag from `TimeframeTransform.timeframe_origin`.
 
 ### Gotchas
 
 - The storage layer intentionally remains fail-closed: every derived candle
   still needs a same-run transform receipt. This fix repairs the missing
   receipt at the ingestion boundary rather than weakening that invariant.
+- A full Screening manifest includes cross-market native `4h` cells; testing
+  only the 200 stock cells can miss this failure even when their receipts are
+  correct.
 - The owner must rerun the canonical Screening command for live
   `last_success_at` and combined-matrix evidence; this branch does not touch
   launchd, plist files, services, or production databases.

--- a/src/kline/ingestion.py
+++ b/src/kline/ingestion.py
@@ -353,9 +353,8 @@ class IngestionOrchestrator:
     ) -> list[MvpCandle]:
         key = self._key(instrument, timeframe, manifest)
         rows: list[MvpCandle] = []
-        is_derived = timeframe in {"4h", "1w"} or (
-            timeframe == "1h"
-            and timeframe_transform is not None
+        is_derived = (
+            timeframe_transform is not None
             and timeframe_transform.timeframe_origin == "aggregated"
         )
         seen_timestamps: set[str] = set()
@@ -665,13 +664,40 @@ class IngestionOrchestrator:
                     latency_ms = round((time_module.perf_counter() - fetch_started_at) * 1000, 1)
                     provider_attempts = receipt_attempts(fetch_receipt)
                     raw_rows = fetch_receipt.candles
+                    transform = fetch_receipt.timeframe_transform
+                    # Some Screening free-source adapters return already
+                    # aggregated 4h rows without exposing their optional
+                    # transform metadata.  Reconstruct that metadata before
+                    # normalizing rows so the derived flag and receipt use
+                    # the same provenance decision.
+                    if (
+                        transform is None
+                        and timeframe == "4h"
+                        and instrument.source_id
+                        in {"tencent_stock_free", "yahoo_finance_free"}
+                        and tuple(instrument.required_timeframes) == ("1d", "4h")
+                    ):
+                        transform = TimeframeTransform(
+                            raw_timeframe=Timeframe.MIN_15,
+                            timeframe_origin="aggregated",
+                            aggregation={
+                                "rule": (
+                                    "cn_a_session_4h_v1"
+                                    if instrument.source_id == "tencent_stock_free"
+                                    else "us_regular_fixed_4h_v1"
+                                ),
+                                "bucket_anchor": "09:30",
+                                "partial_bucket_policy": "drop_and_record",
+                                "partial_bucket_count": 0,
+                            },
+                        )
                     row_issues: list[AggregationIssue] = []
                     mvp_rows = self._to_mvp_rows(
                         instrument,
                         timeframe,
                         raw_rows,
                         manifest,
-                        timeframe_transform=fetch_receipt.timeframe_transform,
+                        timeframe_transform=transform,
                         row_issues=row_issues,
                     )
                     quality = assess_quality(
@@ -749,34 +775,6 @@ class IngestionOrchestrator:
                                 )
                             )
                     if usable_rows:
-                        transform = fetch_receipt.timeframe_transform
-                        # Screening's free-source 4h adapters aggregate 15m
-                        # rows.  Keep the storage contract fail-closed while
-                        # tolerating adapters that return the derived candles
-                        # but omit the optional transform metadata in their
-                        # FetchReceipt.
-                        if (
-                            transform is None
-                            and timeframe == "4h"
-                            and instrument.source_id
-                            in {"tencent_stock_free", "yahoo_finance_free"}
-                            and tuple(instrument.required_timeframes)
-                            == ("1d", "4h")
-                        ):
-                            transform = TimeframeTransform(
-                                raw_timeframe=Timeframe.MIN_15,
-                                timeframe_origin="aggregated",
-                                aggregation={
-                                    "rule": (
-                                        "cn_a_session_4h_v1"
-                                        if instrument.source_id == "tencent_stock_free"
-                                        else "us_regular_fixed_4h_v1"
-                                    ),
-                                    "bucket_anchor": "09:30",
-                                    "partial_bucket_policy": "drop_and_record",
-                                    "partial_bucket_count": 0,
-                                },
-                            )
                         if transform is not None and transform.timeframe_origin == "aggregated":
                             transforms.append(
                                 TransformReceiptWrite(

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -289,6 +289,54 @@ async def test_screening_derived_four_hour_rows_get_fallback_transform_receipt(
 
 
 @pytest.mark.asyncio
+async def test_screening_native_four_hour_rows_do_not_require_transform_receipt(
+    tmp_path: Path,
+) -> None:
+    manifest = apply_screening_scope(load_manifest(MANIFEST_PATH))
+    store = KlineStore(str(tmp_path / "screening-native-4h.db"))
+
+    class NativeAdapter:
+        async def fetch_candles_with_receipt(
+            self, _ticker: str, timeframe: Timeframe, **_kwargs
+        ) -> FetchReceipt:
+            return FetchReceipt(
+                candles=[
+                    Candle(
+                        timestamp="2026-09-07T01:30:00+00:00",
+                        open=100,
+                        high=102,
+                        low=99,
+                        close=101,
+                        volume=10,
+                    )
+                ],
+                timeframe_transform=TimeframeTransform(
+                    raw_timeframe=timeframe,
+                    timeframe_origin="native",
+                    aggregation={"rule": "native_passthrough"},
+                ),
+                source_identity={"selected_source": "hyperliquid"},
+                raw_response={"row_count": 1},
+            )
+
+    receipt = await IngestionOrchestrator(
+        store, adapter_resolver=lambda _instrument: NativeAdapter()
+    ).run_once(
+        IngestionPlan(
+            manifest=manifest,
+            run_id="screening-native-4h",
+            now=datetime(2026, 9, 8, 12, tzinfo=timezone.utc),
+            instrument_ids=("CRYPTO.PERP.BTC",),
+            timeframes=("1d", "4h"),
+        )
+    )
+
+    assert receipt.status == "success"
+    assert receipt.row_counts["transform_receipts"] == 0
+    assert store.mvp_storage_health()["candles"] == 2
+
+
+@pytest.mark.asyncio
 async def test_empty_provider_rows_write_missing_receipt_and_continue_other_cells(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What
- Mark MVP candles as derived only when `TimeframeTransform.timeframe_origin=aggregated`.
- Reconstruct the known Tencent/Yahoo Screening 4h transform before row normalization when provider metadata is absent.
- Add a regression test for native Hyperliquid 4h rows and update `decision-log.md` Gotchas.

## Why
The previous fix covered stock 4h aggregation but `_to_mvp_rows()` still marked every 4h candle as derived. Screening's cross-market Hyperliquid native 4h rows therefore reached atomic promotion without a matching transform receipt and failed with `derived candle requires a matching transform receipt`.

## Validation
- Real副本复现: `cp ~/park-data/market/kline.db repro/kline.db`; `CRYPTO.PERP.BTC` reproduced the full traceback through `src/kline/ingestion.py:977` -> `src/kline/store.py:611`.
- Related tests: `PYTHONPATH=src python3 -m pytest -q tests/test_ingestion.py tests/test_hyperliquid.py tests/test_mvp_reliability.py tests/test_store.py` -> `56 passed`.
- Full tests: `387 passed, 1 unrelated existing failure` in `tests/test_watchlist_seed.py::test_watchlist_target_is_exact_and_rejects_screening_database`.
- Full real副本 command completed atomic promotion with `run_id=mvp-20260908T021418Z`, `transform_receipts=203`, and no receipt mismatch. It returned `status=partial` because 2 cells were forming/quality-fail and 5 cells were entitlement-blocked; owner-side canonical rerun remains required for `status=success` and `workers.screening.last_success_at`.
- `gitleaks version` -> `8.30.1`; `gitleaks detect --source . --no-banner` -> no leaks found.

Closes #166
