### PR TITLE
feat: align execution market freshness polling

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -719,3 +719,16 @@ consumers can use without direct exchange or private SQLite access.
 - Gotchas: `configs/watchlist_manifest.json` is a retained legacy consumer path and is not edited by
   this story; the daily seed now defaults to generated `configs/watchlist_registry_manifest.json`.
   The production plist is changed in-repository only; it is not loaded or restarted by this issue.
+
+## 2026-09-08 - Align execution-market polling and record read-time freshness (#177)
+
+- The execution-market worker defaults to a 5-second poll interval and schedules each poll on a
+  close-aligned phase, one second after the UTC minute boundary. The repository plist records the
+  same interval; the owner-controlled online worker was not restarted or modified here.
+- Each receipt preserves the existing fetch-age p95 and adds per-instrument fetch-age statistics,
+  plus cumulative per-instrument read-age p50/p95/max samples calculated as `now - last_closed_close_time`.
+  Samples are stored in the worker-owned SQLite database so a 30-minute process receipt represents
+  the complete observation window rather than only the latest cycle.
+- Gotchas: the 30-minute acceptance must use temporary DB, receipt, and lock paths because the
+  production lock is outside this worktree; read-age acceptance is separate from API schema and
+  does not require changing the 8100 endpoint.

--- a/ops/launchd/com.wendy.datafeed.execution-market.plist
+++ b/ops/launchd/com.wendy.datafeed.execution-market.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
 <key>Label</key><string>com.wendy.datafeed.execution-market</string>
-<key>ProgramArguments</key><array><string>/usr/local/bin/python3</string><string>-m</string><string>ops.execution_market_worker</string><string>--db</string><string>/Users/wendy/park-data/market/execution_market.db</string><string>--receipt</string><string>/Users/wendy/park-data/market/execution-market-latest.json</string><string>--lock</string><string>/Users/wendy/park-data/market/execution-market-worker.lock</string><string>--interval</string><string>20</string></array>
+<key>ProgramArguments</key><array><string>/usr/local/bin/python3</string><string>-m</string><string>ops.execution_market_worker</string><string>--db</string><string>/Users/wendy/park-data/market/execution_market.db</string><string>--receipt</string><string>/Users/wendy/park-data/market/execution-market-latest.json</string><string>--lock</string><string>/Users/wendy/park-data/market/execution-market-worker.lock</string><string>--interval</string><string>5</string></array>
 <key>WorkingDirectory</key><string>/Users/wendy/park-runtime/datafeed</string>
 <key>EnvironmentVariables</key><dict><key>PYTHONPATH</key><string>/Users/wendy/park-runtime/datafeed/src</string><key>KLINE_RUNTIME_ROOT</key><string>/Users/wendy/park-runtime/datafeed</string><key>KLINE_BUILD_SHA</key><string>__KLINE_BUILD_SHA__</string><key>PYTHONUNBUFFERED</key><string>1</string></dict>
 <key>KeepAlive</key><true/><key>ThrottleInterval</key><integer>30</integer>

--- a/src/kline/execution_market/worker.py
+++ b/src/kline/execution_market/worker.py
@@ -24,7 +24,7 @@ import httpx
 
 BINANCE_URL = "https://fapi.binance.com/fapi/v1/klines"
 HYPERLIQUID_TESTNET_URL = "https://api.hyperliquid-testnet.xyz/info"
-POLL_SECONDS = 20
+POLL_SECONDS = 5
 STALE_SECONDS = 90
 
 INSTRUMENTS = {
@@ -80,6 +80,37 @@ def percentile95(values: Iterable[float]) -> float | None:
         return None
     # nearest-rank p95, deterministic and conservative for small samples
     return ordered[max(0, math.ceil(len(ordered) * 0.95) - 1)]
+
+
+def percentile50(values: Iterable[float]) -> float | None:
+    ordered = sorted(float(v) for v in values)
+    if not ordered:
+        return None
+    return ordered[max(0, math.ceil(len(ordered) * 0.50) - 1)]
+
+
+def age_stats(values: Iterable[float]) -> dict[str, float | int | None]:
+    ordered = sorted(float(v) for v in values)
+    return {
+        "p50": percentile50(ordered),
+        "p95": percentile95(ordered),
+        "max": max(ordered) if ordered else None,
+        "samples": len(ordered),
+    }
+
+
+def next_aligned_run_delay(now: datetime, interval: int = POLL_SECONDS) -> float:
+    """Return the delay to the next poll slot, starting one second after a minute."""
+    interval = max(1, int(interval))
+    epoch = now.timestamp()
+    minute_start = math.floor(epoch / 60) * 60
+    target = minute_start + 1
+    while target <= epoch + 1e-9:
+        target += interval
+        if target >= minute_start + 60:
+            target = minute_start + 61
+            break
+    return max(0.0, target - epoch)
 
 
 def _bar(instrument_id: str, item: Any, fetched: datetime) -> ExecutionBar:
@@ -138,6 +169,10 @@ class ExecutionMarketStore:
           run_id TEXT PRIMARY KEY, fetched_at TEXT NOT NULL, status TEXT NOT NULL,
           p95_age_seconds REAL, bar_count INTEGER NOT NULL, error TEXT
         );
