### PR TITLE
feat: add forming execution market price

### DIFF
--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,28 @@
 # Decision Log
 
+## 2026-09-08 - Forming execution price and v2 freshness (#179)
+
+### Decisions
+
+- The worker keeps the latest forming 1m bar close in a dedicated
+  `execution_market_forming_quotes` table; it never promotes that row into
+  `execution_market_candles`. The existing `price` and `bars` fields remain
+  the last completed-bar view.
+- `last_price` is the forming close and `price_time` is the local `fetched_at`,
+  because neither configured public candle payload provides a reliable bar
+  update timestamp. `fresh` now uses only `last_age_seconds <= 30`, with the
+  threshold configurable by `KLINE_EXECUTION_MARKET_LAST_PRICE_STALE_SECONDS`.
+- The read response is `execution-market-v2`; all v1 fields are retained.
+
+### Gotchas
+
+- A v1 database without the forming quote table remains readable but reports
+  no last price and `fresh=false`; the API never treats the old closed-bar age
+  as a substitute for forming-price freshness.
+- The owner must run the 30-minute XAU/BTC runtime window and trading-system
+  dual comparison after publication; this branch uses temporary paths only and
+  does not touch the active worker, 8100, or launchd.
+
 ## 2026-09-08 - Execution-market 1m read API (#172)
 
 ### Decisions

--- a/src/kline/api.py
+++ b/src/kline/api.py
@@ -50,7 +50,7 @@ from kline.provenance import (
 )
 from kline.quality import QualityReport, analyze_candles
 from kline.registry import get_adapter_for_source, get_store, provider_status, runtime_status
-from kline.execution_market.worker import ExecutionBar, INSTRUMENTS, STALE_SECONDS
+from kline.execution_market.worker import ExecutionBar, INSTRUMENTS, LAST_PRICE_STALE_SECONDS, STALE_SECONDS
 
 router = APIRouter()
 _mvp_matrix_last_success_at: str | None = None
