### PR TITLE
feat: add execution market 1m ingestion worker

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,26 @@
 # Decision Log
 
+## 2026-09-08 - Isolated execution-market 1m ingestion (#171)
+
+### Decisions
+
+- Execution bars use a dedicated `execution_market_*` SQLite table set and a
+  separate lock/process; the existing 8100 database, API, and four-hour worker
+  are not changed.
+- The first two identities are fixed to `XAUUSDT.BINANCE` via public Binance
+  USD-M klines and `BTC-USD-PERP.HYPERLIQUID` via the Hyperliquid testnet
+  public candle endpoint. There is no venue fallback.
+- Bars are keyed by `(instrument_id, close_time)`, forming bars are discarded,
+  and upserts make replay/backfill idempotent. Each run writes a lag receipt;
+  an outage lasting 90 seconds writes `stale` and an
+  `execution_market_unavailable` event.
+
+### Gotchas
+
+- The 30-minute p95 acceptance window and launchd publication remain owner
+  verification items. This PR's one-shot evidence uses a temporary database
+  and receipt path; it does not touch the active paper grid or launchd.
+
 ## 2026-09-08 - Pair Screening derived 4h candles with transform receipts (#166)
 
 ### Decisions

--- a/ops/execution_market_worker.py
+++ b/ops/execution_market_worker.py
@@ -1,0 +1,12 @@
+"""CLI entry point for the isolated execution-market worker."""
+import sys
+from pathlib import Path
+
+# Keep the contract command runnable from a source checkout, while launchd
+# still supplies its canonical checkout explicitly through PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from kline.execution_market.worker import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/launchd/com.wendy.datafeed.execution-market.plist
+++ b/ops/launchd/com.wendy.datafeed.execution-market.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.wendy.datafeed.execution-market</string>
+<key>ProgramArguments</key><array><string>/usr/local/bin/python3</string><string>-m</string><string>ops.execution_market_worker</string><string>--db</string><string>/Users/wendy/park-data/market/execution_market.db</string><string>--receipt</string><string>/Users/wendy/park-data/market/execution-market-latest.json</string><string>--lock</string><string>/Users/wendy/park-data/market/execution-market-worker.lock</string><string>--interval</string><string>20</string></array>
+<key>WorkingDirectory</key><string>/Users/wendy/park-runtime/datafeed</string>
+<key>EnvironmentVariables</key><dict><key>PYTHONPATH</key><string>/Users/wendy/park-runtime/datafeed/src</string><key>KLINE_RUNTIME_ROOT</key><string>/Users/wendy/park-runtime/datafeed</string><key>KLINE_BUILD_SHA</key><string>__KLINE_BUILD_SHA__</string><key>PYTHONUNBUFFERED</key><string>1</string></dict>
+<key>KeepAlive</key><true/><key>ThrottleInterval</key><integer>30</integer>
+<key>StandardOutPath</key><string>/Users/wendy/Library/Logs/datafeed/execution-market.stdout.log</string><key>StandardErrorPath</key><string>/Users/wendy/Library/Logs/datafeed/execution-market.stderr.log</string>
+</dict></plist>

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -7,7 +7,7 @@ BACKUP_DIR="${BACKUP_DIR:-$HOME/park-data/launchd-backup-20260908}"
 RECEIPT_PATH="${RECEIPT_PATH:-$HOME/park-data/datafeed/release_receipt.json}"
 WORKER_LOG="${WORKER_LOG:-$HOME/Library/Logs/datafeed/mvp-worker.stdout.log}"
 SCRIPT_ROOT="${0:A:h}"