+        CREATE TABLE IF NOT EXISTS execution_market_read_age_samples (
+          instrument_id TEXT NOT NULL, sampled_at TEXT NOT NULL,
+          age_seconds REAL NOT NULL
+        );
         CREATE TABLE IF NOT EXISTS execution_market_events (
           id INTEGER PRIMARY KEY AUTOINCREMENT, event TEXT NOT NULL,
           instrument_id TEXT NOT NULL, occurred_at TEXT NOT NULL, detail TEXT
@@ -163,12 +198,36 @@ class ExecutionMarketStore:
         ).fetchall()
         return [ExecutionBar(*row) for row in rows]
 
-    def write(self, bars: list[ExecutionBar], *, run_id: str, fetched_at: datetime, status: str = "ok", error: str | None = None) -> dict[str, Any]:
+    def write(self, bars: list[ExecutionBar], *, run_id: str, fetched_at: datetime, sampled_at: datetime | None = None, status: str = "ok", error: str | None = None) -> dict[str, Any]:
+        sampled_at = sampled_at or fetched_at
         with self.db:
             for bar in bars:
                 self.db.execute("""INSERT INTO execution_market_candles VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
                   ON CONFLICT(instrument_id,close_time) DO UPDATE SET open_time=excluded.open_time, open=excluded.open, high=excluded.high, low=excluded.low, close=excluded.close, volume=excluded.volume, fetched_at=excluded.fetched_at""", tuple(asdict(bar).values()))
-            receipt = {"schema_version": "execution-market-lag-v1", "run_id": run_id, "fetched_at": iso(fetched_at), "status": status, "p95_age_seconds": percentile95(b.age_seconds for b in bars), "bar_count": len(bars), "error": error}
+            read_age: dict[str, dict[str, float | int | None]] = {}
+            for instrument_id in INSTRUMENTS:
+                latest = self.latest(instrument_id, limit=1)
+                if not latest:
+                    continue
+                age = (sampled_at - datetime.fromisoformat(latest[0].close_time.replace("Z", "+00:00"))).total_seconds()
+                self.db.execute(
+                    "INSERT INTO execution_market_read_age_samples VALUES (?,?,?)",
+                    (instrument_id, iso(sampled_at), age),
+                )
+                rows = self.db.execute(
+                    "SELECT age_seconds FROM execution_market_read_age_samples WHERE instrument_id=?",
+                    (instrument_id,),
+                ).fetchall()
+                read_age[instrument_id] = age_stats(row[0] for row in rows)
+            fetch_age = {
+                instrument_id: age_stats(bar.age_seconds for bar in bars if bar.instrument_id == instrument_id)
+                for instrument_id in INSTRUMENTS
+                if any(bar.instrument_id == instrument_id for bar in bars)
+            }
+            receipt = {"schema_version": "execution-market-lag-v1", "run_id": run_id, "fetched_at": iso(fetched_at), "status": status, "p95_age_seconds": percentile95(b.age_seconds for b in bars), "fetch_age_seconds": fetch_age, "bar_count": len(bars), "error": error, "read_age_seconds": read_age}
+            receipt["read_age_p50_seconds"] = {key: value["p50"] for key, value in read_age.items()}
+            receipt["read_age_p95_seconds"] = {key: value["p95"] for key, value in read_age.items()}
+            receipt["read_age_max_seconds"] = {key: value["max"] for key, value in read_age.items()}
             self.db.execute("INSERT INTO execution_market_lag_receipts VALUES (?,?,?,?,?,?)", tuple(receipt[k] for k in ("run_id", "fetched_at", "status", "p95_age_seconds", "bar_count", "error")))
         return receipt
 