@@ -79,7 +79,7 @@ def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[s
     match = _execution_instrument(venue, instrument)
     if not match:
         return {
-            "schema_version": "execution-market-v1",
+            "schema_version": "execution-market-v2",
             "venue": venue,
             "instrument": instrument,
             "price": None,
@@ -88,6 +88,10 @@ def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[s
             "source": None,
             "observed_at": None,
             "age_seconds": None,
+            "last_price": None,
+            "price_time": None,
+            "last_age_seconds": None,
+            "last_price_fresh": False,
             "bars": [],
             "reason": "unsupported_instrument",
         }
@@ -95,6 +99,7 @@ def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[s
     db_path = _execution_market_db()
     now = datetime.now(timezone.utc)
     now_iso = now.isoformat().replace("+00:00", "Z")
+    forming = None
     if not Path(db_path).exists():
         bars = []
     else:
@@ -110,6 +115,16 @@ def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[s
                 (instrument_id, now_iso, max(1, int(limit))),
             ).fetchall()
             bars = [ExecutionBar(*row) for row in rows]
+            try:
+                quote = connection.execute(
+                    """SELECT price, price_time, provider, venue, environment
+                       FROM execution_market_forming_quotes WHERE instrument_id=?""",
+                    (instrument_id,),
+                ).fetchone()
+                forming = quote
+            except sqlite3.Error:
+                # v1 databases have no forming quote table yet.
+                forming = None
         except sqlite3.Error:
             bars = []
         finally:
@@ -125,8 +140,19 @@ def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[s
         age = max(0.0, (now - observed).total_seconds())
         fresh = age <= STALE_SECONDS
         reason = "fresh" if fresh else "stale"
+    last_price = forming[0] if forming else None
+    price_time = forming[1] if forming else None
+    last_age = None
+    if price_time:
+        last_age = max(0.0, (now - datetime.fromisoformat(price_time.replace("Z", "+00:00"))).total_seconds())
+    try:
+        last_price_stale_seconds = float(os.environ.get("KLINE_EXECUTION_MARKET_LAST_PRICE_STALE_SECONDS", LAST_PRICE_STALE_SECONDS))
+    except ValueError:
+        last_price_stale_seconds = LAST_PRICE_STALE_SECONDS
+    last_fresh = last_age is not None and last_age <= last_price_stale_seconds
+    fresh = last_fresh
     return {
-        "schema_version": "execution-market-v1",
+        "schema_version": "execution-market-v2",
         "venue": meta["venue"],
         "instrument": meta["symbol"],
         "instrument_id": instrument_id,
@@ -136,7 +162,11 @@ def _execution_market_payload(venue: str, instrument: str, limit: int) -> dict[s
         "source": latest.provider if latest else meta["provider"],
         "observed_at": latest.close_time if latest else None,
         "age_seconds": round(age, 3) if age is not None else None,
-        "reason": reason,
+        "last_price": last_price,
+        "price_time": price_time,
+        "last_age_seconds": round(last_age, 3) if last_age is not None else None,
+        "last_price_fresh": last_fresh,
+        "reason": "fresh" if last_fresh else ("stale" if last_age is not None else reason),
         "provenance": {
             "provider": latest.provider if latest else meta["provider"],
             "venue": latest.venue if latest else meta["venue"],
@@ -1333,7 +1363,7 @@ async def execution_market(
     instrument: str,
     limit: int = Query(default=240, ge=1, le=1000),
 ) -> dict[str, Any]:
-    """Return the last closed execution-market 1m snapshot, read-only."""
+    """Return completed bars plus the latest forming execution price."""
     return _execution_market_payload(venue, instrument, limit)
 
 

--- a/src/kline/execution_market/worker.py
+++ b/src/kline/execution_market/worker.py
@@ -26,6 +26,7 @@ BINANCE_URL = "https://fapi.binance.com/fapi/v1/klines"
 HYPERLIQUID_TESTNET_URL = "https://api.hyperliquid-testnet.xyz/info"
 POLL_SECONDS = 5
 STALE_SECONDS = 90
+LAST_PRICE_STALE_SECONDS = 30
 
 INSTRUMENTS = {
     "XAUUSDT.BINANCE": {"provider": "binance_usdm_futures", "venue": "binance", "environment": "production", "symbol": "XAUUSDT"},
@@ -64,6 +65,11 @@ class ExecutionBar:
     def age_seconds(self) -> float:
         return (datetime.fromisoformat(self.fetched_at.replace("Z", "+00:00")) -
                 datetime.fromisoformat(self.close_time.replace("Z", "+00:00"))).total_seconds()
+
+    @property
+    def price_time(self) -> str:
+        """The local fetch time is the quote timestamp for this provider."""
+        return self.fetched_at
 
 
 class ProviderUnavailable(RuntimeError):
@@ -165,11 +171,20 @@ class ExecutionMarketStore:
           volume REAL NOT NULL, provider TEXT NOT NULL, venue TEXT NOT NULL,
           environment TEXT NOT NULL, fetched_at TEXT NOT NULL, PRIMARY KEY(instrument_id, close_time)
         );
+        CREATE TABLE IF NOT EXISTS execution_market_forming_quotes (
+          instrument_id TEXT PRIMARY KEY, price REAL NOT NULL, price_time TEXT NOT NULL,
+          bar_open_time TEXT NOT NULL, bar_close_time TEXT NOT NULL,
+          provider TEXT NOT NULL, venue TEXT NOT NULL, environment TEXT NOT NULL
+        );
         CREATE TABLE IF NOT EXISTS execution_market_lag_receipts (
           run_id TEXT PRIMARY KEY, fetched_at TEXT NOT NULL, status TEXT NOT NULL,
           p95_age_seconds REAL, bar_count INTEGER NOT NULL, error TEXT
         );
         CREATE TABLE IF NOT EXISTS execution_market_read_age_samples (
+          instrument_id TEXT NOT NULL, sampled_at TEXT NOT NULL,
+          age_seconds REAL NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS execution_market_last_age_samples (
           instrument_id TEXT NOT NULL, sampled_at TEXT NOT NULL,
           age_seconds REAL NOT NULL
         );
@@ -231,6 +246,35 @@ class ExecutionMarketStore:
             self.db.execute("INSERT INTO execution_market_lag_receipts VALUES (?,?,?,?,?,?)", tuple(receipt[k] for k in ("run_id", "fetched_at", "status", "p95_age_seconds", "bar_count", "error")))
         return receipt
 
+    def write_forming(self, bars: list[ExecutionBar], *, sampled_at: datetime | None = None) -> dict[str, dict[str, float | int | None]]:
+        """Persist the latest forming close separately from completed candles."""
+        sampled_at = sampled_at or utc_now()
+        last_age: dict[str, dict[str, float | int | None]] = {}
+        with self.db:
+            for bar in bars:
+                self.db.execute(
+                    """INSERT INTO execution_market_forming_quotes
+                       VALUES (?,?,?,?,?,?,?,?)
+                       ON CONFLICT(instrument_id) DO UPDATE SET
+                       price=excluded.price, price_time=excluded.price_time,
+                       bar_open_time=excluded.bar_open_time, bar_close_time=excluded.bar_close_time,
+                       provider=excluded.provider, venue=excluded.venue,
+                       environment=excluded.environment""",
+                    (bar.instrument_id, bar.close, bar.price_time, bar.open_time,
+                     bar.close_time, bar.provider, bar.venue, bar.environment),
+                )
+                age = max(0.0, (sampled_at - datetime.fromisoformat(bar.price_time.replace("Z", "+00:00"))).total_seconds())
+                self.db.execute(
+                    "INSERT INTO execution_market_last_age_samples VALUES (?,?,?)",
+                    (bar.instrument_id, iso(sampled_at), age),
+                )
+                rows = self.db.execute(
+                    "SELECT age_seconds FROM execution_market_last_age_samples WHERE instrument_id=?",
+                    (bar.instrument_id,),
+                ).fetchall()
+                last_age[bar.instrument_id] = age_stats(row[0] for row in rows)
+        return last_age
+
     def mark_failure(self, instrument_id: str, now: datetime, error: str) -> bool:
         row = self.db.execute("SELECT unavailable_since FROM execution_market_provider_state WHERE instrument_id=?", (instrument_id,)).fetchone()
         since = row[0] if row and row[0] else iso(now)
@@ -279,17 +323,24 @@ def run_once(db_path: str | Path, receipt_path: str | Path, *, lock_path: str | 
     own_client = client is None
     client = client or httpx.Client(timeout=15)
     all_bars: list[ExecutionBar] = []
+    last_age: dict[str, dict[str, float | int | None]] = {}
     errors: list[dict[str, str]] = []
     try:
         for instrument_id in INSTRUMENTS:
             try:
                 bars = fetch_binance(instrument_id, fetched, client) if instrument_id.startswith("XAU") else fetch_hyperliquid(instrument_id, fetched, client)
                 completed = [bar for bar in bars if is_completed_bar(datetime.fromisoformat(bar.close_time.replace("Z", "+00:00")), fetched)]
+                forming = [bar for bar in bars if not is_completed_bar(datetime.fromisoformat(bar.close_time.replace("Z", "+00:00")), fetched)]
+                last_age.update(store.write_forming(forming[-1:], sampled_at=fetched))
                 all_bars.extend(completed)
                 store.mark_success(instrument_id)
             except ProviderUnavailable as exc:
                 errors.append({"instrument_id": instrument_id, "error": str(exc), "stale": str(store.mark_failure(instrument_id, fetched, str(exc))).lower()})
         receipt = store.write(all_bars, run_id=f"execution-{uuid.uuid4().hex[:12]}", fetched_at=fetched, sampled_at=clock(), status="stale" if any(e["stale"] == "true" for e in errors) else ("partial" if errors else "ok"), error=json.dumps(errors) if errors else None)
+        receipt["last_age_seconds"] = last_age
+        receipt["last_age_p50_seconds"] = {key: value["p50"] for key, value in last_age.items()}
+        receipt["last_age_p95_seconds"] = {key: value["p95"] for key, value in last_age.items()}
+        receipt["last_age_max_seconds"] = {key: value["max"] for key, value in last_age.items()}
     finally:
         if own_client: client.close()
         store.close()

--- a/src/kline/execution_market/worker.py
+++ b/src/kline/execution_market/worker.py
@@ -273,6 +273,15 @@ class ExecutionMarketStore:
                     (bar.instrument_id,),
                 ).fetchall()
                 last_age[bar.instrument_id] = age_stats(row[0] for row in rows)
+            for instrument_id in INSTRUMENTS:
+                if instrument_id in last_age:
+                    continue
+                rows = self.db.execute(
+                    "SELECT age_seconds FROM execution_market_last_age_samples WHERE instrument_id=?",
+                    (instrument_id,),
+                ).fetchall()
+                if rows:
+                    last_age[instrument_id] = age_stats(row[0] for row in rows)
         return last_age
 
     def mark_failure(self, instrument_id: str, now: datetime, error: str) -> bool:

--- a/tests/test_execution_market.py
+++ b/tests/test_execution_market.py
@@ -32,6 +32,18 @@ def test_forming_bar_is_excluded_and_p95_is_deterministic():
     assert age_stats([10, 20, 30, 40]) == {"p50": 20.0, "p95": 40.0, "max": 40.0, "samples": 4}
 
 
+def test_forming_price_is_stored_separately_from_completed_candles(tmp_path):
+    from kline.execution_market.worker import ExecutionBar
+    store = ExecutionMarketStore(tmp_path / "execution.db")
+    completed = ExecutionBar("XAUUSDT.BINANCE", "2026-09-08T11:59:00Z", "2026-09-08T11:59:59Z", 1, 2, 0.5, 100, 3, "binance_usdm_futures", "binance", "production", "2026-09-08T12:00:00Z")
+    forming = ExecutionBar("XAUUSDT.BINANCE", "2026-09-08T12:00:00Z", "2026-09-08T12:00:59.999Z", 1, 2, 0.5, 101, 3, "binance_usdm_futures", "binance", "production", "2026-09-08T12:00:10Z")
+    store.write([completed], run_id="r1", fetched_at=datetime(2026, 9, 8, 12, tzinfo=timezone.utc))
+    store.write_forming([forming], sampled_at=datetime(2026, 9, 8, 12, 0, 10, tzinfo=timezone.utc))
+    assert store.latest("XAUUSDT.BINANCE")[0].close == 100
+    assert store.db.execute("select price from execution_market_forming_quotes").fetchone()[0] == 101
+    store.close()
+
+
 def test_poll_slots_are_one_second_after_minute_and_interval_aligned():
     now = datetime(2026, 9, 8, 12, 0, 59, tzinfo=timezone.utc)
     assert next_aligned_run_delay(now, 5) == 2

--- a/tests/test_execution_market_api.py
+++ b/tests/test_execution_market_api.py
@@ -18,21 +18,28 @@ def _bar(close_time: datetime, close: float = 2400.0) -> ExecutionBar:
 def _client(tmp_path, monkeypatch, bars: list[ExecutionBar]) -> TestClient:
     path = tmp_path / "execution-market.db"
     store = ExecutionMarketStore(path)
-    store.write(bars, run_id="test", fetched_at=datetime.now(timezone.utc))
+    now = datetime.now(timezone.utc)
+    completed = [bar for bar in bars if datetime.fromisoformat(bar.close_time.replace("Z", "+00:00")) <= now]
+    forming = [bar for bar in bars if datetime.fromisoformat(bar.close_time.replace("Z", "+00:00")) > now]
+    store.write(completed, run_id="test", fetched_at=now)
+    store.write_forming(forming[-1:], sampled_at=now)
     store.close()
     monkeypatch.setenv("KLINE_EXECUTION_MARKET_DB", str(path))
     return TestClient(create_app())
 
 
-def test_fresh_response_maps_execution_reader_fields_and_excludes_forming(tmp_path, monkeypatch):
+def test_fresh_response_maps_execution_reader_fields_and_separates_forming(tmp_path, monkeypatch):
     now = datetime.now(timezone.utc)
     with _client(tmp_path, monkeypatch, [_bar(now - timedelta(seconds=30)), _bar(now + timedelta(seconds=30), 2500)]) as client:
         response = client.get("/api/execution-market/binance/XAUUSDT", params={"limit": 240})
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["schema_version"] == "execution-market-v1"
+    assert payload["schema_version"] == "execution-market-v2"
     assert payload["price"] == 2400.0
+    assert payload["last_price"] == 2500.0
+    assert payload["price_time"] is not None
+    assert payload["last_age_seconds"] < 5
     assert payload["trusted"] is True
     assert payload["fresh"] is True
     assert payload["source"] == "binance_usdm_futures"
@@ -45,6 +52,7 @@ def test_stale_response_is_present_but_not_fresh(tmp_path, monkeypatch):
         payload = client.get("/api/execution-market/binance/XAUUSDT").json()
 
     assert payload["price"] == 2400.0
+    assert payload["last_price"] is None
     assert payload["trusted"] is True
     assert payload["fresh"] is False
     assert payload["reason"] == "stale"
@@ -57,12 +65,15 @@ def test_missing_response_is_explicit(tmp_path, monkeypatch):
 
     assert payload == {
         **payload,
-        "schema_version": "execution-market-v1",
+        "schema_version": "execution-market-v2",
         "price": None,
         "trusted": False,
         "fresh": False,
         "observed_at": None,
         "age_seconds": None,
+        "last_price": None,
+        "price_time": None,
+        "last_age_seconds": None,
         "reason": "missing",
         "bars": [],
     }


### PR DESCRIPTION
## What
- Persist the latest forming 1m close in a dedicated execution-market quote table.
- Expose `last_price`, `price_time`, `last_age_seconds`, and v2 freshness on the execution-market API while retaining v1 fields.
- Keep completed bars separate and add per-instrument last-age receipt statistics.

## Why
Closed 1m bars arrive 60–120s late, so execution freshness must use the forming bar close. `price_time` is explicitly the local `fetched_at` because the configured public candle payloads do not provide a reliable update timestamp.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_execution_market*` → 13 passed.
- `gitleaks 8.30.1 detect --source . --no-banner --redact` → no leaks found.
- `PYTHONPATH=src python3 -m compileall -q src ops` and `git diff --check` → passed.
- Isolated real upstream one-shot using temporary `/tmp` db/receipt/lock → XAU and BTC forming quotes present, no errors, `last_age_seconds` 0.0 at write.
- 30-minute isolated real run is in progress at `/tmp/datafeed-issue-179.abqvd` and will be appended as evidence when complete.

Closes #179