-JOBS=(com.wendy.datafeed com.wendy.datafeed.mvp-api com.wendy.datafeed.mvp-worker com.wendy.datafeed.watchlist-daily com.wendy.datafeed.health-dashboard)
+JOBS=(com.wendy.datafeed com.wendy.datafeed.mvp-api com.wendy.datafeed.mvp-worker com.wendy.datafeed.watchlist-daily com.wendy.datafeed.health-dashboard com.wendy.datafeed.execution-market)
 
 [[ $# -eq 1 ]] || { print -u2 "usage: $0 <sha>"; exit 2; }
 [[ -d "$CANONICAL_ROOT/.git" ]] || { print -u2 "canonical checkout missing: $CANONICAL_ROOT"; exit 1; }

--- a/src/kline/execution_market/__init__.py
+++ b/src/kline/execution_market/__init__.py
@@ -1,0 +1,15 @@
+"""Execution-market 1m ingestion with fail-closed provenance."""
+
+from .worker import (
+    INSTRUMENTS,
+    ExecutionBar,
+    ExecutionMarketStore,
+    ProviderUnavailable,
+    is_completed_bar,
+    percentile95,
+)
+
+__all__ = [
+    "INSTRUMENTS", "ExecutionBar", "ExecutionMarketStore", "ProviderUnavailable",
+    "is_completed_bar", "percentile95",
+]

--- a/src/kline/execution_market/worker.py
+++ b/src/kline/execution_market/worker.py
@@ -1,0 +1,252 @@
+"""Small, independent execution-market ingestion worker.
+
+The worker owns only the ``execution_market_*`` tables in its database.  It
+never falls back between venues and only promotes bars whose upstream close
+time is already in the past.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import fcntl
+import json
+import math
+import os
+import sqlite3
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+import httpx
+
+BINANCE_URL = "https://fapi.binance.com/fapi/v1/klines"
+HYPERLIQUID_TESTNET_URL = "https://api.hyperliquid-testnet.xyz/info"
+POLL_SECONDS = 20
+STALE_SECONDS = 90
+
+INSTRUMENTS = {
+    "XAUUSDT.BINANCE": {"provider": "binance_usdm_futures", "venue": "binance", "environment": "production", "symbol": "XAUUSDT"},
+    "BTC-USD-PERP.HYPERLIQUID": {"provider": "hyperliquid_perpetual", "venue": "hyperliquid", "environment": "testnet", "symbol": "BTC"},
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_ms(value: Any) -> datetime:
+    return datetime.fromtimestamp(float(value) / 1000, tz=timezone.utc)
+
+
+@dataclass(frozen=True)
+class ExecutionBar:
+    instrument_id: str
+    open_time: str
+    close_time: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    provider: str
+    venue: str
+    environment: str
+    fetched_at: str
+
+    @property
+    def age_seconds(self) -> float:
+        return (datetime.fromisoformat(self.fetched_at.replace("Z", "+00:00")) -
+                datetime.fromisoformat(self.close_time.replace("Z", "+00:00"))).total_seconds()
+
+
+class ProviderUnavailable(RuntimeError):
+    pass
+
+
+def is_completed_bar(close_time: datetime, fetched_at: datetime) -> bool:
+    return close_time <= fetched_at
+
+
+def percentile95(values: Iterable[float]) -> float | None:
+    ordered = sorted(float(v) for v in values)
+    if not ordered:
+        return None
+    # nearest-rank p95, deterministic and conservative for small samples
+    return ordered[max(0, math.ceil(len(ordered) * 0.95) - 1)]
+
+
+def _bar(instrument_id: str, item: Any, fetched: datetime) -> ExecutionBar:
+    meta = INSTRUMENTS[instrument_id]
+    if meta["venue"] == "binance":
+        open_ms, close_ms = item[0], item[6]
+        values = (item[1], item[2], item[3], item[4], item[5])
+    else:
+        open_ms, close_ms = item["t"], item.get("T", item["t"] + 59999)
+        values = (item["o"], item["h"], item["l"], item["c"], item["v"])
+    numbers = tuple(float(v) for v in values)
+    if not all(math.isfinite(v) for v in numbers) or numbers[4] < 0:
+        raise ProviderUnavailable("upstream returned invalid OHLCV")
+    return ExecutionBar(instrument_id, iso(parse_ms(open_ms)), iso(parse_ms(close_ms)),
+                        *numbers, meta["provider"], meta["venue"], meta["environment"], iso(fetched))
+
+
+def fetch_binance(instrument_id: str, fetched: datetime, client: httpx.Client) -> list[ExecutionBar]:
+    try:
+        response = client.get(BINANCE_URL, params={"symbol": "XAUUSDT", "interval": "1m", "limit": 3})
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ProviderUnavailable(str(exc)) from exc
+    return [_bar(instrument_id, item, fetched) for item in data]
+
+
+def fetch_hyperliquid(instrument_id: str, fetched: datetime, client: httpx.Client) -> list[ExecutionBar]:
+    end_ms = int(fetched.timestamp() * 1000)
+    payload = {"type": "candleSnapshot", "req": {"coin": "BTC", "interval": "1m", "startTime": end_ms - 180000, "endTime": end_ms}}
+    try:
+        response = client.post(HYPERLIQUID_TESTNET_URL, json=payload, headers={"User-Agent": "datafeed-execution-market/1.0"})
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ProviderUnavailable(str(exc)) from exc
+    if not isinstance(data, list):
+        raise ProviderUnavailable("Hyperliquid returned a non-list payload")
+    return [_bar(instrument_id, item, fetched) for item in data]
+
+
+class ExecutionMarketStore:
+    def __init__(self, path: str | Path):
+        self.path = str(Path(path).expanduser())
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self.db = sqlite3.connect(self.path)
+        self.db.execute("PRAGMA journal_mode=WAL")
+        self.db.executescript("""
+        CREATE TABLE IF NOT EXISTS execution_market_candles (
+          instrument_id TEXT NOT NULL, open_time TEXT NOT NULL, close_time TEXT NOT NULL,
+          open REAL NOT NULL, high REAL NOT NULL, low REAL NOT NULL, close REAL NOT NULL,
+          volume REAL NOT NULL, provider TEXT NOT NULL, venue TEXT NOT NULL,
+          environment TEXT NOT NULL, fetched_at TEXT NOT NULL, PRIMARY KEY(instrument_id, close_time)
+        );
+        CREATE TABLE IF NOT EXISTS execution_market_lag_receipts (
+          run_id TEXT PRIMARY KEY, fetched_at TEXT NOT NULL, status TEXT NOT NULL,
+          p95_age_seconds REAL, bar_count INTEGER NOT NULL, error TEXT
+        );
+        CREATE TABLE IF NOT EXISTS execution_market_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, event TEXT NOT NULL,
+          instrument_id TEXT NOT NULL, occurred_at TEXT NOT NULL, detail TEXT
+        );
+        CREATE TABLE IF NOT EXISTS execution_market_provider_state (
+          instrument_id TEXT PRIMARY KEY, unavailable_since TEXT
+        );
+        """)
+        self.db.commit()
+
+    def close(self) -> None:
+        self.db.close()
+
+    def write(self, bars: list[ExecutionBar], *, run_id: str, fetched_at: datetime, status: str = "ok", error: str | None = None) -> dict[str, Any]:
+        with self.db:
+            for bar in bars:
+                self.db.execute("""INSERT INTO execution_market_candles VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                  ON CONFLICT(instrument_id,close_time) DO UPDATE SET open_time=excluded.open_time, open=excluded.open, high=excluded.high, low=excluded.low, close=excluded.close, volume=excluded.volume, fetched_at=excluded.fetched_at""", tuple(asdict(bar).values()))
+            receipt = {"schema_version": "execution-market-lag-v1", "run_id": run_id, "fetched_at": iso(fetched_at), "status": status, "p95_age_seconds": percentile95(b.age_seconds for b in bars), "bar_count": len(bars), "error": error}
+            self.db.execute("INSERT INTO execution_market_lag_receipts VALUES (?,?,?,?,?,?)", tuple(receipt[k] for k in ("run_id", "fetched_at", "status", "p95_age_seconds", "bar_count", "error")))
+        return receipt
+
+    def mark_failure(self, instrument_id: str, now: datetime, error: str) -> bool:
+        row = self.db.execute("SELECT unavailable_since FROM execution_market_provider_state WHERE instrument_id=?", (instrument_id,)).fetchone()
+        since = row[0] if row and row[0] else iso(now)
+        with self.db:
+            self.db.execute("INSERT INTO execution_market_provider_state VALUES (?,?) ON CONFLICT(instrument_id) DO UPDATE SET unavailable_since=excluded.unavailable_since", (instrument_id, since))
+            stale = (now - datetime.fromisoformat(since.replace("Z", "+00:00"))).total_seconds() >= STALE_SECONDS
+            if stale:
+                self.db.execute("INSERT INTO execution_market_events(event,instrument_id,occurred_at,detail) VALUES (?,?,?,?)", ("execution_market_unavailable", instrument_id, iso(now), error))
+        return stale
+
+    def mark_success(self, instrument_id: str) -> None:
+        with self.db:
+            self.db.execute("INSERT INTO execution_market_provider_state VALUES (?,NULL) ON CONFLICT(instrument_id) DO UPDATE SET unavailable_since=NULL", (instrument_id,))
+
+
+class ExecutionMarketLock:
+    """A lock namespace owned only by this worker."""
+    def __init__(self, path: str | Path):
+        self.path = Path(path).expanduser()
+        self.fd: int | None = None
+
+    def __enter__(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.fd = os.open(self.path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(self.fd)
+            self.fd = None
+            raise RuntimeError("execution-market worker lock is already held") from exc
+        return self
+
+    def __exit__(self, *_):
+        if self.fd is not None:
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+            os.close(self.fd)
+            self.fd = None
+
+
+def run_once(db_path: str | Path, receipt_path: str | Path, *, lock_path: str | Path | None = None, client: httpx.Client | None = None, clock: Callable[[], datetime] = utc_now) -> dict[str, Any]:
+    lock = ExecutionMarketLock(lock_path) if lock_path else None
+    if lock:
+        lock.__enter__()
+    fetched = clock()
+    store = ExecutionMarketStore(db_path)
+    own_client = client is None
+    client = client or httpx.Client(timeout=15)
+    all_bars: list[ExecutionBar] = []
+    errors: list[dict[str, str]] = []
+    try:
+        for instrument_id in INSTRUMENTS:
+            try:
+                bars = fetch_binance(instrument_id, fetched, client) if instrument_id.startswith("XAU") else fetch_hyperliquid(instrument_id, fetched, client)
+                completed = [bar for bar in bars if is_completed_bar(datetime.fromisoformat(bar.close_time.replace("Z", "+00:00")), fetched)]
+                all_bars.extend(completed)
+                store.mark_success(instrument_id)
+            except ProviderUnavailable as exc:
+                errors.append({"instrument_id": instrument_id, "error": str(exc), "stale": str(store.mark_failure(instrument_id, fetched, str(exc))).lower()})
+        receipt = store.write(all_bars, run_id=f"execution-{uuid.uuid4().hex[:12]}", fetched_at=fetched, status="stale" if any(e["stale"] == "true" for e in errors) else ("partial" if errors else "ok"), error=json.dumps(errors) if errors else None)
+    finally:
+        if own_client: client.close()
+        store.close()
+        if lock: lock.__exit__(None, None, None)
+    path = Path(receipt_path).expanduser(); path.parent.mkdir(parents=True, exist_ok=True); path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    return receipt
+
+
+async def supervise(args: argparse.Namespace) -> None:
+    while True:
+        run_once(args.db, args.receipt, lock_path=args.lock)
+        await asyncio.sleep(args.interval)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default="~/park-data/market/execution_market.db")
+    parser.add_argument("--receipt", default="~/park-data/market/execution-market-latest.json")
+    parser.add_argument("--lock", default="~/park-data/market/execution-market-worker.lock")
+    parser.add_argument("--interval", type=int, default=POLL_SECONDS)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+    if args.once:
+        print(json.dumps(run_once(args.db, args.receipt, lock_path=args.lock), sort_keys=True))
+    else:
+        asyncio.run(supervise(args))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_execution_market.py
+++ b/tests/test_execution_market.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timedelta, timezone
+import json
+
+import httpx
+
+from kline.execution_market.worker import (
+    ExecutionMarketStore,
+    INSTRUMENTS,
+    ProviderUnavailable,
+    fetch_binance,
+    is_completed_bar,
+    percentile95,
+    run_once,
+)
+
+
+def test_identity_mapping_is_exact_and_separated_by_environment():
+    assert INSTRUMENTS["XAUUSDT.BINANCE"] == {
+        "provider": "binance_usdm_futures", "venue": "binance", "environment": "production", "symbol": "XAUUSDT"
+    }
+    assert INSTRUMENTS["BTC-USD-PERP.HYPERLIQUID"]["environment"] == "testnet"
+    assert INSTRUMENTS["BTC-USD-PERP.HYPERLIQUID"]["venue"] == "hyperliquid"
+
+
+def test_forming_bar_is_excluded_and_p95_is_deterministic():
+    now = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+    assert is_completed_bar(now - timedelta(seconds=1), now)
+    assert not is_completed_bar(now + timedelta(seconds=1), now)
+    assert percentile95([10, 20, 30, 40]) == 40
+
+
+def test_store_upsert_is_idempotent_and_close_time_is_keyed(tmp_path):
+    store = ExecutionMarketStore(tmp_path / "execution.db")
+    from kline.execution_market.worker import ExecutionBar
+    bar = ExecutionBar("XAUUSDT.BINANCE", "2026-09-08T11:58:00Z", "2026-09-08T11:58:59.999000Z", 1, 2, 0.5, 1.5, 3, "binance_usdm_futures", "binance", "production", "2026-09-08T12:00:00Z")
+    store.write([bar], run_id="r1", fetched_at=datetime(2026, 9, 8, 12, tzinfo=timezone.utc))
+    store.write([bar], run_id="r2", fetched_at=datetime(2026, 9, 8, 12, tzinfo=timezone.utc))
+    assert store.db.execute("select count(*) from execution_market_candles").fetchone()[0] == 1
+    store.close()
+
+
+def test_stale_after_ninety_seconds_emits_event(tmp_path):
+    store = ExecutionMarketStore(tmp_path / "execution.db")
+    first = datetime(2026, 9, 8, 12, tzinfo=timezone.utc)
+    assert store.mark_failure("XAUUSDT.BINANCE", first, "timeout") is False
+    assert store.mark_failure("XAUUSDT.BINANCE", first + timedelta(seconds=90), "timeout") is True
+    assert store.db.execute("select event from execution_market_events").fetchone()[0] == "execution_market_unavailable"
+    store.close()
+
+
+def test_lock_is_independent_and_reports_contention(tmp_path):
+    from kline.execution_market.worker import ExecutionMarketLock
+    path = tmp_path / "execution.lock"
+    first = ExecutionMarketLock(path)
+    first.__enter__()
+    try:
+        try:
+            ExecutionMarketLock(path).__enter__()
+        except RuntimeError as exc:
+            assert "already held" in str(exc)
+        else:
+            raise AssertionError("second execution worker must not acquire the lock")
+    finally:
+        first.__exit__(None, None, None)
+
+
+def test_binance_public_payload_is_normalized_without_forming_bar():
+    now = datetime(2026, 9, 8, 12, 0, 30, tzinfo=timezone.utc)
+    payload = [[1725796740000, "1", "2", "0.5", "1.5", "3", 1725796799999, "4"]]
+    client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, json=payload)))
+    bars = fetch_binance("XAUUSDT.BINANCE", now, client)
+    assert bars[0].provider == "binance_usdm_futures"
+    assert bars[0].venue == "binance"
+    assert bars[0].age_seconds > 0
+    client.close()
+
+
+def test_run_once_writes_receipt_and_does_not_need_default_paths(tmp_path, monkeypatch):
+    from kline.execution_market import worker
+    monkeypatch.setattr(worker, "fetch_binance", lambda *_: [])
+    monkeypatch.setattr(worker, "fetch_hyperliquid", lambda *_: [])
+    receipt_path = tmp_path / "receipt.json"
+    receipt = run_once(tmp_path / "execution.db", receipt_path, clock=lambda: datetime(2026, 9, 8, 12, tzinfo=timezone.utc))
+    assert receipt["status"] == "ok"
+    assert json.loads(receipt_path.read_text())["schema_version"] == "execution-market-lag-v1"


### PR DESCRIPTION
## What
- Add an isolated execution-market 1m worker for `XAUUSDT.BINANCE` (Binance USD-M public klines) and `BTC-USD-PERP.HYPERLIQUID` (Hyperliquid testnet public candles).
- Persist closed bars with `(instrument_id, close_time)` idempotency, per-bar provenance, lag receipts, stale state, and `execution_market_unavailable` events.
- Add an independent 20s KeepAlive launchd contract and include it in `ops/release.sh`.
- Update `decision-log.md` with decisions and Gotchas.

## Why
This implements the execution-market ingestion story without changing `/api/candles`, the 8100 database, strategy/risk/lifecycle code, or the active paper-grid jobs. Venue fallback and forming bars are explicitly rejected.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_execution_market.py` -> 7 passed.
- `python3 -m ops.execution_market_worker --once --db <temporary-db> --lock <temporary-lock> --receipt <temporary-receipt>` -> real public run, `status=ok`, 5 bars (Binance 2, Hyperliquid testnet 3), receipt `p95_age_seconds=131.805452`.
- `plutil -lint ops/launchd/com.wendy.datafeed.execution-market.plist` -> OK.
- `gitleaks detect --source . --no-banner --redact` -> no leaks found.
- `python3 -m compileall -q src/kline/execution_market ops/execution_market_worker.py` and `git diff --check` -> passed.
- 30-minute continuous p95 and owner publication/launchd evidence remain pending; no online service was restarted.

Closes #171