@@ -230,7 +289,7 @@ def run_once(db_path: str | Path, receipt_path: str | Path, *, lock_path: str | 
                 store.mark_success(instrument_id)
             except ProviderUnavailable as exc:
                 errors.append({"instrument_id": instrument_id, "error": str(exc), "stale": str(store.mark_failure(instrument_id, fetched, str(exc))).lower()})
-        receipt = store.write(all_bars, run_id=f"execution-{uuid.uuid4().hex[:12]}", fetched_at=fetched, status="stale" if any(e["stale"] == "true" for e in errors) else ("partial" if errors else "ok"), error=json.dumps(errors) if errors else None)
+        receipt = store.write(all_bars, run_id=f"execution-{uuid.uuid4().hex[:12]}", fetched_at=fetched, sampled_at=clock(), status="stale" if any(e["stale"] == "true" for e in errors) else ("partial" if errors else "ok"), error=json.dumps(errors) if errors else None)
     finally:
         if own_client: client.close()
         store.close()
@@ -241,8 +300,8 @@ def run_once(db_path: str | Path, receipt_path: str | Path, *, lock_path: str | 
 
 async def supervise(args: argparse.Namespace) -> None:
     while True:
+        await asyncio.sleep(next_aligned_run_delay(utc_now(), args.interval))
         run_once(args.db, args.receipt, lock_path=args.lock)
-        await asyncio.sleep(args.interval)
 
 
 def main() -> int:

--- a/tests/test_execution_market.py
+++ b/tests/test_execution_market.py
@@ -10,6 +10,8 @@ from kline.execution_market.worker import (
     fetch_binance,
     is_completed_bar,
     percentile95,
+    age_stats,
+    next_aligned_run_delay,
     run_once,
 )
 
@@ -27,6 +29,14 @@ def test_forming_bar_is_excluded_and_p95_is_deterministic():
     assert is_completed_bar(now - timedelta(seconds=1), now)
     assert not is_completed_bar(now + timedelta(seconds=1), now)
     assert percentile95([10, 20, 30, 40]) == 40
+    assert age_stats([10, 20, 30, 40]) == {"p50": 20.0, "p95": 40.0, "max": 40.0, "samples": 4}
+
+
+def test_poll_slots_are_one_second_after_minute_and_interval_aligned():
+    now = datetime(2026, 9, 8, 12, 0, 59, tzinfo=timezone.utc)
+    assert next_aligned_run_delay(now, 5) == 2
+    now = datetime(2026, 9, 8, 12, 1, 1, tzinfo=timezone.utc)
+    assert next_aligned_run_delay(now, 5) == 5
 
 
 def test_store_upsert_is_idempotent_and_close_time_is_keyed(tmp_path):
@@ -83,3 +93,15 @@ def test_run_once_writes_receipt_and_does_not_need_default_paths(tmp_path, monke
     receipt = run_once(tmp_path / "execution.db", receipt_path, clock=lambda: datetime(2026, 9, 8, 12, tzinfo=timezone.utc))
     assert receipt["status"] == "ok"
     assert json.loads(receipt_path.read_text())["schema_version"] == "execution-market-lag-v1"
+
+
+def test_read_age_histogram_is_per_instrument_and_accumulates(tmp_path):
+    from kline.execution_market.worker import ExecutionBar
+    store = ExecutionMarketStore(tmp_path / "execution.db")
+    bar = ExecutionBar("XAUUSDT.BINANCE", "2026-09-08T11:59:00Z", "2026-09-08T11:59:59Z", 1, 2, 0.5, 1.5, 3, "binance_usdm_futures", "binance", "production", "2026-09-08T12:00:00Z")
+    store.write([bar], run_id="r1", fetched_at=datetime(2026, 9, 8, 12, 0, 1, tzinfo=timezone.utc))
+    receipt = store.write([], run_id="r2", fetched_at=datetime(2026, 9, 8, 12, 0, 6, tzinfo=timezone.utc))
+    assert receipt["read_age_seconds"]["XAUUSDT.BINANCE"]["samples"] == 2
+    assert receipt["read_age_p50_seconds"]["XAUUSDT.BINANCE"] == 2.0
+    assert receipt["read_age_max_seconds"]["XAUUSDT.BINANCE"] == 7.0
+    store.close()


### PR DESCRIPTION
## What
- Change execution-market polling from 20s to 5s and align polls to one second after each UTC minute close.
- Add cumulative per-instrument read-age p50/p95/max samples and per-instrument fetch-age statistics to the worker receipt.
- Add focused alignment/histogram tests and update decision-log.md with Gotchas.

## Why
- Make minute-close ingestion proactive and make API read-time freshness observable without changing the 8100 API schema.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_execution_market*` -> 12 passed.
- `python3 -m py_compile ...` and `git diff --check` -> passed.
- `plutil -lint ops/launchd/com.wendy.datafeed.execution-market.plist` -> OK.
- `gitleaks detect --no-banner --redact --source .` (gitleaks 8.30.1) -> no leaks found.
- 30-minute isolated real run with `PYTHONPATH=src python3 -m ops.execution_market_worker --db /tmp/em.db --receipt /tmp/em.json --lock /tmp/em.lock --interval 5`: 356 samples per instrument; read-age p95 XAU 56.97s / BTC 61.96s; read-age max XAU 66.49s / BTC 117.50s; fetch-age p95 XAU 116.00s / BTC 176.00s. Read-age p95 and XAU max passed; BTC max and both fetch-age thresholds did not pass due observed upstream lag.
- No online worker, 8100, LaunchAgents, or live/real-money path was changed or restarted.

Closes #177