### PR TITLE
fix: keep the daily seed running when the registry ref lookup fails

### DIFF
--- a/ops/sync_watchlist_registry.py
+++ b/ops/sync_watchlist_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 from pathlib import Path
 import tempfile
 from datetime import datetime, timezone
@@ -143,8 +144,33 @@ def _write_json(path: str | Path, payload: Mapping[str, Any]) -> None:
     temporary.replace(target)
 
 
+def _github_token() -> str | None:
+    """Optional token so the ref lookup uses the 5,000/h authenticated limit.
+
+    Read from GITHUB_TOKEN or GH_TOKEN, or from the file named by
+    GITHUB_TOKEN_FILE. Anonymous lookups share a 60/h per-IP budget with
+    everything else on the machine and blocked the daily seed on 2026-09-09.
+    """
+    for name in ("GITHUB_TOKEN", "GH_TOKEN"):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    path = os.environ.get("GITHUB_TOKEN_FILE", "").strip()
+    if path:
+        try:
+            value = Path(path).expanduser().read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        return value or None
+    return None
+
+
 def _fetch_json(url: str) -> Mapping[str, Any]:
-    request = Request(url, headers={"Accept": "application/vnd.github+json", "User-Agent": "datafeed-watchlist-sync"})
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "datafeed-watchlist-sync"}
+    token = _github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers)
     try:
         with urlopen(request, timeout=30) as response:
             payload = json.loads(response.read().decode("utf-8"))
@@ -207,7 +233,48 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--manifest-output", default=str(DEFAULT_MANIFEST_OUTPUT))
     parser.add_argument("--receipt", default=str(DEFAULT_RECEIPT))
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--reuse-manifest-on-lookup-failure",
+        action="store_true",
+        help=(
+            "If the upstream ref lookup fails (network, rate limit) and a manifest already exists, "
+            "keep that manifest and exit 0 so the daily seed still runs. Content or validation "
+            "errors still block."
+        ),
+    )
     return parser
+
+
+def _reuse_existing_manifest(args: argparse.Namespace, observed_at: str, error: Exception) -> dict[str, Any] | None:
+    """Receipt for running on the previously synced manifest, or None if we must block."""
+    if not getattr(args, "reuse_manifest_on_lookup_failure", False):
+        return None
+    if "ref lookup failed" not in str(error):
+        return None
+    manifest_path = Path(args.manifest_output).expanduser().resolve()
+    if not manifest_path.exists():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        validate_watchlist_manifest(manifest)
+    except Exception:  # noqa: BLE001 — an unreadable manifest is not something to build on
+        return None
+    pinned = None
+    for item in manifest.get("instruments", []):
+        pinned = (item.get("metadata") or {}).get("registry_commit")
+        if pinned:
+            break
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "observed_at": observed_at,
+        "status": "lookup_failed_manifest_reused",
+        "changed": False,
+        "registry_repository": REGISTRY_REPOSITORY,
+        "registry_ref": args.ref,
+        "registry_sha": pinned,
+        "manifest_path": str(manifest_path),
+        "lookup_error": f"{type(error).__name__}: {error}",
+    }
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -219,7 +286,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             commit = args.commit or APPROVED_WATCHLIST_COMMIT
             snapshot_payload = build_snapshot(args.source, commit=commit)
         else:
-            commit, raw_bytes = fetch_registry(args.ref)
+            try:
+                commit, raw_bytes = fetch_registry(args.ref)
+            except RuntimeError as lookup_error:
+                reused = _reuse_existing_manifest(args, observed_at, lookup_error)
+                if reused is not None:
+                    if not args.dry_run:
+                        _write_json(receipt_path, reused)
+                    print(json.dumps(reused, ensure_ascii=False, sort_keys=True))
+                    return 0
+                raise
             snapshot_payload = build_snapshot_from_bytes(raw_bytes, commit=commit)
         snapshot_path = Path(args.snapshot_output).expanduser().resolve()
         manifest_path = Path(args.manifest_output).expanduser().resolve()

--- a/tests/test_sync_watchlist_registry.py
+++ b/tests/test_sync_watchlist_registry.py
@@ -65,3 +65,175 @@ def test_fetch_registry_resolves_ref_and_fetches_the_same_commit(monkeypatch) ->
         f"{sync.GITHUB_API}/repos/{sync.REGISTRY_REPOSITORY}/commits/main",
         f"{sync.GITHUB_RAW}/{sync.REGISTRY_REPOSITORY}/{commit}/{sync.REGISTRY_FILE}",
     ]
