### PR TITLE
feat: M2-S2 execution market API

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,23 @@
 # Decision Log
 
+## 2026-09-08 - Execution-market 1m read API (#172)
+
+### Decisions
+
+- 8100 exposes a read-only `GET /api/execution-market/{venue}/{instrument}`
+  response with schema `execution-market-v1`, the last closed 1m price, a
+  bounded recent-bar series, freshness, trust, source, observation time, and
+  provenance.
+- The API reads only the dedicated execution-market database and requires an
+  exact venue/instrument identity. It never falls back across venues, serves a
+  forming bar, or changes the existing `/api/candles` and `/api/health` paths.
+
+### Gotchas
+
+- A stale or missing bar remains an explicit response with `fresh=false` and a
+  reason; HTTP 200 is not execution evidence. Live ten-sample freshness remains
+  an owner/runtime acceptance gate and is not proved by fixture tests.
+
 ## 2026-09-08 - Isolated execution-market 1m ingestion (#171)
 
 ### Decisions

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
 from pathlib import Path
+import sqlite3
 from time import monotonic
 from typing import Any, Mapping
 
@@ -47,10 +50,106 @@ from kline.provenance import (
 )
 from kline.quality import QualityReport, analyze_candles
 from kline.registry import get_adapter_for_source, get_store, provider_status, runtime_status
+from kline.execution_market.worker import ExecutionBar, INSTRUMENTS, STALE_SECONDS
 
 router = APIRouter()
 _mvp_matrix_last_success_at: str | None = None
 _combined_matrix_last_success_at: str | None = None
+
+
+def _execution_market_db() -> str:
+    return os.environ.get(
+        "KLINE_EXECUTION_MARKET_DB",
+        str(Path("~/park-data/market/execution_market.db").expanduser()),
+    )
+
+
+def _execution_instrument(venue: str, instrument: str) -> tuple[str, dict[str, str]] | None:
+    wanted_venue = venue.strip().lower()
+    wanted_instrument = instrument.strip().upper()
+    for instrument_id, meta in INSTRUMENTS.items():
+        if meta["venue"] == wanted_venue and (
+            meta["symbol"].upper() == wanted_instrument or instrument_id.upper() == wanted_instrument
+        ):
+            return instrument_id, meta
+    return None
+
+
+def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[str, Any]:
+    match = _execution_instrument(venue, instrument)
+    if not match:
+        return {
+            "schema_version": "execution-market-v1",
+            "venue": venue,
+            "instrument": instrument,
+            "price": None,
+            "trusted": False,
+            "fresh": False,
+            "source": None,
+            "observed_at": None,
+            "age_seconds": None,
+            "bars": [],
+            "reason": "unsupported_instrument",
+        }
+    instrument_id, meta = match
+    db_path = _execution_market_db()
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat().replace("+00:00", "Z")
+    if not Path(db_path).exists():
+        bars = []
+    else:
+        connection = None
+        try:
+            connection = sqlite3.connect(f"file:{Path(db_path).resolve()}?mode=ro", uri=True)
+            rows = connection.execute(
+                """SELECT instrument_id, open_time, close_time, open, high, low, close,
+                          volume, provider, venue, environment, fetched_at
+                    FROM execution_market_candles
+                    WHERE instrument_id=? AND close_time<=?
+                    ORDER BY close_time DESC LIMIT ?""",
+                (instrument_id, now_iso, max(1, int(limit))),
+            ).fetchall()
+            bars = [ExecutionBar(*row) for row in rows]
+        except sqlite3.Error:
+            bars = []
+        finally:
+            if connection is not None:
+                connection.close()
+
+    latest = bars[0] if bars else None
+    age = None
+    fresh = False
+    reason = "missing"
+    if latest:
+        observed = datetime.fromisoformat(latest.close_time.replace("Z", "+00:00"))
+        age = max(0.0, (now - observed).total_seconds())
+        fresh = age <= STALE_SECONDS
+        reason = "fresh" if fresh else "stale"
+    return {
+        "schema_version": "execution-market-v1",
+        "venue": meta["venue"],
+        "instrument": meta["symbol"],
+        "instrument_id": instrument_id,
+        "price": latest.close if latest else None,
+        "trusted": bool(latest and latest.provider and latest.venue == meta["venue"] and latest.environment),
+        "fresh": fresh,
+        "source": latest.provider if latest else meta["provider"],
+        "observed_at": latest.close_time if latest else None,
+        "age_seconds": round(age, 3) if age is not None else None,
+        "reason": reason,
+        "provenance": {
+            "provider": latest.provider if latest else meta["provider"],
+            "venue": latest.venue if latest else meta["venue"],
+            "environment": latest.environment if latest else meta["environment"],
+            "instrument_id": instrument_id,
+        },
+        "bars": [
+            {"open_time": bar.open_time, "close_time": bar.close_time, "open": bar.open,
+             "high": bar.high, "low": bar.low, "close": bar.close, "volume": bar.volume,
+             "provider": bar.provider, "venue": bar.venue, "environment": bar.environment}
+            for bar in reversed(bars)
+        ],
+    }
 
 
 @dataclass(frozen=True)
@@ -1226,6 +1325,16 @@ async def get_instrument_definition(
             },
         ) from e
     return definition
+
+
+@router.get("/execution-market/{venue}/{instrument}")
+async def execution_market(
+    venue: str,
+    instrument: str,
+    limit: int = Query(default=240, ge=1, le=1000),
+) -> dict[str, Any]:
+    """Return the last closed execution-market 1m snapshot, read-only."""
+    return _execution_market_payload(venue, instrument, limit)
 
 
 @router.get("/tickers")

--- a/src/kline/execution_market/worker.py
+++ b/src/kline/execution_market/worker.py
@@ -151,6 +151,18 @@ class ExecutionMarketStore:
     def close(self) -> None:
         self.db.close()
 
+    def latest(self, instrument_id: str, *, limit: int = 240) -> list[ExecutionBar]:
+        """Read only completed bars, newest first, for the execution API."""
+        rows = self.db.execute(
+            """SELECT instrument_id, open_time, close_time, open, high, low, close,
+                      volume, provider, venue, environment, fetched_at
+                 FROM execution_market_candles
+                WHERE instrument_id=?
+                ORDER BY close_time DESC LIMIT ?""",
+            (instrument_id, max(1, int(limit))),
+        ).fetchall()
+        return [ExecutionBar(*row) for row in rows]
+
     def write(self, bars: list[ExecutionBar], *, run_id: str, fetched_at: datetime, status: str = "ok", error: str | None = None) -> dict[str, Any]:
         with self.db:
             for bar in bars:

--- a/tests/test_execution_market_api.py
+++ b/tests/test_execution_market_api.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from kline.app import create_app
+from kline.execution_market.worker import ExecutionBar, ExecutionMarketStore
+
+
+def _bar(close_time: datetime, close: float = 2400.0) -> ExecutionBar:
+    close_text = close_time.isoformat().replace("+00:00", "Z")
+    open_text = (close_time - timedelta(seconds=59)).isoformat().replace("+00:00", "Z")
+    return ExecutionBar(
+        "XAUUSDT.BINANCE", open_text, close_text, close, close + 1, close - 1,
+        close, 10, "binance_usdm_futures", "binance", "production", close_text,
+    )
+
+
+def _client(tmp_path, monkeypatch, bars: list[ExecutionBar]) -> TestClient:
+    path = tmp_path / "execution-market.db"
+    store = ExecutionMarketStore(path)
+    store.write(bars, run_id="test", fetched_at=datetime.now(timezone.utc))
+    store.close()
+    monkeypatch.setenv("KLINE_EXECUTION_MARKET_DB", str(path))
+    return TestClient(create_app())
+
+
+def test_fresh_response_maps_execution_reader_fields_and_excludes_forming(tmp_path, monkeypatch):
+    now = datetime.now(timezone.utc)
+    with _client(tmp_path, monkeypatch, [_bar(now - timedelta(seconds=30)), _bar(now + timedelta(seconds=30), 2500)]) as client:
+        response = client.get("/api/execution-market/binance/XAUUSDT", params={"limit": 240})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "execution-market-v1"
+    assert payload["price"] == 2400.0
+    assert payload["trusted"] is True
+    assert payload["fresh"] is True
+    assert payload["source"] == "binance_usdm_futures"
+    assert payload["observed_at"] == payload["bars"][-1]["close_time"]
+    assert len(payload["bars"]) == 1
+
+
+def test_stale_response_is_present_but_not_fresh(tmp_path, monkeypatch):
+    with _client(tmp_path, monkeypatch, [_bar(datetime.now(timezone.utc) - timedelta(seconds=120))]) as client:
+        payload = client.get("/api/execution-market/binance/XAUUSDT").json()
+
+    assert payload["price"] == 2400.0
+    assert payload["trusted"] is True
+    assert payload["fresh"] is False
+    assert payload["reason"] == "stale"
+    assert payload["age_seconds"] > 90
+
+
+def test_missing_response_is_explicit(tmp_path, monkeypatch):
+    with _client(tmp_path, monkeypatch, []) as client:
+        payload = client.get("/api/execution-market/binance/XAUUSDT").json()
+
+    assert payload == {
+        **payload,
+        "schema_version": "execution-market-v1",
+        "price": None,
+        "trusted": False,
+        "fresh": False,
+        "observed_at": None,
+        "age_seconds": None,
+        "reason": "missing",
+        "bars": [],
+    }


### PR DESCRIPTION
## What\n\n- Add read-only GET /api/execution-market/{venue}/{instrument} with versioned execution-market-v1 schema.\n- Return the latest closed 1m price, trusted, fresh, source, observed_at, age_seconds, provenance, and up to 240 recent bars.\n- Keep exact venue/instrument identity, exclude forming bars at query time, and expose explicit stale/missing reasons.\n- Add fresh/stale/missing API tests and update decision-log.md with Gotchas.\n\n## Why\n\nM2-S2 supplies the read contract required by default_market_reader while preserving the existing candles/health APIs and the worker's no-fallback boundary.\n\n## Validation\n\n- PYTHONPATH=src python3 -m pytest -q tests/test_execution_market_api.py: 3 passed.\n- PYTHONPATH=src python3 -m pytest -q: 400 passed.\n- gitleaks dir --redact .: no leaks found.\n- Temporary uvicorn kline.app:create_app --factory --port 18199 with the live worker database: real XAUUSDT.BINANCE response returned price=4427.32, fresh=true, age_seconds=38.981..57.240; 10 consecutive samples all stayed fresh=true and age_seconds <= 90.\n- Existing /api/health: HTTP 200. Existing /api/candles/... with its existing strict query: HTTP 200 and kline-candles-v1; no existing candles/health implementation lines changed.\n- No online 8100 service, worker, launchd plist, or runtime directory was modified or restarted.\n\nCloses #172