+
+
+def test_fetch_json_sends_bearer_token_from_env(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        seen.update(request.headers)
+        return Response()
+
+    monkeypatch.setattr(sync, "urlopen", fake_urlopen)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN_FILE", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-123")
+    sync._fetch_json("https://api.github.com/x")
+    assert seen.get("Authorization") == "Bearer tok-123"
+
+
+def test_fetch_json_reads_token_file(monkeypatch, tmp_path: Path) -> None:
+    seen: dict[str, str] = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        seen.update(request.headers)
+        return Response()
+
+    token_file = tmp_path / "github-token"
+    token_file.write_text("tok-file\n", encoding="utf-8")
+    monkeypatch.setattr(sync, "urlopen", fake_urlopen)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN_FILE", str(token_file))
+    sync._fetch_json("https://api.github.com/x")
+    assert seen.get("Authorization") == "Bearer tok-file"
+
+
+def test_fetch_json_anonymous_without_token(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        seen.update(request.headers)
+        return Response()
+
+    monkeypatch.setattr(sync, "urlopen", fake_urlopen)
+    for name in ("GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN_FILE"):
+        monkeypatch.delenv(name, raising=False)
+    sync._fetch_json("https://api.github.com/x")
+    assert "Authorization" not in seen
+
+
+def _existing_manifest(tmp_path: Path) -> Path:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "watchlist-manifest-v1",
+                "instruments": [
+                    {
+                        "instrument_id": "WATCH.CROSS.SPX",
+                        "asset_class": "index",
+                        "ticker": "SPX",
+                        "provider": "yahoo",
+                        "metadata": {"registry_commit": "b" * 40},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def test_lookup_failure_reuses_existing_manifest_when_allowed(monkeypatch, tmp_path: Path) -> None:
+    manifest_path = _existing_manifest(tmp_path)
+    receipt_path = tmp_path / "receipt.json"
+
+    def failing_fetch(_ref):
+        raise RuntimeError("registry ref lookup failed: HTTP Error 403: rate limit exceeded")
+
+    monkeypatch.setattr(sync, "fetch_registry", failing_fetch)
+    monkeypatch.setattr(sync, "validate_watchlist_manifest", lambda _m: None)
+    before = manifest_path.read_bytes()
+
+    code = sync.main(
+        [
+            "--ref", "main",
+            "--snapshot-output", str(tmp_path / "snapshot.json"),
+            "--manifest-output", str(manifest_path),
+            "--receipt", str(receipt_path),
+            "--reuse-manifest-on-lookup-failure",
+        ]
+    )
+
+    assert code == 0
+    assert manifest_path.read_bytes() == before
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["status"] == "lookup_failed_manifest_reused"
+    assert receipt["changed"] is False
+    assert receipt["registry_sha"] == "b" * 40
+    assert "rate limit" in receipt["lookup_error"]
+
+
+def test_lookup_failure_still_blocks_without_flag(monkeypatch, tmp_path: Path) -> None:
+    manifest_path = _existing_manifest(tmp_path)
+    receipt_path = tmp_path / "receipt.json"
+
+    def failing_fetch(_ref):
+        raise RuntimeError("registry ref lookup failed: HTTP Error 403: rate limit exceeded")
+
+    monkeypatch.setattr(sync, "fetch_registry", failing_fetch)
+
+    code = sync.main(
+        [
+            "--ref", "main",
+            "--snapshot-output", str(tmp_path / "snapshot.json"),
+            "--manifest-output", str(manifest_path),
+            "--receipt", str(receipt_path),
+        ]
+    )
+
+    assert code == 2
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "blocked"
+
+
+def test_lookup_failure_blocks_when_no_manifest_exists(monkeypatch, tmp_path: Path) -> None:
+    receipt_path = tmp_path / "receipt.json"
+
+    def failing_fetch(_ref):
+        raise RuntimeError("registry ref lookup failed: HTTP Error 403: rate limit exceeded")
+
+    monkeypatch.setattr(sync, "fetch_registry", failing_fetch)
+
+    code = sync.main(
+        [
+            "--ref", "main",
+            "--snapshot-output", str(tmp_path / "snapshot.json"),
+            "--manifest-output", str(tmp_path / "missing-manifest.json"),
+            "--receipt", str(receipt_path),
+            "--reuse-manifest-on-lookup-failure",
+        ]
+    )
+
+    assert code == 2
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "blocked"


### PR DESCRIPTION
## 问题

08:15 的 `com.wendy.datafeed.watchlist-daily` 是 `sync_watchlist_registry && watchlist_seed`。2026-09-09 本机匿名 GitHub API 额度（60/h，按 IP 共享）用尽，ref 查询 403，sync 返回 2，种子没跑。K 线日报、8932 盘中总览、晨报整个上午都是 09-04 / 09-07 的柱。

## 改动

- `_fetch_json` 在存在 `GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN_FILE` 时带 Bearer token（5,000/h）。没有 token 行为不变。
- 新增 `--reuse-manifest-on-lookup-failure`：只有 ref 查询本身失败（网络、限流）且已有合法清单时，沿用该清单，回执 `status=lookup_failed_manifest_reused`，退出 0，让种子照常按昨天的 universe 跑。内容错误、校验失败仍然阻塞。
- 三个 token 测试 + 三个失败路径测试（允许沿用 / 不带 flag 仍阻塞 / 没有清单仍阻塞）。

launchd plist 的对应改动（加 flag 与 `GITHUB_TOKEN_FILE`）在本机完成，不在仓库里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)